### PR TITLE
Allow Content-Type headers in cross-origin requests

### DIFF
--- a/arweave-server
+++ b/arweave-server
@@ -1,4 +1,4 @@
-# !/bin/sh
+#!/bin/sh
 
 set -o errexit
 

--- a/src/ar_http_iface_server.erl
+++ b/src/ar_http_iface_server.erl
@@ -153,11 +153,14 @@ handle('HEAD', [<<"info">>], _Req) ->
 
 %% @doc Return permissive CORS headers for all endpoints
 handle('OPTIONS', [<<"block">>], _) ->
-	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>}], <<"OK">>};
+	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>},
+	       {<<"Access-Control-Allow-Headers">>, <<"Content-Type">>}], <<"OK">>};
 handle('OPTIONS', [<<"tx">>], _) ->
-	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>}], <<"OK">>};
+	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>},
+	       {<<"Access-Control-Allow-Headers">>, <<"Content-Type">>}], <<"OK">>};
 handle('OPTIONS', [<<"peer">>|_], _) ->
-	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>}], <<"OK">>};
+	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET, POST">>},
+	       {<<"Access-Control-Allow-Headers">>, <<"Content-Type">>}], <<"OK">>};
 handle('OPTIONS', _, _Req) ->
 	{200, [{<<"Access-Control-Allow-Methods">>, <<"GET">>}], <<"OK">>};
 


### PR DESCRIPTION
Closes #35 