### PR TITLE
Update outdated fn call

### DIFF
--- a/src/ar_join.erl
+++ b/src/ar_join.erl
@@ -100,7 +100,7 @@ verify_time_sync(Peers) ->
 					{error, Err} ->
 						ar:info(
 							"Failed to get time from peer ~s: ~p.",
-							[ar_util:format(Peer), Err]
+							[ar_util:format_peer(Peer), Err]
 						),
 						true
 				end


### PR DESCRIPTION
ar_util:format has been changed and renamed into ar_util:format_peer recently but one of the calllers was not updated.