### PR TITLE
Add support for custom weave data folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: gitmodules build
 gitmodules:
 	git submodule update --init
 
-build: data blocks hash_lists wallet_lists
+build:
 	( \
 		cd lib/jiffy && \
 		../../bin/mute-on-success ./rebar compile && \
@@ -58,20 +58,6 @@ build: data blocks hash_lists wallet_lists
 	)
 	erlc $(ERLC_OPTS) +export_all -o ebin/ src/ar.erl
 	erl $(ERL_OPTS) -noshell -s ar rebuild -s init stop
-
-
-blocks:
-	mkdir -p blocks
-	mkdir -p blocks/enc
-
-hash_lists:
-	mkdir -p hash_lists
-
-wallet_lists:
-	mkdir -p wallet_lists
-
-data:
-	mkdir -p data/mnesia
 
 docs: all
 	mkdir -p docs

--- a/arweave-server
+++ b/arweave-server
@@ -2,8 +2,6 @@
 
 set -o errexit
 
-mkdir -p ebin logs blocks hash_lists wallets wallet_lists txs blocks/enc priv data data/mnesia
-
 if [ -t 1 ]; then
     SHELL_OPTS=
 else

--- a/docker-arweave-server
+++ b/docker-arweave-server
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-mkdir -p ebin logs blocks wallets txs blocks/enc priv data/genesis_txs
+mkdir -p ebin logs priv
 
 if [ -t 1 ]; then
 	SHELL_OPTS=

--- a/src/ar.hrl
+++ b/src/ar.hrl
@@ -167,13 +167,17 @@
 %% @doc Log output directory
 -define(LOG_DIR, "logs").
 -define(BLOCK_DIR, "blocks").
--define(BLOCK_ENC_DIR, "blocks/enc").
+-define(ENCRYPTED_BLOCK_DIR, "blocks/enc").
 -define(TX_DIR, "txs").
 
 %% @doc Backup block hash list storage directory.
 -define(HASH_LIST_DIR, "hash_lists").
+%% @doc Directory for storing miner wallets.
+-define(WALLET_DIR, "wallets").
 %% @doc Directory for storing unique wallet lists.
 -define(WALLET_LIST_DIR, "wallet_lists").
+%% @doc Directory for storing transaction index.
+-define(TX_INDEX_DIR, "data/mnesia").
 
 %% @doc Port to use for cross-machine message transfer.
 -define(DEFAULT_HTTP_IFACE_PORT, 1984).

--- a/src/ar_block_index.erl
+++ b/src/ar_block_index.erl
@@ -78,7 +78,7 @@ get_block_filename(ID) ->
 %% @doc Return a list of block keys (hash and height) and their associated
 %% file names.
 blocks_on_disk() ->
