### PR TITLE
Add check if block is in BHL for GET /block/(hash|height)/...

### DIFF
--- a/src/ar_storage.erl
+++ b/src/ar_storage.erl
@@ -228,7 +228,7 @@ do_read_block(Filename, BHL) ->
 							ar:report(
 								[
 									{
-										error_reading_wallet_list_from_disk, 
+										error_reading_wallet_list_from_disk,
 										ar_util:encode(B#block.indep_hash)
 									},
 									{type, Type}


### PR DESCRIPTION
If block hash is not yet in BHL we so far had an error. The request `GET /block/hash` failed in that case. Now we're checking if it is contained and return a 404 otherwise.

Implementation could be more simple if `hash` and `height` would not be handled in one function. Could be optimised in next step.

Fixes #46 