### PR TITLE
Add GET /wallet/{w}/txs(/{earliest_tx}) endpoint

### DIFF
--- a/http_iface_docs.md
+++ b/http_iface_docs.md
@@ -56,7 +56,7 @@ Retrieve a JSON transaction record via the specified ID.
 - **Method**
   GET
 - **URL Parameters**
-  [transaction_id] : base64url encoded ID associated with the transaction
+  [transaction_id] : Base64 encoded ID associated with the transaction
 
 
 #### Example Response
@@ -473,7 +473,7 @@ Retrieve the ID of the last transaction made by the given address.
 - **Method**
   GET
 - **URL Parameters**
-  [wallet_address] : A base64url encoded SHA256 hash of the RSA modulus.
+  [wallet_address] : A Base64 encoded SHA256 hash of the public key.
 
 
 #### Example Response
@@ -503,10 +503,45 @@ xhr.send();
 ```
 
 
+## GET transactions via address
+
+Retrieve the ID of the last transaction made by the given wallet.
+
+- **URL**
+  `/wallet/[wallet_address]/txs/[earliest_tx]`
+- **Method**
+  GET
+- **URL Parameters**
+
+  - [wallet_address] : A Base64 encoded SHA256 hash of the public key.
+  - [earliest_tx] (optional) : A Base64 encoded ID of the earliest transaction to fetch. If not specified, all transactions of the given wallet are returned.
 
 
+#### Example Response
+
+A JSON list of base64url encoded transaction identifiers.
+
+```javascript
+["bUfaJN-KKS1LRh_DlJv4ff1gmdbHP4io-J9x7cLY5is","b23...xg"]
+```
 
 
+#### JavaScript Example Request
+
+```javascript
+var node = 'http://127.0.0.1:1984';
+var path = '/wallet/VukPk7P3qXAS2Q76ejTwC6Y_U_bMl_z6mgLvgSUJIzE/txs/bUfaJN-KKS1LRh_DlJv4ff1gmdbHP4io-J9x7cLY5is';
+var url = node + path;
+var xhr = new XMLHttpRequest();
+
+xhr.open('GET', url);
+xhr.onreadystatechange = function() {
+  if(xhr.readystate == 4 && xhr.status == 200) {
+    // Do something.
+  }
+};
+xhr.send();
+```
 
 
 ## GET nodes peer list  

--- a/src/ar_http_iface_server.erl
+++ b/src/ar_http_iface_server.erl
@@ -468,7 +468,7 @@ handle('GET', [<<"wallet">>, Addr, <<"last_tx">>], _Req) ->
 		{ok, AddrOK} ->
 			{200, [],
 				ar_util:encode(
-					ar_node:get_last_tx(whereis(http_entrypoint_node), AddrOK)
+					?OK(ar_node:get_last_tx(whereis(http_entrypoint_node), AddrOK))
 				)
 			}
 	end;

--- a/src/ar_http_iface_server.erl
+++ b/src/ar_http_iface_server.erl
@@ -473,6 +473,17 @@ handle('GET', [<<"wallet">>, Addr, <<"last_tx">>], _Req) ->
 			}
 	end;
 
+%% @doc Return transaction identifiers (hashes) for the wallet specified via wallet_address.
+%% GET request to endpoint /wallet/{wallet_address}/txs
+handle('GET', [<<"wallet">>, Addr, <<"txs">>], _Req) ->
+	handle_get_wallet_txs(Addr, none);
+
+%% @doc Return transaction identifiers (hashes) starting from the earliest_tx for the wallet
+%% specified via wallet_address.
+%% GET request to endpoint /wallet/{wallet_address}/txs/{earliest_tx}
+handle('GET', [<<"wallet">>, Addr, <<"txs">>, EarliestTX], _Req) ->
+	handle_get_wallet_txs(Addr, ar_util:decode(EarliestTX));
+
 %% @doc Return the encrypted blockshadow corresponding to the indep_hash.
 %% GET request to endpoint /block/hash/{indep_hash}/encrypted
 %handle('GET', [<<"block">>, <<"hash">>, Hash, <<"encrypted">>], _Req) ->
@@ -713,6 +724,33 @@ get_tx_filename(Hash) ->
 			end;
 		{ok, Filename} ->
 			{ok, Filename}
+	end.
+
+handle_get_wallet_txs(Addr, EarliestTXID) ->
+	case safe_decode(Addr) of
+		{error, invalid} ->
+			{400, [], <<"Invalid address.">>};
+		{ok, AddrOK} ->
+			{ok, LastTXID} = ar_node:get_last_tx(whereis(http_entrypoint_node), AddrOK),
+			{200, [],
+				ar_serialize:jsonify(get_wallet_txs(EarliestTXID, LastTXID))
+			}
+	end.
+
+%% @doc Returns a list of all TX IDs starting with LastTXID to EarliestTXID (inclusive)
+%% for the same wallet.
+get_wallet_txs(EarliestTXID, LatestTXID) ->
+	get_wallet_txs(EarliestTXID, LatestTXID, []).
+
+get_wallet_txs(EarliestTXID, PreviousTXID, Acc) ->
+	case PreviousTXID of
+		<<>> ->
+			lists:reverse(Acc);
+		EarliestTXID ->
+			lists:reverse([ar_util:encode(EarliestTXID) | Acc]);
+		_ ->
+			TX = ar_storage:read_tx(PreviousTXID),
+			get_wallet_txs(EarliestTXID, TX#tx.last_tx, [ar_util:encode(PreviousTXID) | Acc])
 	end.
 
 handle_post_tx(TX) ->

--- a/src/ar_http_iface_tests.erl
+++ b/src/ar_http_iface_tests.erl
@@ -887,6 +887,87 @@ post_unsigned_tx() ->
 		maps:from_list(GetTXRes)
 	).
 
+get_wallet_txs_test() ->
+	ar_storage:clear(),
+	%% Create a wallet
+	{_, Pub} = ar_wallet:new(),
+	WalletAddress = binary_to_list(ar_util:encode(ar_wallet:to_address(Pub))),
+	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), 10000, <<>>}]),
+	Node = ar_node:start([], [B0]),
+	ar_http_iface_server:reregister(Node),
+	Bridge = ar_bridge:start([], Node, ?DEFAULT_HTTP_IFACE_PORT),
+	ar_http_iface_server:reregister(http_bridge_node, Bridge),
+	ar_node:add_peers(Node, Bridge),
+	{ok, {{<<"200">>, <<"OK">>}, _, Body, _, _}} =
+		ar_httpc:request(
+			<<"GET">>,
+			{127, 0, 0, 1, 1984},
+			"/wallet/" ++ WalletAddress ++ "/txs"
+		),
+	TXs = ar_serialize:dejsonify(Body),
+	%% Expect the wallet to have no transactions
+	?assertEqual([], TXs),
+	%% Sign and post a transaction and expect it to appear in the wallet list
+	TX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub) },
+	{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
+		ar_httpc:request(
+			<<"POST">>,
+			{127, 0, 0, 1, 1984},
+			"/tx",
+			[],
+			ar_serialize:jsonify(ar_serialize:tx_to_json_struct(TX))
+		),
+	receive after 250 -> ok end,
+	ar_node:mine(Node),
+	receive after 1000 -> ok end,
+	{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXBody, _, _}} =
+		ar_httpc:request(
+			<<"GET">>,
+			{127, 0, 0, 1, 1984},
+			"/wallet/" ++ WalletAddress ++ "/txs"
+		),
+	OneTX = ar_serialize:dejsonify(GetOneTXBody),
+	?assertEqual([ar_util:encode(TX#tx.id)], OneTX),
+	%% Expect the same when the TX is specified as the earliest TX
+	{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXAgainBody, _, _}} =
+		ar_httpc:request(
+			<<"GET">>,
+			{127, 0, 0, 1, 1984},
+			"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(TX#tx.id))
+		),
+	OneTXAgain = ar_serialize:dejsonify(GetOneTXAgainBody),
+	?assertEqual([ar_util:encode(TX#tx.id)], OneTXAgain),
+	%% Add one more TX and expect it to be appended to the wallet list
+	SecondTX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub), last_tx = TX#tx.id },
+	{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
+		ar_httpc:request(
+			<<"POST">>,
+			{127, 0, 0, 1, 1984},
+			"/tx",
+			[],
+			ar_serialize:jsonify(ar_serialize:tx_to_json_struct(SecondTX))
+		),
+	receive after 250 -> ok end,
+	ar_node:mine(Node),
+	receive after 1000 -> ok end,
+	{ok, {{<<"200">>, <<"OK">>}, _, GetTwoTXsBody, _, _}} =
+		ar_httpc:request(
+			<<"GET">>,
+			{127, 0, 0, 1, 1984},
+			"/wallet/" ++ WalletAddress ++ "/txs"
+		),
+	Expected = [ar_util:encode(SecondTX#tx.id), ar_util:encode(TX#tx.id)],
+	?assertEqual(Expected, ar_serialize:dejsonify(GetTwoTXsBody)),
+	%% Specify the second TX as the earliest and expect the first one to be excluded
+	{ok, {{<<"200">>, <<"OK">>}, _, GetSecondTXBody, _, _}} =
+		ar_httpc:request(
+			<<"GET">>,
+			{127, 0, 0, 1, 1984},
+			"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(SecondTX#tx.id))
+		),
+	OneSecondTX = ar_serialize:dejsonify(GetSecondTXBody),
+	?assertEqual([ar_util:encode(SecondTX#tx.id)], OneSecondTX).
+
 %	Node = ar_node:start([], B0),
 %	ar_http_iface_server:reregister(Node),
 %	ar_node:mine(Node),

--- a/src/ar_http_iface_tests.erl
+++ b/src/ar_http_iface_tests.erl
@@ -888,85 +888,87 @@ post_unsigned_tx() ->
 	).
 
 get_wallet_txs_test() ->
-	ar_storage:clear(),
-	%% Create a wallet
-	{_, Pub} = ar_wallet:new(),
-	WalletAddress = binary_to_list(ar_util:encode(ar_wallet:to_address(Pub))),
-	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), 10000, <<>>}]),
-	Node = ar_node:start([], [B0]),
-	ar_http_iface_server:reregister(Node),
-	Bridge = ar_bridge:start([], Node, ?DEFAULT_HTTP_IFACE_PORT),
-	ar_http_iface_server:reregister(http_bridge_node, Bridge),
-	ar_node:add_peers(Node, Bridge),
-	{ok, {{<<"200">>, <<"OK">>}, _, Body, _, _}} =
-		ar_httpc:request(
-			<<"GET">>,
-			{127, 0, 0, 1, 1984},
-			"/wallet/" ++ WalletAddress ++ "/txs"
-		),
-	TXs = ar_serialize:dejsonify(Body),
-	%% Expect the wallet to have no transactions
-	?assertEqual([], TXs),
-	%% Sign and post a transaction and expect it to appear in the wallet list
-	TX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub) },
-	{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
-		ar_httpc:request(
-			<<"POST">>,
-			{127, 0, 0, 1, 1984},
-			"/tx",
-			[],
-			ar_serialize:jsonify(ar_serialize:tx_to_json_struct(TX))
-		),
-	receive after 250 -> ok end,
-	ar_node:mine(Node),
-	receive after 1000 -> ok end,
-	{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXBody, _, _}} =
-		ar_httpc:request(
-			<<"GET">>,
-			{127, 0, 0, 1, 1984},
-			"/wallet/" ++ WalletAddress ++ "/txs"
-		),
-	OneTX = ar_serialize:dejsonify(GetOneTXBody),
-	?assertEqual([ar_util:encode(TX#tx.id)], OneTX),
-	%% Expect the same when the TX is specified as the earliest TX
-	{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXAgainBody, _, _}} =
-		ar_httpc:request(
-			<<"GET">>,
-			{127, 0, 0, 1, 1984},
-			"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(TX#tx.id))
-		),
-	OneTXAgain = ar_serialize:dejsonify(GetOneTXAgainBody),
-	?assertEqual([ar_util:encode(TX#tx.id)], OneTXAgain),
-	%% Add one more TX and expect it to be appended to the wallet list
-	SecondTX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub), last_tx = TX#tx.id },
-	{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
-		ar_httpc:request(
-			<<"POST">>,
-			{127, 0, 0, 1, 1984},
-			"/tx",
-			[],
-			ar_serialize:jsonify(ar_serialize:tx_to_json_struct(SecondTX))
-		),
-	receive after 250 -> ok end,
-	ar_node:mine(Node),
-	receive after 1000 -> ok end,
-	{ok, {{<<"200">>, <<"OK">>}, _, GetTwoTXsBody, _, _}} =
-		ar_httpc:request(
-			<<"GET">>,
-			{127, 0, 0, 1, 1984},
-			"/wallet/" ++ WalletAddress ++ "/txs"
-		),
-	Expected = [ar_util:encode(SecondTX#tx.id), ar_util:encode(TX#tx.id)],
-	?assertEqual(Expected, ar_serialize:dejsonify(GetTwoTXsBody)),
-	%% Specify the second TX as the earliest and expect the first one to be excluded
-	{ok, {{<<"200">>, <<"OK">>}, _, GetSecondTXBody, _, _}} =
-		ar_httpc:request(
-			<<"GET">>,
-			{127, 0, 0, 1, 1984},
-			"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(SecondTX#tx.id))
-		),
-	OneSecondTX = ar_serialize:dejsonify(GetSecondTXBody),
-	?assertEqual([ar_util:encode(SecondTX#tx.id)], OneSecondTX).
+	{timeout, 10, fun() ->
+		ar_storage:clear(),
+		%% Create a wallet
+		{_, Pub} = ar_wallet:new(),
+		WalletAddress = binary_to_list(ar_util:encode(ar_wallet:to_address(Pub))),
+		[B0] = ar_weave:init([{ar_wallet:to_address(Pub), 10000, <<>>}]),
+		Node = ar_node:start([], [B0]),
+		ar_http_iface_server:reregister(Node),
+		Bridge = ar_bridge:start([], Node, ?DEFAULT_HTTP_IFACE_PORT),
+		ar_http_iface_server:reregister(http_bridge_node, Bridge),
+		ar_node:add_peers(Node, Bridge),
+		{ok, {{<<"200">>, <<"OK">>}, _, Body, _, _}} =
+			ar_httpc:request(
+				<<"GET">>,
+				{127, 0, 0, 1, 1984},
+				"/wallet/" ++ WalletAddress ++ "/txs"
+			),
+		TXs = ar_serialize:dejsonify(Body),
+		%% Expect the wallet to have no transactions
+		?assertEqual([], TXs),
+		%% Sign and post a transaction and expect it to appear in the wallet list
+		TX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub) },
+		{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
+			ar_httpc:request(
+				<<"POST">>,
+				{127, 0, 0, 1, 1984},
+				"/tx",
+				[],
+				ar_serialize:jsonify(ar_serialize:tx_to_json_struct(TX))
+			),
+		receive after 250 -> ok end,
+		ar_node:mine(Node),
+		receive after 1000 -> ok end,
+		{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXBody, _, _}} =
+			ar_httpc:request(
+				<<"GET">>,
+				{127, 0, 0, 1, 1984},
+				"/wallet/" ++ WalletAddress ++ "/txs"
+			),
+		OneTX = ar_serialize:dejsonify(GetOneTXBody),
+		?assertEqual([ar_util:encode(TX#tx.id)], OneTX),
+		%% Expect the same when the TX is specified as the earliest TX
+		{ok, {{<<"200">>, <<"OK">>}, _, GetOneTXAgainBody, _, _}} =
+			ar_httpc:request(
+				<<"GET">>,
+				{127, 0, 0, 1, 1984},
+				"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(TX#tx.id))
+			),
+		OneTXAgain = ar_serialize:dejsonify(GetOneTXAgainBody),
+		?assertEqual([ar_util:encode(TX#tx.id)], OneTXAgain),
+		%% Add one more TX and expect it to be appended to the wallet list
+		SecondTX = (ar_tx:new())#tx{ owner = ar_wallet:to_address(Pub), last_tx = TX#tx.id },
+		{ok, {{<<"200">>, <<"OK">>}, _, _, _, _}} =
+			ar_httpc:request(
+				<<"POST">>,
+				{127, 0, 0, 1, 1984},
+				"/tx",
+				[],
+				ar_serialize:jsonify(ar_serialize:tx_to_json_struct(SecondTX))
+			),
+		receive after 250 -> ok end,
+		ar_node:mine(Node),
+		receive after 1000 -> ok end,
+		{ok, {{<<"200">>, <<"OK">>}, _, GetTwoTXsBody, _, _}} =
+			ar_httpc:request(
+				<<"GET">>,
+				{127, 0, 0, 1, 1984},
+				"/wallet/" ++ WalletAddress ++ "/txs"
+			),
+		Expected = [ar_util:encode(SecondTX#tx.id), ar_util:encode(TX#tx.id)],
+		?assertEqual(Expected, ar_serialize:dejsonify(GetTwoTXsBody)),
+		%% Specify the second TX as the earliest and expect the first one to be excluded
+		{ok, {{<<"200">>, <<"OK">>}, _, GetSecondTXBody, _, _}} =
+			ar_httpc:request(
+				<<"GET">>,
+				{127, 0, 0, 1, 1984},
+				"/wallet/" ++ WalletAddress ++ "/txs/" ++ binary_to_list(ar_util:encode(SecondTX#tx.id))
+			),
+		OneSecondTX = ar_serialize:dejsonify(GetSecondTXBody),
+		?assertEqual([ar_util:encode(SecondTX#tx.id)], OneSecondTX)
+	end}.
 
 %	Node = ar_node:start([], B0),
 %	ar_http_iface_server:reregister(Node),

--- a/src/ar_node.erl
+++ b/src/ar_node.erl
@@ -14,7 +14,7 @@
 -export([get_hash_list/1, get_height/1]).
 -export([get_trusted_peers/1]).
 -export([get_balance/2]).
--export([get_last_tx/2, get_last_tx_from_floating/2]).
+-export([get_last_tx/2]).
 -export([get_pending_txs/1, get_full_pending_txs/1]).
 -export([get_current_diff/1, get_diff/1]).
 -export([get_floating_wallet_list/1]).
@@ -417,20 +417,6 @@ get_last_tx(Node, Addr) when ?IS_ADDR(Addr) ->
 get_last_tx(Node, WalletID) ->
 	get_last_tx(Node, ar_wallet:to_address(WalletID)).
 
-%% @doc Get the last tx id associated with a a given wallet address from the
-%% floating wallet list.
-%% Should the wallet not have made a tx the empty binary will be returned.
-% TODO: Returns empty binary on timeout, this is also
-% a valid return.
-get_last_tx_from_floating(Node, Addr) when ?IS_ADDR(Addr) ->
-	Node ! {get_last_tx_from_floating, self(), Addr},
-	receive
-		{last_tx_from_floating, Addr, LastTX} -> LastTX
-		after ?LOCAL_NET_TIMEOUT -> <<>>
-	end;
-get_last_tx_from_floating(Node, WalletID) ->
-	get_last_tx_from_floating(Node, ar_wallet:to_address(WalletID)).
-
 %% @doc Returns a list of pending transactions.
 %% Pending transactions are those that are valid, but not currently actively
 %% being mined as they are waiting to be distributed around the network.
@@ -766,14 +752,6 @@ handle(SPid, {get_last_tx, From, Addr}) ->
 	{ok, WalletList} = ar_node_state:lookup(SPid, wallet_list),
 	From ! {last_tx, Addr,
 		case lists:keyfind(Addr, 1, WalletList) of
-			{Addr, _Balance, Last} -> Last;
-			false				   -> <<>>
-		end},
-	ok;
-handle(SPid, {get_last_tx_from_floating, From, Addr}) ->
-	{ok, FloatingWalletList} = ar_node_state:lookup(SPid, floating_wallet_list),
-	From ! {last_tx_from_floating, Addr,
-		case lists:keyfind(Addr, 1, FloatingWalletList) of
 			{Addr, _Balance, Last} -> Last;
 			false				   -> <<>>
 		end},

--- a/src/ar_node.erl
+++ b/src/ar_node.erl
@@ -406,12 +406,13 @@ get_balance(Node, WalletID) ->
 
 %% @doc Get the last tx id associated with a given wallet address.
 %% Should the wallet not have made a tx the empty binary will be returned.
-% TODO: Timeout returns an empty binary, this is also a valid return.
 get_last_tx(Node, Addr) when ?IS_ADDR(Addr) ->
 	Node ! {get_last_tx, self(), Addr},
 	receive
-		{last_tx, Addr, LastTX} -> LastTX
-		after ?LOCAL_NET_TIMEOUT -> <<>>
+		{last_tx, Addr, LastTX} ->
+			{ok, LastTX}
+	after ?LOCAL_NET_TIMEOUT ->
+		timeout
 	end;
 get_last_tx(Node, WalletID) ->
 	get_last_tx(Node, ar_wallet:to_address(WalletID)).
@@ -419,7 +420,7 @@ get_last_tx(Node, WalletID) ->
 %% @doc Get the last tx id associated with a a given wallet address from the
 %% floating wallet list.
 %% Should the wallet not have made a tx the empty binary will be returned.
-% TODO: Duplicate of get_last_tx, returns empty binary on timeout, this is also
+% TODO: Returns empty binary on timeout, this is also
 % a valid return.
 get_last_tx_from_floating(Node, Addr) when ?IS_ADDR(Addr) ->
 	Node ! {get_last_tx_from_floating, self(), Addr},

--- a/src/ar_node_tests.erl
+++ b/src/ar_node_tests.erl
@@ -428,7 +428,7 @@ last_tx_test_() ->
 		timer:sleep(500),
 		ar_node:mine(Node1), % Mine B1
 		timer:sleep(500),
-		?assertEqual(ar_node:get_last_tx(Node2, Pub1), ID)
+		?assertEqual(?OK(ar_node:get_last_tx(Node2, Pub1)), ID)
 	end}.
 
 %%%

--- a/src/ar_node_tests.erl
+++ b/src/ar_node_tests.erl
@@ -731,24 +731,26 @@ wallet_two_transaction_test_() ->
 	end}.
 
 %% @doc Wallet0 -> Wallet1 { with tags } | mine | check
-mine_tx_with_key_val_tags_test() ->
-	ar_storage:clear(),
-	{Priv1, Pub1} = ar_wallet:new(),
-	{_Priv2, Pub2} = ar_wallet:new(),
-	TX = ar_tx:new(Pub2, ?AR(1), ?AR(9000), <<>>),
-	SignedTX = ar_tx:sign(TX, Priv1, Pub1),
-	B0 = ar_weave:init([{ar_wallet:to_address(Pub1), ?AR(10000), <<>>}], 8),
-	Node1 = ar_node:start([], B0),
-	Node2 = ar_node:start([Node1], B0),
-	ar_node:add_peers(Node1, Node2),
-	ar_storage:write_tx([SignedTX]),
-	ar_node:add_tx(Node1, SignedTX),
-	timer:sleep(300),
-	ar_node:mine(Node1), % Mine B1
-	timer:sleep(1000),
-	BHL = [B1Hash|_] = ar_node:get_blocks(Node2),
-	#block { txs = TXs } = ar_storage:read_block(B1Hash, BHL),
-	?assertEqual(ar_storage:read_tx(TXs), [SignedTX]).
+mine_tx_with_key_val_tags_test_() ->
+	{timeout, 10, fun() ->
+		ar_storage:clear(),
+		{Priv1, Pub1} = ar_wallet:new(),
+		{_Priv2, Pub2} = ar_wallet:new(),
+		TX = ar_tx:new(Pub2, ?AR(1), ?AR(9000), <<>>),
+		SignedTX = ar_tx:sign(TX, Priv1, Pub1),
+		B0 = ar_weave:init([{ar_wallet:to_address(Pub1), ?AR(10000), <<>>}], 8),
+		Node1 = ar_node:start([], B0),
+		Node2 = ar_node:start([Node1], B0),
+		ar_node:add_peers(Node1, Node2),
+		ar_storage:write_tx([SignedTX]),
+		ar_node:add_tx(Node1, SignedTX),
+		timer:sleep(300),
+		ar_node:mine(Node1), % Mine B1
+		timer:sleep(1000),
+		BHL = [B1Hash|_] = ar_node:get_blocks(Node2),
+		#block { txs = TXs } = ar_storage:read_block(B1Hash, BHL),
+		?assertEqual(ar_storage:read_tx(TXs), [SignedTX])
+	end}.
 
 %% @doc Wallet1 -> Wallet2 | Wallet1 -> Wallet3 | mine | check
 %% @doc Wallet1 -> Wallet2 | Wallet1 -> Wallet3 | mine | check

--- a/src/ar_sim_client.erl
+++ b/src/ar_sim_client.erl
@@ -186,7 +186,7 @@ send_specified_data_tx(Filepath) ->
 	).
 
 create_data_tx({Priv, Pub}, Data) ->
-	LastTx = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
+	{ok, LastTx} = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
 	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
 	TX = ar_tx:new(Data, 0, LastTx),
 	Cost = ar_tx:calculate_min_tx_cost(
@@ -205,7 +205,7 @@ create_data_tx(KeyList, Data) ->
 %% @doc Create a random data TX with max length MaxTxLen
 create_random_data_tx({Priv, Pub}, MaxTxLen) ->
 	% Generate and dispatch a new data transaction.
-	LastTx = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
+	{ok, LastTx} = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
 	%ar:d({random_data_tx_pub, ar_util:encode(ar_wallet:to_address(Pub))}),
 	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
 	Data = << 0:(rand:uniform(MaxTxLen) * 8) >>,
@@ -223,7 +223,7 @@ create_random_data_tx({Priv, Pub}, MaxTxLen) ->
 create_random_data_tx(KeyList, MaxTxLen) ->
 	{Priv, Pub} = lists:nth(rand:uniform(50), KeyList),
 	% Generate and dispatch a new data transaction.
-	LastTx = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
+	{ok, LastTx} = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
 	%ar:d({random_data_tx_pub, ar_util:encode(ar_wallet:to_address(Pub))}),
 	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
 	Data = << 0:(rand:uniform(MaxTxLen) * 8) >>,
@@ -259,7 +259,7 @@ create_random_fin_tx(KeyList, MaxAmount) ->
 	{Priv, Pub} = lists:nth(rand:uniform(50), KeyList),
 	{_, Dest} = lists:nth(rand:uniform(50), KeyList),
 	% Generate and dispatch a new data transaction.
-	LastTx = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
+	{ok, LastTx} = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
 	%ar:d({random_fin_tx_pub, ar_util:encode(ar_wallet:to_address(Pub))}),
 	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
 	Qty = rand:uniform(MaxAmount),
@@ -277,7 +277,7 @@ create_random_fin_tx(KeyList, MaxAmount) ->
 create_random_fin_tx({Priv, Pub}, KeyList, MaxAmount) ->
 	{_, Dest} = lists:nth(rand:uniform(10), KeyList),
 	% Generate and dispatch a new data transaction.
-	LastTx = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
+	{ok, LastTx} = ar_node:get_last_tx(whereis(http_entrypoint_node), Pub),
 	%ar:d({random_fin_tx_pub, ar_util:encode(ar_wallet:to_address(Pub))}),
 	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
 	Qty = rand:uniform(MaxAmount),


### PR DESCRIPTION
The endpoint returns identifiers of transactions made by the given wallet. Optionally stops when reaches the given transaction in the transaction chain.