### PR TITLE
Maintenance/validate url hash

### DIFF
--- a/src/ar_http_iface.erl
+++ b/src/ar_http_iface.erl
@@ -446,7 +446,7 @@ handle('GET', [<<"block">>, <<"hash">>, Hash], _Req) ->
 		{error, invalid} ->
 			{400, [], <<"invalid hash">>};
 		{error, _, unavailable} ->
-			{404, [], {file, "block not found"}};
+			{404, [], <<"block not found">>};
 		{ok, Filename} ->
 			{ok, [], {file, Filename}}
 	end;

--- a/src/ar_http_iface.erl
+++ b/src/ar_http_iface.erl
@@ -114,10 +114,10 @@ handle('GET', [<<"tx">>, <<"pending">>], _Req) ->
 %% @doc Return a transaction specified via the the transaction id (hash)
 %% GET request to endpoint /tx/{hash}
 handle('GET', [<<"tx">>, Hash], _Req) ->
-	case hash_to_maybe_filename(Hash) of
+	case hash_to_maybe_filename(tx, Hash) of
 		{error, invalid} ->
 			{400, [], <<"invalid hash">>};
-		{error, unavailable} ->
+		{error, ID, unavailable} ->
 			case is_a_pending_tx(ID) of
 				true ->
 					{202, [], <<"Pending">>};
@@ -163,11 +163,12 @@ handle('POST', [<<"arql">>], Req) ->
 %% @doc Return the data field of the transaction specified via the transaction ID (hash) served as HTML.
 %% GET request to endpoint /tx/{hash}/data.html
 handle('GET', [<<"tx">>, Hash, <<"data.html">>], _Req) ->