-	BlocksDir = ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR,
+	BlocksDir = filename:join(ar_meta_db:get(data_dir), ?BLOCK_DIR),
 	filelib:fold_files(
 		BlocksDir,
 		"\.json$",

--- a/src/ar_block_index.erl
+++ b/src/ar_block_index.erl
@@ -78,12 +78,13 @@ get_block_filename(ID) ->
 %% @doc Return a list of block keys (hash and height) and their associated
 %% file names.
 blocks_on_disk() ->
+	BlocksDir = ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR,
 	filelib:fold_files(
-		"blocks",
+		BlocksDir,
 		"\.json$",
 		false,
 		fun(FN, Acc) ->
-			{ok, [Height, RawHash], ""} = io_lib:fread("blocks/~u_~64c.json", FN),
+			{ok, [Height, RawHash], ""} = io_lib:fread(BlocksDir ++ "/~u_~64c.json", FN),
 			[
 				{Height, ar_util:decode(RawHash), FN}
 			|

--- a/src/ar_block_index.erl
+++ b/src/ar_block_index.erl
@@ -13,7 +13,7 @@
 start() ->
 	% Spawn a new process to own the table.
 	Parent = self(),
-	PID = 
+	PID =
 		spawn(
 			fun() ->
 				ar:info([starting_block_index]),
@@ -41,7 +41,7 @@ stop(ETSOwner) ->
 
 %% @doc Add an index for a given block to the database.
 add(B, Filename) -> add(B#block.height, B#block.indep_hash, Filename).
-add(Height, Hash, Filename) ->
+add(Height, Hash, Filename) when is_list(Filename) ->
 	ets:insert(?MODULE, [{Height, Filename}, {Hash, Filename}]).
 
 %% @doc Remove a reference to a block when given its hash or height.

--- a/src/ar_cleanup.erl
+++ b/src/ar_cleanup.erl
@@ -21,8 +21,9 @@ all() ->
 
 %% @doc Remove all blocks from blocks directory not in HashList
 remove_invalid_blocks(HashList) ->
-	DataDir = ar_meta_db:get(data_dir) ++ "/",
-	{ok, RawFiles} = file:list_dir(DataDir ++ ?BLOCK_DIR),
+	DataDir = ar_meta_db:get(data_dir),
+	BlockDir = filename:join(DataDir, ?BLOCK_DIR),
+	{ok, RawFiles} = file:list_dir(BlockDir),
 	Files =
 		lists:filter(
 			fun(X) ->
@@ -32,7 +33,7 @@ remove_invalid_blocks(HashList) ->
 		),
 	lists:foreach(
 		fun(X) ->
-			file:delete(DataDir ++ ?BLOCK_DIR ++ X)
+			file:delete(filename:join(BlockDir, X))
 		end,
 		lists:filter(
 			fun(Y) ->
@@ -48,11 +49,12 @@ remove_invalid_blocks(HashList) ->
 			Files
 		)
 	),
-	case file:list_dir(DataDir ++ ?ENCRYPTED_BLOCK_DIR) of
+	EncryptedBlockDir = filename:join(DataDir, ?ENCRYPTED_BLOCK_DIR),
+	case file:list_dir(EncryptedBlockDir) of
 		{ok, FilesEnc} ->
 			lists:foreach(
 				fun(X) ->
-					file:delete(DataDir ++ ?ENCRYPTED_BLOCK_DIR ++ X)
+					file:delete(filename:join(EncryptedBlockDir, X))
 				end,
 				FilesEnc
 			);
@@ -90,5 +92,5 @@ remove_block_keep_directory_test() ->
 	B1 = ar_weave:add(B0, []),
 	ar_storage:write_block(hd(B1)),
 	remove_invalid_blocks([]),
-	{ok, Files} = (file:list_dir(ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR)),
+	{ok, Files} = file:list_dir(filename:join(ar_meta_db:get(data_dir), ?BLOCK_DIR)),
 	0 = length(lists:filter(fun filelib:is_file/1, Files -- [".gitignore"])).

--- a/src/ar_cleanup.erl
+++ b/src/ar_cleanup.erl
@@ -21,7 +21,8 @@ all() ->
 
 %% @doc Remove all blocks from blocks directory not in HashList
 remove_invalid_blocks(HashList) ->
-	{ok, RawFiles} = file:list_dir(?BLOCK_DIR),
+	DataDir = ar_meta_db:get(data_dir) ++ "/",
+	{ok, RawFiles} = file:list_dir(DataDir ++ ?BLOCK_DIR),
 	Files =
 		lists:filter(
 			fun(X) ->
@@ -31,7 +32,7 @@ remove_invalid_blocks(HashList) ->
 		),
 	lists:foreach(
 		fun(X) ->
-			file:delete(?BLOCK_DIR ++ X)
+			file:delete(DataDir ++ ?BLOCK_DIR ++ X)
 		end,
 		lists:filter(
 			fun(Y) ->
@@ -47,11 +48,11 @@ remove_invalid_blocks(HashList) ->
 			Files
 		)
 	),
-	case file:list_dir(?BLOCK_ENC_DIR) of
+	case file:list_dir(DataDir ++ ?ENCRYPTED_BLOCK_DIR) of
 		{ok, FilesEnc} ->
 			lists:foreach(
 				fun(X) ->
-					file:delete(?BLOCK_ENC_DIR ++ X)
+					file:delete(DataDir ++ ?ENCRYPTED_BLOCK_DIR ++ X)
 				end,
 				FilesEnc
 			);
@@ -89,5 +90,5 @@ remove_block_keep_directory_test() ->
 	B1 = ar_weave:add(B0, []),
 	ar_storage:write_block(hd(B1)),
 	remove_invalid_blocks([]),
-	{ok, Files} = (file:list_dir(?BLOCK_DIR)),
+	{ok, Files} = (file:list_dir(ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR)),
 	0 = length(lists:filter(fun filelib:is_file/1, Files -- [".gitignore"])).

--- a/src/ar_storage.erl
+++ b/src/ar_storage.erl
@@ -29,16 +29,16 @@ start() ->
 
 %% @doc Ensure that all of the relevant storage directories exist.
 ensure_directories() ->
-	filelib:ensure_dir(?TX_DIR),
-	filelib:ensure_dir(?BLOCK_DIR),
-	filelib:ensure_dir(?BLOCK_ENC_DIR),
-	filelib:ensure_dir(?WALLET_LIST_DIR),
-	filelib:ensure_dir(?HASH_LIST_DIR),
-	filelib:ensure_dir(?LOG_DIR).
+	DataDir = ar_meta_db:get(data_dir) ++ "/",
+	filelib:ensure_dir(DataDir ++ ?TX_DIR ++ "/"),
+	filelib:ensure_dir(DataDir ++ ?BLOCK_DIR ++ "/"),
+	filelib:ensure_dir(DataDir ++ ?ENCRYPTED_BLOCK_DIR ++ "/"),
+	filelib:ensure_dir(DataDir ++ ?WALLET_LIST_DIR ++ "/"),
+	filelib:ensure_dir(DataDir ++ ?HASH_LIST_DIR ++ "/").
 
 %% @doc Clear the cache of saved blocks.
 clear() ->
-	lists:map(fun file:delete/1, filelib:wildcard(?BLOCK_DIR ++ "/*.json")),
+	lists:map(fun file:delete/1, filelib:wildcard(ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR ++ "/*.json")),
 	ar_block_index:clear().
 
 %% @doc Removes a saved block.
@@ -59,11 +59,12 @@ block_exists(Hash) ->
 %% @doc Move a block into the 'invalid' block directory.
 invalidate_block(B) ->
 	ar_block_index:remove(B#block.indep_hash),
+	DataDir = ar_meta_db:get(data_dir) ++ "/",
 	TargetFile =
 		lists:flatten(
 			io_lib:format(
 				"~s/invalid/~w_~s.json",
-				[?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
+				[DataDir ++ ?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
 			)
 		),
 	filelib:ensure_dir(TargetFile),
@@ -71,7 +72,7 @@ invalidate_block(B) ->
 		lists:flatten(
 			io_lib:format(
 				"~s/~w_~s.json",
-				[?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
+				[DataDir ++ ?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
 			)
 		),
 		TargetFile
@@ -96,7 +97,7 @@ write_block(RawB) ->
 		Name = lists:flatten(
 			io_lib:format(
 				"~s/~w_~s.json",
-				[?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
+				[ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
 			)
 		),
 		BlockToWrite
@@ -121,7 +122,7 @@ write_block(RawB) ->
 				Name = lists:flatten(
 					io_lib:format(
 						"~s/~w_~s.json",
-						[?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
+						[ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
 					)
 				),
 				BlockToWrite
@@ -161,7 +162,7 @@ write_encrypted_block(Hash, B) ->
 		Name = lists:flatten(
 			io_lib:format(
 				"~s/~s_~s.json",
-				[?BLOCK_ENC_DIR, "encrypted" , ar_util:encode(Hash)]
+				[ar_meta_db:get(data_dir) ++ "/" ++ ?ENCRYPTED_BLOCK_DIR, "encrypted" , ar_util:encode(Hash)]
 			)
 		),
 		BlockToWrite
@@ -176,7 +177,7 @@ write_encrypted_block(Hash, B) ->
 				Name = lists:flatten(
 					io_lib:format(
 						"~s/~s_~s.json",
-						[?BLOCK_ENC_DIR, "encrypted" , ar_util:encode(Hash)]
+						[ar_meta_db:get(data_dir) ++ "/" ++ ?ENCRYPTED_BLOCK_DIR, "encrypted" , ar_util:encode(Hash)]
 					)
 				),
 				BlockToWrite
@@ -283,21 +284,21 @@ lookup_block_filename(ID) ->
 %% @doc Generate a wildcard search string for a block,
 %% given a block, binary hash, or list.
 name_block(Height) when is_integer(Height) ->
-	?BLOCK_DIR ++ "/" ++ integer_to_list(Height) ++ "_*.json";
+	ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR ++ "/" ++ integer_to_list(Height) ++ "_*.json";
 name_block(B) when is_record(B, block) ->
-	?BLOCK_DIR
+	ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR
 		++ "/"
 		++ integer_to_list(B#block.height)
 		++ "_"
 		++ binary_to_list(ar_util:encode(B#block.indep_hash))
 		++ ".json";
 name_block(BinHash) when is_binary(BinHash) ->
-	?BLOCK_DIR ++ "/*_" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
+	ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR ++ "/*_" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
 
 %% @doc Generate a wildcard search string for an encrypted block,
 %% given a block, binary hash, or list.
 name_enc_block(BinHash) when is_binary(BinHash) ->
-	?BLOCK_ENC_DIR ++ "/*_" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
+	ar_meta_db:get(data_dir) ++ "/" ++ ?ENCRYPTED_BLOCK_DIR ++ "/*_" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
 
 %% @doc Delete the tx with the given hash from disk.
 delete_tx(Hash) ->
@@ -305,7 +306,7 @@ delete_tx(Hash) ->
 
 %% @doc Returns the number of blocks stored on disk.
 txs_on_disk() ->
-	{ok, Files} = file:list_dir(?TX_DIR),
+	{ok, Files} = file:list_dir(ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR),
 	length(Files).
 
 %% @doc Returns whether the TX with the given hash is stored on disk.
@@ -325,7 +326,7 @@ write_tx(Tx) ->
 		Name = lists:flatten(
 			io_lib:format(
 				"~s/~s.json",
-				[?TX_DIR, ar_util:encode(Tx#tx.id)]
+				[ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR, ar_util:encode(Tx#tx.id)]
 			)
 		),
 		ar_serialize:jsonify(ar_serialize:tx_to_json_struct(Tx))
@@ -341,7 +342,7 @@ write_tx(Tx) ->
 				Name = lists:flatten(
 					io_lib:format(
 						"~s/~s.json",
-						[?TX_DIR, ar_util:encode(Tx#tx.id)]
+						[ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR, ar_util:encode(Tx#tx.id)]
 					)
 				),
 				ar_serialize:jsonify(ar_serialize:tx_to_json_struct(Tx))
@@ -394,7 +395,7 @@ write_block_hash_list(BinID, BHL) ->
 	ar:report([{writing_block_hash_list_to_disk, ID = ar_util:encode(BinID)}]),
 	JSON = ar_serialize:jsonify(ar_serialize:hash_list_to_json_struct(BHL)),
 	file:write_file(
-		?HASH_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinID)) ++ ".json",
+		ar_meta_db:get(data_dir) ++ "/" ++ ?HASH_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinID)) ++ ".json",
 		JSON
 	),
 	ID.
@@ -404,14 +405,14 @@ write_wallet_list(WalletList) ->
 	ID = ar_block:hash_wallet_list(WalletList),
 	JSON = ar_serialize:jsonify(ar_serialize:wallet_list_to_json_struct(WalletList)),
 	file:write_file(
-		?WALLET_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(ID)) ++ ".json",
+		ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(ID)) ++ ".json",
 		JSON
 	),
 	ID.
 
 %% @doc Read a list of block hashes from the disk.
 read_block_hash_list(BinID) ->
-	FileName = ?HASH_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinID)) ++ ".json",
+	FileName = ar_meta_db:get(data_dir) ++ "/" ++ ?HASH_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinID)) ++ ".json",
 	{ok, Binary} = file:read_file(FileName),
 	ar_serialize:json_struct_to_hash_list(ar_serialize:dejsonify(Binary)).
 
@@ -434,7 +435,7 @@ parse_wallet_list_json(JSON) ->
 	end.
 
 wallet_list_file(Hash) ->
-	?WALLET_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(Hash)) ++ ".json".
+	ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_LIST_DIR ++ "/" ++ binary_to_list(ar_util:encode(Hash)) ++ ".json".
 
 lookup_tx_filename(ID) ->
 	case filelib:wildcard(name_tx(ID)) of
@@ -454,12 +455,12 @@ lookup_tx_filename(ID) ->
 
 %% @doc Returns the file name for a TX with the given hash
 name_tx(Tx) when is_record(Tx, tx) ->
-	?TX_DIR
+	ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR
 		++ "/"
 		++ binary_to_list(ar_util:encode(Tx#tx.id))
 		++ ".json";
 name_tx(BinHash) when is_binary(BinHash) ->
-	?TX_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
+	ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR ++ "/" ++ binary_to_list(ar_util:encode(BinHash)) ++ ".json".
 
 % @doc Check that there is enough space to write Bytes bytes of data
 enough_space(Bytes) ->
@@ -584,7 +585,7 @@ invalidate_block_test() ->
 		lists:flatten(
 			io_lib:format(
 				"~s/invalid/~w_~s.json",
-				[?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
+				[ar_meta_db:get(data_dir) ++ "/" ++ ?BLOCK_DIR, B#block.height, ar_util:encode(B#block.indep_hash)]
 			)
 		),
 	?assert(B == do_read_block(TargetFile, B#block.hash_list)).

--- a/src/ar_storage.erl
+++ b/src/ar_storage.erl
@@ -476,26 +476,7 @@ store_and_retrieve_tx_test() ->
 	write_tx(Tx0),
 	Tx0 = read_tx(Tx0),
 	Tx0 = read_tx(Tx0#tx.id),
-	file:delete(name_tx(Tx0)).
-
-% store_and_retrieve_encrypted_block_test() ->
-%	  B0 = ar_weave:init([]),
-%	  ar_storage:write_block(B0),
-%	  B1 = ar_weave:add(B0, []),
-%	  CipherText = ar_block:encrypt_block(hd(B0), hd(B1)),
-%	  write_encrypted_block((hd(B0))#block.hash, CipherText),
-%	read_encrypted_block((hd(B0))#block.hash),
-%	Block0 = hd(B0),
-%	Block0 = ar_block:decrypt_full_block(hd(B1), CipherText, Key).
-
-% not_enough_space_test() ->
-%	Disk = ar_meta_db:get(disk_space),
-%	ar_meta_db:put(disk_space, 0),
-%	[B0] = ar_weave:init(),
-%	Tx0 = ar_tx:new(<<"DATA1">>),
-%	{error, enospc} = write_block(B0),
-%	{error, enospc} = write_tx(Tx0),
-%	ar_meta_db:put(disk_space, Disk).
+	file:delete(tx_filepath(Tx0)).
 
 %% @doc Ensure blocks can be written to disk, then moved into the 'invalid'
 %% block directory.

--- a/src/ar_tx_search.erl
+++ b/src/ar_tx_search.erl
@@ -133,8 +133,8 @@ server() ->
 
 %% @doc Initialise the mnesia database
 initDB() ->
-	DataDir = ar_meta_db:get(data_dir),
-	TXIndexDir = DataDir ++ "/" ++ ?TX_INDEX_DIR,
+	TXIndexDir = filename:join(ar_meta_db:get(data_dir), ?TX_INDEX_DIR),
+	%% Append the / to make filelib:ensure_dir/1 create a directory if one does not exist.
 	filelib:ensure_dir(TXIndexDir ++ "/"),
 	application:set_env(mnesia, dir, TXIndexDir),
 	mnesia:create_schema([node()]),

--- a/src/ar_tx_search.erl
+++ b/src/ar_tx_search.erl
@@ -133,7 +133,10 @@ server() ->
 
 %% @doc Initialise the mnesia database
 initDB() ->
-	application:set_env(mnesia, dir, "data/mnesia"),
+	DataDir = ar_meta_db:get(data_dir),
+	TXIndexDir = DataDir ++ "/" ++ ?TX_INDEX_DIR,
+	filelib:ensure_dir(TXIndexDir ++ "/"),
+	application:set_env(mnesia, dir, TXIndexDir),
 	mnesia:create_schema([node()]),
 	mnesia:start(),
 	try

--- a/src/ar_wallet.erl
+++ b/src/ar_wallet.erl
@@ -52,7 +52,7 @@ new_keyfile(WalletName) ->
 
 wallet_filename(WalletName, PubKey) ->
 	lists:flatten([
-		"wallets/arweave_keyfile_",
+		ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_DIR ++ "/arweave_keyfile_",
 		binary_to_list(wallet_name(WalletName, PubKey)),
 		".json"
 	]).
@@ -136,7 +136,7 @@ address_double_encode_test() ->
 %%doc Check generated keyfiles can be retrieved
 generate_keyfile_test() ->
 	{Priv, Pub} = new_keyfile(),
-	FileName = "wallets/arweave_keyfile_" ++ binary_to_list(ar_util:encode(to_address(Pub))) ++ ".json",
+	FileName = ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_DIR ++ "/arweave_keyfile_" ++ binary_to_list(ar_util:encode(to_address(Pub))) ++ ".json",
 	{Priv, Pub} = load_keyfile(FileName).
 
 %% @doc Check keyfile generation

--- a/src/ar_wallet.erl
+++ b/src/ar_wallet.erl
@@ -45,17 +45,17 @@ new_keyfile(WalletName) ->
 				]
 			}
 		),
-	Filename = wallet_filename(WalletName, Pub),
+	Filename = wallet_filepath(WalletName, Pub),
 	filelib:ensure_dir(Filename),
 	file:write_file(Filename, Key),
 	{{Priv, Pub}, Pub}.
 
-wallet_filename(WalletName, PubKey) ->
-	lists:flatten([
-		ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_DIR ++ "/arweave_keyfile_",
-		binary_to_list(wallet_name(WalletName, PubKey)),
-		".json"
-	]).
+wallet_filepath(WalletName, PubKey) ->
+	wallet_filepath(wallet_name(WalletName, PubKey)).
+
+wallet_filepath(Wallet) ->
+	Filename = lists:flatten(["arweave_keyfile_", binary_to_list(Wallet), ".json"]),
+	filename:join([ar_meta_db:get(data_dir), ?WALLET_DIR, Filename]).
 
 wallet_name(wallet_address, PubKey) ->
 	ar_util:encode(to_address(PubKey));
@@ -136,7 +136,7 @@ address_double_encode_test() ->
 %%doc Check generated keyfiles can be retrieved
 generate_keyfile_test() ->
 	{Priv, Pub} = new_keyfile(),
-	FileName = ar_meta_db:get(data_dir) ++ "/" ++ ?WALLET_DIR ++ "/arweave_keyfile_" ++ binary_to_list(ar_util:encode(to_address(Pub))) ++ ".json",
+	FileName = wallet_filepath(ar_util:encode(to_address(Pub))),
 	{Priv, Pub} = load_keyfile(FileName).
 
 %% @doc Check keyfile generation

--- a/src/ar_weave.erl
+++ b/src/ar_weave.erl
@@ -345,7 +345,7 @@ read_genesis_txs() ->
 	{ok, Files} = file:list_dir("data/genesis_txs"),
 	lists:foldl(
 		fun(F, Acc) ->
-			file:copy("data/genesis_txs/" ++ F, "txs/" ++ F),
+			file:copy("data/genesis_txs/" ++ F, ar_meta_db:get(data_dir) ++ "/" ++ ?TX_DIR ++ "/" ++ F),
 			[ar_util:decode(hd(string:split(F, ".")))|Acc]
 		end,
 		[],


### PR DESCRIPTION
The motivation is to be able to run multiple independent miners from the same folder for testing purposes. As a bonus, the feature simplifies the task of copying data between machines (a common miners need).