### PR TITLE
Fix/clean object files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,19 @@ gitmodules:
 
 build: ebin data logs blocks hash_lists wallet_lists
 	rm -rf priv
-	cd lib/jiffy && ./rebar compile && cd ../.. && mv lib/jiffy/priv ./
+	( \
+		cd lib/jiffy && \
+		./rebar compile && \
+		cd ../.. && \
+		mv lib/jiffy/priv ./ \
+	)
 	(cd lib/prometheus && ./rebar3 compile)
 	(cd lib/accept && ./rebar3 compile)
-	(cd lib/prometheus_process_collector && ./rebar3 compile && cp _build/default/lib/prometheus_process_collector/priv/*.so ../../priv)
+	( \
+		cd lib/prometheus_process_collector && \
+		./rebar3 compile && \
+		cp _build/default/lib/prometheus_process_collector/priv/*.so ../../priv \
+	)
 	erlc $(ERLC_OPTS) +export_all -o ebin/ src/ar.erl
 	erl $(ERL_OPTS) -noshell -s ar rebuild -s init stop
 

--- a/Makefile
+++ b/Makefile
@@ -42,19 +42,18 @@ gitmodules:
 	git submodule update --init
 
 build: ebin data logs blocks hash_lists wallet_lists
-	rm -rf priv
 	( \
 		cd lib/jiffy && \
 		./rebar compile && \
 		cd ../.. && \
-		mv lib/jiffy/priv ./ \
+		cp lib/jiffy/priv/jiffy.so ./priv/ \
 	)
 	(cd lib/prometheus && ./rebar3 compile)
 	(cd lib/accept && ./rebar3 compile)
 	( \
 		cd lib/prometheus_process_collector && \
 		./rebar3 compile && \
-		cp _build/default/lib/prometheus_process_collector/priv/*.so ../../priv \
+		cp _build/default/lib/prometheus_process_collector/priv/prometheus_process_collector.so ../../priv/ \
 	)
 	erlc $(ERLC_OPTS) +export_all -o ebin/ src/ar.erl
 	erl $(ERL_OPTS) -noshell -s ar rebuild -s init stop
@@ -93,7 +92,8 @@ sim_hard: all
 	erl $(ERL_OPTS) -s ar_network spawn_and_mine hard
 
 clean:
-	rm -rf ebin docs logs priv
+	rm -rf ebin docs logs
+	rm -f priv/jiffy.so priv/prometheus_process_collector.so
 	rm -f erl_crash.dump
 
 todo:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: gitmodules build
 gitmodules:
 	git submodule update --init
 
-build: ebin data logs blocks hash_lists wallet_lists
+build: data blocks hash_lists wallet_lists
 	( \
 		cd lib/jiffy && \
 		./rebar compile && \
@@ -58,12 +58,6 @@ build: ebin data logs blocks hash_lists wallet_lists
 	erlc $(ERLC_OPTS) +export_all -o ebin/ src/ar.erl
 	erl $(ERL_OPTS) -noshell -s ar rebuild -s init stop
 
-
-ebin:
-	mkdir -p ebin
-
-logs:
-	mkdir -p logs
 
 blocks:
 	mkdir -p blocks
@@ -92,7 +86,9 @@ sim_hard: all
 	erl $(ERL_OPTS) -s ar_network spawn_and_mine hard
 
 clean:
-	rm -rf ebin docs logs
+	rm ./ebin/*.beam
+	rm ./logs/*.log
+	rm -rf docs
 	rm -f priv/jiffy.so priv/prometheus_process_collector.so
 	rm -f erl_crash.dump
 

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,15 @@ sim_hard: all
 	erl $(ERL_OPTS) -s ar_network spawn_and_mine hard
 
 clean:
-	rm ./ebin/*.beam
-	rm ./logs/*.log
+	rm -f ./ebin/*.beam
+	rm -f ./logs/*.log
 	rm -rf docs
 	rm -f priv/jiffy.so priv/prometheus_process_collector.so
 	rm -f erl_crash.dump
+	(cd lib/jiffy && ./rebar clean)
+	(cd lib/prometheus && ./rebar3 clean --all)
+	(cd lib/accept && ./rebar3 clean --all)
+	(cd lib/prometheus_process_collector && ./rebar3 clean --all)
 
 todo:
 	grep --color --line-number --recursive TODO "src"


### PR DESCRIPTION
Fixes issue #76 where the object files from the jiffy NIF aren't deleted on `make clean`.

Review recommendations:
Look through commit by commit in commit order (not timestamp order like on Github).