### PR TITLE
Make block time configurable at compile time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ COPY Emakefile .
 ADD lib lib
 ADD src src
 
-# Eg. "-DTARGET_TIME=5 -DRETARGET_BLOCKS=5"
+# E.g. "-DTARGET_TIME=5 -DRETARGET_BLOCKS=10" or "-DFIXED_DIFF=2"
 ARG ERLC_OPTS
+
 RUN make all
 
 FROM erlang:20-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD src src
 # E.g. "-DTARGET_TIME=5 -DRETARGET_BLOCKS=10" or "-DFIXED_DIFF=2"
 ARG ERLC_OPTS
 
-RUN make all
+RUN make build
 
 FROM erlang:20-alpine
 
@@ -37,4 +37,4 @@ COPY --from=builder /arweave/lib/prometheus_process_collector/_build/default/lib
             lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/ebin
 
 EXPOSE 1984
-ENTRYPOINT ["./arweave-server"]
+ENTRYPOINT ["./docker-arweave-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ COPY data data
 COPY --from=builder /arweave/priv priv
 COPY --from=builder /arweave/ebin ebin
 COPY --from=builder /arweave/src/av/sigs src/av/sigs
+COPY --from=builder /arweave/lib/prometheus/_build/default/lib/prometheus/ebin \
+            lib/prometheus/_build/default/lib/prometheus/ebin
+COPY --from=builder /arweave/lib/accept/_build/default/lib/accept/ebin \
+            lib/accept/_build/default/lib/accept/ebin
+COPY --from=builder /arweave/lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/ebin \
+            lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/ebin
 
 EXPOSE 1984
 ENTRYPOINT ["./arweave-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY Makefile .
 COPY Emakefile .
 ADD lib lib
 ADD src src
+
+# Eg. "-DTARGET_TIME=5 -DRETARGET_BLOCKS=5"
+ARG ERLC_OPTS
 RUN make all
 
 FROM erlang:20-alpine

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,12 @@ log:
 catlog:
 	cat logs/`ls -t logs | head -n 1`
 
-all: ebin logs blocks
+all: gitmodules build
+
+gitmodules:
+	git submodule update --init
+
+build: ebin logs blocks
 	rm -rf priv
 	rm -rf data/mnesia
 	cd lib/jiffy && ./rebar compile && cd ../.. && mv lib/jiffy/priv ./

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ all: ebin logs blocks
 	rm -rf priv
 	rm -rf data/mnesia
 	cd lib/jiffy && ./rebar compile && cd ../.. && mv lib/jiffy/priv ./
-	git submodule init
-	git submodule update
 	(cd lib/prometheus && ./rebar3 compile)
 	(cd lib/accept && ./rebar3 compile)
 	(cd lib/prometheus_process_collector && ./rebar3 compile && cp _build/default/lib/prometheus_process_collector/priv/*.so ../../priv)

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,9 @@ all: ebin logs blocks
 	(cd lib/prometheus && ./rebar3 compile)
 	(cd lib/accept && ./rebar3 compile)
 	(cd lib/prometheus_process_collector && ./rebar3 compile && cp _build/default/lib/prometheus_process_collector/priv/*.so ../../priv)
-	erlc +export_all -o ebin/ src/ar.erl
+	erlc $(ERLC_OPTS) +export_all -o ebin/ src/ar.erl
 	erl $(ERL_OPTS) -noshell -s ar rebuild -s init stop
+
 
 ebin:
 	mkdir -p ebin

--- a/docker-arweave-server
+++ b/docker-arweave-server
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-mkdir -p ebin logs blocks wallets txs blocks/enc priv
+mkdir -p ebin logs blocks wallets txs blocks/enc priv data/genesis_txs
 
 if [ -t 1 ]; then
 	SHELL_OPTS=

--- a/src/ar.erl
+++ b/src/ar.erl
@@ -349,13 +349,19 @@ rebuild() ->
 			load,
 			{d, 'TARGET_TIME', ?TARGET_TIME},
 			{d, 'RETARGET_BLOCKS', ?RETARGET_BLOCKS}
-		] ++ fixed_diff_option()
+		] ++ fixed_diff_option() ++ fixed_delay_option()
 	).
 
 -ifdef(FIXED_DIFF).
 fixed_diff_option() -> [{d, 'FIXED_DIFF', ?FIXED_DIFF}].
 -else.
 fixed_diff_option() -> [].
+-endif.
+
+-ifdef(FIXED_DELAY).
+fixed_delay_option() -> [{d, 'FIXED_DELAY', ?FIXED_DELAY}].
+-else.
+fixed_delay_option() -> [].
 -endif.
 
 %% @doc passthrough to supervisor start_link

--- a/src/ar.erl
+++ b/src/ar.erl
@@ -310,7 +310,9 @@ start(
 			{miner, Node},
 			{mining_address, PrintMiningAddress},
 			{peers, Peers},
-			{polling, Polling}
+			{polling, Polling},
+			{target_time, ?TARGET_TIME},
+			{retarget_blocks, ?RETARGET_BLOCKS}
 		]
 	),
 	% Start the first node in the gossip network (with HTTP interface)
@@ -342,7 +344,7 @@ generate_logfile_name() ->
 
 %% @doc Run the erlang make system on the project.
 rebuild() ->
-	make:all([load]).
+	make:all([load, {d, 'TARGET_TIME', ?TARGET_TIME}, {d, 'RETARGET_BLOCKS', ?RETARGET_BLOCKS}]).
 
 %% @doc passthrough to supervisor start_link
 start_link() ->

--- a/src/ar.erl
+++ b/src/ar.erl
@@ -344,7 +344,19 @@ generate_logfile_name() ->
 
 %% @doc Run the erlang make system on the project.
 rebuild() ->
-	make:all([load, {d, 'TARGET_TIME', ?TARGET_TIME}, {d, 'RETARGET_BLOCKS', ?RETARGET_BLOCKS}]).
+	make:all(
+		[
+			load,
+			{d, 'TARGET_TIME', ?TARGET_TIME},
+			{d, 'RETARGET_BLOCKS', ?RETARGET_BLOCKS}
+		] ++ fixed_diff_option()
+	).
+
+-ifdef(FIXED_DIFF).
+fixed_diff_option() -> [{d, 'FIXED_DIFF', ?FIXED_DIFF}].
+-else.
+fixed_diff_option() -> [].
+-endif.
 
 %% @doc passthrough to supervisor start_link
 start_link() ->

--- a/src/ar.hrl
+++ b/src/ar.hrl
@@ -30,8 +30,14 @@
 %% @doc NB: Setting the default difficulty high will cause TNT to fail.
 -define(DEFAULT_DIFF, 8).
 
+-ifndef(TARGET_TIME).
 -define(TARGET_TIME, 120).
+-endif.
+
+-ifndef(RETARGET_BLOCKS).
 -define(RETARGET_BLOCKS, 10).
+-endif.
+
 -define(RETARGET_TOLERANCE, 0.1).
 -define(BLOCK_PAD_SIZE, (1024*1024*1)).
 

--- a/src/ar_node.erl
+++ b/src/ar_node.erl
@@ -1944,8 +1944,12 @@ start_mining(S = #state { hash_list = BHL, txs = TXs, reward_addr = RewardAddr, 
 %% This wait helps ensure that a tx has propogated around the network.
 %% NB: If debug is defined no wait is applied.
 -ifdef(DEBUG).
-calculate_delay(0) -> 0;
-calculate_delay(Bytes) -> 0.
+-define(FIXED_DELAY, 0).
+-endif.
+
+-ifdef(FIXED_DELAY).
+calculate_delay(0) -> ?FIXED_DELAY;
+calculate_delay(Bytes) -> ?FIXED_DELAY.
 -else.
 calculate_delay(0) ->
     30000;

--- a/src/ar_retarget.erl
+++ b/src/ar_retarget.erl
@@ -63,6 +63,9 @@ maybe_retarget(B, OldB) ->
 
 %% @doc Calculate a new difficulty, given an old difficulty and the period
 %% since the last retarget occcurred.
+-ifdef(FIXED_DIFF).
+calculate_difficulty(_OldDiff, _TS, _Last) -> ?FIXED_DIFF.
+-else.
 calculate_difficulty(OldDiff, TS, Last) ->
 	TargetTime = ?RETARGET_BLOCKS * ?TARGET_TIME,
 	ActualTime = TS - Last,
@@ -72,6 +75,7 @@ calculate_difficulty(OldDiff, TS, Last) ->
 	    TargetTime > ActualTime -> OldDiff + 1;
 	    true -> OldDiff - 1
 	end.
+-endif.
 
 %% @doc Validate that a new block has an appropriate difficulty.
 validate(NewB, OldB) when ?IS_RETARGET_BLOCK(NewB) ->


### PR DESCRIPTION
@DamonSweeney @samcamwilliams @allquantor

This speeds up our clients integration tests a lot, here's how I use it: 
https://github.com/toknapp/arweave4s/blob/23e1bd8ecbc10dbb4bce1ce34071afdcb60e27d0/docker-compose.yaml#L7

(from the latest batch of changes in the client https://github.com/toknapp/arweave4s/pull/23)