-	ID = ar_util:decode(Hash),
-	F = ar_storage:lookup_tx_filename(ID),
-	case F of
-		unavailable -> {404, [], {file, "data/not_found.html"}};
-		Filename ->
+	case hash_to_maybe_filename(tx, Hash) of
+		{error, invalid} ->
+			{400, [], <<"invalid hash">>};
+		{error, _, unavailable} ->
+			{404, [], {file, "data/not_found.html"}};
+		{ok, Filename} ->
 			T = ar_storage:do_read_tx(Filename),
 			{200, [], T#tx.data}
 	end;
@@ -309,18 +310,21 @@ handle('GET', [<<"price">>, SizeInBytes], _Req) ->
 %% GET request to endpoint /price/{bytes}/{address}
 %% TODO: Change so current block does not need to be pulled to calculate cost
 handle('GET', [<<"price">>, SizeInBytes, Addr], _Req) ->
-	{200, [],
-		integer_to_binary(
-			ar_tx:calculate_min_tx_cost(
-				list_to_integer(
-					binary_to_list(SizeInBytes)
-				),
-				ar_node:get_current_diff(whereis(http_entrypoint_node)),
-				ar_node:get_wallet_list(whereis(http_entrypoint_node)),
-				ar_util:decode(Addr)
-			)
-		)
-	};
+	case safe_decode(Addr) of
+		{error, invalid} ->
+			{400, [], <<"invalid address">>};
+		{ok, AddrOK} ->
+			{200, [],
+				integer_to_binary(
+					ar_tx:calculate_min_tx_cost(
+						binary_to_integer(SizeInBytes),
+						ar_node:get_current_diff(whereis(http_entrypoint_node)),
+						ar_node:get_wallet_list(whereis(http_entrypoint_node)),
+						AddrOK
+					)
+				)
+			}
+	end;
 
 %% @doc Return the current hash list held by the node.
 %% GET request to endpoint /hash_list
@@ -390,26 +394,30 @@ handle('POST', [<<"peers">>, <<"port">>, RawPort], Req) ->
 %% @doc Return the balance of the wallet specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/balance
 handle('GET', [<<"wallet">>, Addr, <<"balance">>], _Req) ->
-	{200, [],
-		integer_to_binary(
-			ar_node:get_balance(
-				whereis(http_entrypoint_node),
-				ar_util:decode(Addr)
-			)
-		)
-	};
+	case safe_decode(Addr) of
+		{error, invalid} ->
+			{400, [], <<"invalid address">>};
+		{ok, AddrOK} ->
+			{200, [],
+				integer_to_binary(
+					ar_node:get_balance(whereis(http_entrypoint_node), AddrOK)
+				)
+			}
+	end;
 
 %% @doc Return the last transaction ID (hash) for the wallet specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/last_tx
 handle('GET', [<<"wallet">>, Addr, <<"last_tx">>], _Req) ->
-	{200, [],
-		ar_util:encode(
-			ar_node:get_last_tx(
-				whereis(http_entrypoint_node),
-				ar_util:decode(Addr)
-			)
-		)
-	};
+	case safe_decode(Addr) of
+		{error, invalid} ->
+			{400, [], <<"invalid address">>};
+		{ok, AddrOK} ->
+			{200, [],
+				ar_util:encode(
+					ar_node:get_last_tx(whereis(http_entrypoint_node), AddrOK)
+				)
+			}
+	end;
 
 %% @doc Return the encrypted blockshadow corresponding to the indep_hash.
 %% GET request to endpoint /block/hash/{indep_hash}/encrypted
@@ -434,10 +442,12 @@ handle('GET', [<<"wallet">>, Addr, <<"last_tx">>], _Req) ->
 %% @doc Return the blockshadow corresponding to the indep_hash.
 %% GET request to endpoint /block/hash/{indep_hash}
 handle('GET', [<<"block">>, <<"hash">>, Hash], _Req) ->
-	case ar_storage:lookup_block_filename(ar_util:decode(Hash)) of
-		unavailable ->
-			{404, [], <<"Block not found.">>};
-		Filename  ->
+	case hash_to_maybe_filename(block, Hash) of
+		{error, invalid} ->
+			{400, [], <<"invalid hash">>};
+		{error, _, unavailable} ->
+			{404, [], {file, "block not found"}};
+		{ok, Filename} ->
 			{ok, [], {file, Filename}}
 	end;
 
@@ -462,15 +472,19 @@ handle('GET', [<<"block">>, <<"height">>, Height], _Req) ->
 handle('GET', [<<"block">>, <<"hash">>, Hash, Field], _Req) ->
 	case ar_meta_db:get(subfield_queries) of
 		true ->
-			Block = ar_storage:read_block(ar_util:decode(Hash)),
-			case Block of
-				unavailable ->
-					{404, [], <<"Not Found.">>};
-				B ->
-					{BLOCKJSON} = ar_serialize:block_to_json_struct(B),
-					{_, Res} = lists:keyfind(list_to_existing_atom(binary_to_list(Field)), 1, BLOCKJSON),
-					Result = block_field_to_string(Field, Res),
-					{200, [], Result}
+			case safe_decode(Hash) of
+				{error, invalid} ->
+					{400, [], <<"invalid hash">>};
+				{ok, HashOK} ->
+					case ar_storage:read_block(HashOK) of
+						unavailable ->
+							{404, [], <<"Not Found.">>};
+						B ->
+							{BLOCKJSON} = ar_serialize:block_to_json_struct(B),
+							Res = val_for_key(binary_to_existing_atom(Field), BLOCKJSON),
+							Result = block_field_to_string(Field, Res),
+							{200, [], Result}
+					end
 			end;
 		_ ->
 			{421, [], <<"Subfield block querying is disabled on this node.">>}
@@ -559,20 +573,20 @@ handle('GET', [<<"services">>], _Req) ->
 %% {field} := { id | last_tx | owner | tags | target | quantity | data | signature | reward }
 %%
 handle('GET', [<<"tx">>, Hash, Field], _Req) ->
-	Id=ar_util:decode(Hash),
-	F=ar_storage:lookup_tx_filename(Id),
-	case F of
-		unavailable ->
-			case lists:member(Id, ar_node:get_pending_txs(whereis(http_entrypoint_node))) of
+	case hash_to_maybe_filename(tx, Hash) of
+		{error, invalid} ->
+			{400, [], <<"invalid hash">>};
+		{error, ID, unavailable} ->
+			case is_a_pending_tx(ID) of
 				true ->
 					{202, [], <<"Pending">>};
 				false ->
 					{404, [], <<"Not Found.">>}
 			end;
-		Filename ->
+		{ok, Filename} ->
 			{ok, JSONBlock} = file:read_file(Filename),
 			{TXJSON} = ar_serialize:dejsonify(JSONBlock),
-			{_, Res} = lists:keyfind(Field, 1, TXJSON),
+			Res = val_for_key(Field, TXJSON),
 			{200, [], Res}
 	end;
 
@@ -602,7 +616,7 @@ handle(_, _, _) ->
 	{400, [], <<"Request type not found.">>}.
 
 %% @doc Handles all other elli metadata events.
-handle_event(elli_startup, Args, Config) -> ok;
+handle_event(elli_startup, _Args, _Config) -> ok;
 handle_event(Type, Args, Config)
 		when (Type == request_throw)
 		or (Type == request_error)
@@ -611,7 +625,7 @@ handle_event(Type, Args, Config)
 	%ar:report_console([{elli_event, Type}, {args, Args}, {config, Config}]),
 	ok;
 %% Uncomment to show unhandeled message types.
-handle_event(Type, Args, Config) ->
+handle_event(_Type, _Args, _Config) ->
 	%ar:report_console([{elli_event, Type}, {args, Args}, {config, Config}]),
 	ok.
 
@@ -1117,22 +1131,31 @@ block_field_to_string(<<"hash_list">>, Res) -> ar_serialize:jsonify(Res);
 block_field_to_string(<<"wallet_list">>, Res) -> ar_serialize:jsonify(Res);
 block_field_to_string(<<"reward_addr">>, Res) -> Res.
 
-hash_to_maybe_filename(Hash) ->
+%% @doc stdlib function composition.
+binary_to_existing_atom(B) ->
+	list_to_existing_atom(binary_to_list(B)).
+
+%% @doc checks if hash is valid & if so returns filename.
+hash_to_maybe_filename(Type, Hash) ->
 	case safe_decode(Hash) of
 		{error, invalid} ->
 			{error, invalid};
 		{ok, ID} ->
-			F = ar_storage:lookup_tx_filename(ID),
+			{Mod, Fun} = type_to_mf({Type, lookup_filename}),
+			F = apply(Mod, Fun, [ID]),
 			case F of
 				unavailable ->
-					{error, unavailable}
+					{error, ID, unavailable};
 				Filename ->
 					{ok, Filename}
-	end.	
+			end
+	end.
 
+%% @doc Return true if ID is a pending tx.
 is_a_pending_tx(ID) ->
 	lists:member(ID, ar_node:get_pending_txs(whereis(http_entrypoint_node))).
 
+%% @doc wrapper aound util:decode catching exceptions for invalid base64url encoding.
 safe_decode(X) ->
 	try
 		D = ar_util:decode(X),
@@ -1141,6 +1164,18 @@ safe_decode(X) ->
 		_:_ ->
 			{error, invalid}
 	end.
+
+%% @doc converts a tuple of atoms to a {Module, Function} tuple.
+type_to_mf({tx, lookup_filename}) ->
+	{ar_storage, lookup_tx_filename};
+type_to_mf({block, lookup_filename}) ->
+	{ar_storage, lookup_block_filename}.
+
+%% @doc Convenience function for lists:keyfind(Key, 1, List).
+%% returns Value not {Key, Value}.
+val_for_key(K, L) ->
+	{K, V} = lists:keyfind(K, 1, L),
+	V.
 
 %%% Tests
 


### PR DESCRIPTION
All urls containing hashes (anything sent to util:decode/1) are now checked. Affected handle functions have had nested cases streamlined (a bit); various helper functions have been added.