### PR TITLE
Copy over the prometheus nif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@ COPY --from=builder /arweave/lib/accept/_build/default/lib/accept/ebin \
             lib/accept/_build/default/lib/accept/ebin
 COPY --from=builder /arweave/lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/ebin \
             lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/ebin
+COPY --from=builder /arweave/lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/priv \
+            lib/prometheus_process_collector/_build/default/lib/prometheus_process_collector/priv
 
 EXPOSE 1984
 ENTRYPOINT ["./docker-arweave-server"]


### PR DESCRIPTION
@arweave-kyle @samcamwilliams  I don't think the `cp` of the prometheus library to `priv` is working as intended, the application still looks for it in its own `priv` directory.