### PR TITLE
Ensure previous block exists in polling mode

### DIFF
--- a/src/ar_poller.erl
+++ b/src/ar_poller.erl
@@ -54,10 +54,17 @@ get_remote_block_pair(Peer, BHL) ->
 	end.
 
 get_remote_block_pair(Peer, BHL, B) ->
-	PreviousRecallBH = ar_util:get_recall_hash(B#block.previous_block, BHL),
-	case get_block(PreviousRecallBH, BHL, Peer) of
-		{ok, PreviouRecallB} -> {B, PreviouRecallB};
-		unavailable -> unavailable
+	%% Fetch the previous block, since that's required before calling
+	%% ar_util:get_recall_hash/2
+	case get_block(B#block.previous_block, BHL, Peer) of
+		{ok, _} ->
+			PreviousRecallBH = ar_util:get_recall_hash(B#block.previous_block, BHL),
+			case get_block(PreviousRecallBH, BHL, Peer) of
+				{ok, PreviouRecallB} -> {B, PreviouRecallB};
+				unavailable -> unavailable
+			end;
+		unavailable ->
+			unavailable
 	end.
 
 get_block(BH, BHL, Peer) ->

--- a/src/ar_util.erl
+++ b/src/ar_util.erl
@@ -86,12 +86,14 @@ get_head_block(not_joined) -> unavailable;
 get_head_block(BHL = [IndepHash|_]) ->
 	ar_storage:read_block(IndepHash, BHL).
 
-%% @doc find the hash of a recall block.
-get_recall_hash(B, HashList) ->
+%% @doc find the hash of a recall block. If BlockOrHash is a hash, its block
+%% must be on disk already. TODO: Get rid of this requirement.
+get_recall_hash(BlockOrHash, HashList) ->
 	lists:nth(
-        1 + ar_weave:calculate_recall_block(B, HashList),
+        1 + ar_weave:calculate_recall_block(BlockOrHash, HashList),
         lists:reverse(HashList)
     ).
+
 get_recall_hash(_Height, Hash, []) -> Hash;
 get_recall_hash(0, Hash, _HastList) -> Hash;
 get_recall_hash(Height, Hash, HashList) ->


### PR DESCRIPTION
The polling server fails when fetching a {block, recall block} pair if the previous block is not on disk. There are multiple ways to reproduce the issue. Commonly it happens on startup, when the network join is slow (the poller does not wait for the joining).