### PR TITLE
Maintenance/slimline block validation

### DIFF
--- a/src/ar_block.erl
+++ b/src/ar_block.erl
@@ -367,8 +367,8 @@ verify_indep_hash(Block = #block { indep_hash = Indep }) ->
 	Indep == ar_weave:indep_hash(Block).
 
 %% @doc Verify the dependent hash of a given block is valid
-verify_dep_hash(NewB, BlockDataSegment) ->
-	NewB#block.hash == ar_weave:hash(BlockDataSegment, NewB#block.nonce).
+verify_dep_hash(NewB, BlockDataSegmentHash) ->
+	NewB#block.hash == BlockDataSegmentHash.
 
 %% @doc Verify that the block was created within the last ten minutes
 verify_timestamp(Timestamp, NewB) ->

--- a/src/ar_block.erl
+++ b/src/ar_block.erl
@@ -1,7 +1,7 @@
 -module(ar_block).
 -export([block_to_binary/1, block_field_size_limit/1]).
 -export([get_recall_block/5, get_recall_block/6]).
--export([verify_dep_hash/4, verify_indep_hash/1, verify_timestamp/2]).
+-export([verify_dep_hash/2, verify_indep_hash/1, verify_timestamp/2]).
 -export([verify_height/2, verify_last_retarget/1, verify_previous_block/2]).
 -export([verify_block_hash_list/2, verify_wallet_list/4, verify_weave_size/3]).
 -export([hash_wallet_list/1]).
@@ -367,19 +367,8 @@ verify_indep_hash(Block = #block { indep_hash = Indep }) ->
 	Indep == ar_weave:indep_hash(Block).
 
 %% @doc Verify the dependent hash of a given block is valid
-verify_dep_hash(NewB, OldB, RecallB, MinedTXs) ->
-	NewB#block.hash ==
-		ar_weave:hash(
-			ar_block:generate_block_data_segment(
-				OldB,
-				RecallB,
-				MinedTXs,
-				NewB#block.reward_addr,
-				NewB#block.timestamp,
-				NewB#block.tags
-			),
-			NewB#block.nonce
-		).
+verify_dep_hash(NewB, BlockDataSegment) ->
+	NewB#block.hash == ar_weave:hash(BlockDataSegment, NewB#block.nonce).
 
 %% @doc Verify that the block was created within the last ten minutes
 verify_timestamp(Timestamp, NewB) ->

--- a/src/ar_mine.erl
+++ b/src/ar_mine.erl
@@ -1,6 +1,6 @@
 -module(ar_mine).
 -export([start/6, start/7, change_data/2, stop/1, miner/2, schedule_hash/1]).
--export([validate/3, next_diff/1]).
+-export([validate/3, validate_by_hash/2, next_diff/1]).
 -include("ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -270,6 +270,23 @@ validate(DataSegment, Nonce, Diff) ->
 	NewDiff = erlang:max(Diff, ?MIN_DIFF),
 	case NewHash = ar_weave:hash(DataSegment, Nonce) of
 		<< 0:NewDiff, _/bitstring >> -> NewHash;
+		_ -> false
+	end.
+-endif.
+
+%% @doc Validate that a given block data segment hash satisfies the difficulty requirement.
+-ifdef(DEBUG).
+validate_by_hash(DataSegmentHash, Diff) ->
+	NewDiff = Diff,
+	case DataSegmentHash of
+		<< 0:NewDiff, _/bitstring >> -> DataSegmentHash;
+		_ -> false
+	end.
+-else.
+validate_by_hash(DataSegmentHash, Diff) ->
+	NewDiff = erlang:max(Diff, ?MIN_DIFF),
+	case DataSegmentHash of
+		<< 0:NewDiff, _/bitstring >> -> DataSegmentHash;
 		_ -> false
 	end.
 -endif.

--- a/src/ar_node_utils.erl
+++ b/src/ar_node_utils.erl
@@ -476,14 +476,16 @@ validate(
 		RewardAddr,
 		Tags) ->
 	% TODO: Fix names.
-	BDS = ar_block:generate_block_data_segment(OldB, RecallB, TXs, RewardAddr, Timestamp, Tags),
-	Mine = ar_mine:validate(BDS, Nonce, Diff),
+	BDSHash = ar_weave:hash(
+		ar_block:generate_block_data_segment(OldB, RecallB, TXs, RewardAddr, Timestamp, Tags),
+		Nonce),
+	Mine = ar_mine:validate_by_hash(BDSHash, Diff),
 	Wallet = validate_wallet_list(WalletList),
 	IndepRecall = ar_weave:verify_indep(RecallB, HashList),
 	Txs = ar_tx:verify_txs(TXs, Diff, OldB#block.wallet_list),
 	Retarget = ar_retarget:validate(NewB, OldB),
 	IndepHash = ar_block:verify_indep_hash(NewB),
-	Hash = ar_block:verify_dep_hash(NewB, BDS),
+	Hash = ar_block:verify_dep_hash(NewB, BDSHash),
 	WeaveSize = ar_block:verify_weave_size(NewB, OldB, TXs),
 	Size = ar_block:block_field_size_limit(NewB),
 	%Time = ar_block:verify_timestamp(OldB, NewB),

--- a/src/ar_node_utils.erl
+++ b/src/ar_node_utils.erl
@@ -476,13 +476,14 @@ validate(
 		RewardAddr,
 		Tags) ->
 	% TODO: Fix names.
-	Mine = ar_mine:validate(ar_block:generate_block_data_segment(OldB, RecallB, TXs, RewardAddr, Timestamp, Tags), Nonce, Diff),
+	BDS = ar_block:generate_block_data_segment(OldB, RecallB, TXs, RewardAddr, Timestamp, Tags),
+	Mine = ar_mine:validate(BDS, Nonce, Diff),
 	Wallet = validate_wallet_list(WalletList),
 	IndepRecall = ar_weave:verify_indep(RecallB, HashList),
 	Txs = ar_tx:verify_txs(TXs, Diff, OldB#block.wallet_list),
 	Retarget = ar_retarget:validate(NewB, OldB),
 	IndepHash = ar_block:verify_indep_hash(NewB),
-	Hash = ar_block:verify_dep_hash(NewB, OldB, RecallB, TXs),
+	Hash = ar_block:verify_dep_hash(NewB, BDS),
 	WeaveSize = ar_block:verify_weave_size(NewB, OldB, TXs),
 	Size = ar_block:block_field_size_limit(NewB),
 	%Time = ar_block:verify_timestamp(OldB, NewB),


### PR DESCRIPTION
nb the new ar_mine:validate_by_hash and the old ar_mine:validate: I have left ar_mine:validate alone as it is called from elsewhere in ar_mine, and I didn't want to get into secondary refactoring.

(tests at 88)