### PR TITLE
Serve transactions on isolated origins

### DIFF
--- a/src/ar.erl
+++ b/src/ar.erl
@@ -112,7 +112,7 @@ main("") ->
 		end,
 		[
 			{"peer (ip:port)", "Join a network on a peer (or set of peers)."},
-			{"start_hash_list (file)", "Start the node from a given block."},
+			{"start_hash_list (hash)", "Start the node from a given block."},
 			{"mine", "Automatically start mining once the netwok has been joined."},
 			{"port", "The local port to use for mining. "
 						"This port must be accessible by remote peers."},
@@ -183,8 +183,8 @@ parse(["disk_space", Size|Rest], O) ->
 	parse(Rest, O#opts { disk_space = (list_to_integer(Size)*1024*1024*1024) });
 parse(["load_mining_key", File|Rest], O)->
 	parse(Rest, O#opts { load_key = File });
-parse(["start_hash_list", IndepHash|Rest], O)->
-	parse(Rest, O#opts { start_hash_list = ar_util:decode(IndepHash) });
+parse(["start_hash_list", BHLHash|Rest], O)->
+	parse(Rest, O#opts { start_hash_list = ar_util:decode(BHLHash) });
 parse(["benchmark"|Rest], O)->
 	parse(Rest, O#opts { benchmark = true });
 parse(["auto_update", "false" | Rest], O) ->
@@ -332,7 +332,8 @@ start(
 						if Init -> ar_weave:init(ar_util:genesis_wallets(), Diff);
 						true -> not_joined
 						end;
-					_ -> ar_storage:read_hash_list(ar_util:decode(BHL))
+					_ ->
+						ar_storage:read_block_hash_list(BHL)
 				end,
 				0,
 				MiningAddress,

--- a/src/ar.erl
+++ b/src/ar.erl
@@ -400,13 +400,11 @@ start(
 		]
 	),
 	%% Start the first node in the gossip network (with HTTP interface).
-	ar_http_iface_server:start(
-		Port,
-		Node,
-		SearchNode,
-		undefined,
-		Bridge
-	),
+	ar_http_iface_server:start(Port, [
+		{http_entrypoint_node, Node},
+		{http_search_node, SearchNode},
+		{http_bridge_node, Bridge}
+	]),
 	case Polling of
 		true ->
 			ar_meta_db:put(polling_mode, true),

--- a/src/ar_base32.erl
+++ b/src/ar_base32.erl
@@ -1,0 +1,69 @@
+%% @doc This module is very strongly inspired by OTP's base64 source code.
+%% See https://github.com/erlang/otp/blob/93ec8bb2dbba9456395a54551fe9f1e0f86184b1/lib/stdlib/src/base64.erl#L66-L80
+-module(ar_base32).
+
+-export([encode/1]).
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+%% @doc Encode data into a lowercase unpadded RFC 4648 base32 alphabet
+encode(Bin) when is_binary(Bin) ->
+	encode_binary(Bin, <<>>).
+
+%%%===================================================================
+%%% Private functions.
+%%%===================================================================
+
+encode_binary(<<>>, A) ->
+	A;
+encode_binary(<<B1:8>>, A) ->
+	<<A/bits, (b32e(B1 bsr 3)):8, (b32e((B1 band 7) bsl 2)):8>>;
+encode_binary(<<B1:8, B2:8>>, A) ->
+	BB = (B1 bsl 8) bor B2,
+	<<A/bits,
+		(b32e(BB bsr 11)):8,
+		(b32e((BB bsr 6) band 31)):8,
+		(b32e((BB bsr 1) band 31)):8,
+		(b32e((BB bsl 4) band 31)):8>>;
+encode_binary(<<B1:8, B2:8, B3:8>>, A) ->
+	BB = (B1 bsl 16) bor (B2 bsl 8) bor B3,
+	<<A/bits,
+		(b32e(BB bsr 19)):8,
+		(b32e((BB bsr 14) band 31)):8,
+		(b32e((BB bsr 9) band 31)):8,
+		(b32e((BB bsr 4) band 31)):8,
+		(b32e((BB bsl 1) band 31)):8>>;
+encode_binary(<<B1:8, B2:8, B3:8, B4:8>>, A) ->
+	BB = (B1 bsl 24) bor (B2 bsl 16) bor (B3 bsl 8) bor B4,
+	<<A/bits,
+		(b32e(BB bsr 27)):8,
+		(b32e((BB bsr 22) band 31)):8,
+		(b32e((BB bsr 17) band 31)):8,
+		(b32e((BB bsr 12) band 31)):8,
+		(b32e((BB bsr 7) band 31)):8,
+		(b32e((BB bsr 2) band 31)):8,
+		(b32e((BB bsl 3) band 31)):8>>;
+encode_binary(<<B1:8, B2:8, B3:8, B4:8, B5:8, Ls/bits>>, A) ->
+	BB = (B1 bsl 32) bor (B2 bsl 24) bor (B3 bsl 16) bor (B4 bsl 8) bor B5,
+	encode_binary(
+		Ls,
+		<<A/bits,
+			(b32e(BB bsr 35)):8,
+			(b32e((BB bsr 30) band 31)):8,
+			(b32e((BB bsr 25) band 31)):8,
+			(b32e((BB bsr 20) band 31)):8,
+			(b32e((BB bsr 15) band 31)):8,
+			(b32e((BB bsr 10) band 31)):8,
+			(b32e((BB bsr 5) band 31)):8,
+			(b32e(BB band 31)):8>>
+	).
+
+-compile({inline, [{b32e, 1}]}).
+b32e(X) ->
+	element(X+1, {
+		$a, $b, $c, $d, $e, $f, $g, $h, $i, $j, $k, $l, $m,
+		$n, $o, $p, $q, $r, $s, $t, $u, $v, $w, $x, $y, $z,
+		$2, $3, $4, $5, $6, $7, $8, $9
+	}).

--- a/src/ar_domain.erl
+++ b/src/ar_domain.erl
@@ -1,0 +1,44 @@
+-module(ar_domain).
+
+-export([get_labeling/3, lookup_arweave_txt_record/1, derive_tx_label/2]).
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+get_labeling(ApexDomain, CustomDomains, Hostname) ->
+	Size = byte_size(ApexDomain),
+	case binary:match(Hostname, ApexDomain) of
+		{0, Size} ->
+			apex;
+		{N, Size} ->
+			Label = binary:part(Hostname, {0, N-1}),
+			{labeled, Label};
+		nomatch ->
+			get_labeling_1(CustomDomains, Hostname)
+	end.
+
+lookup_arweave_txt_record(Domain) ->
+	case inet_res:lookup("_arweave." ++ binary_to_list(Domain), in, txt) of
+		[] ->
+			not_found;
+		[RecordChunks|_] ->
+			list_to_binary(lists:concat(RecordChunks))
+	end.
+
+derive_tx_label(TXID, BH) ->
+	Data = <<TXID/binary, BH/binary>>,
+	Digest = crypto:hash(sha256, Data),
+	binary:part(ar_base32:encode(Digest), {0, 12}).
+
+%%%===================================================================
+%%% Private functions.
+%%%===================================================================
+
+get_labeling_1(CustomDomains, Hostname) ->
+	case lists:member(Hostname, CustomDomains) of
+		true ->
+			{custom, Hostname};
+		false ->
+			unknown
+	end.

--- a/src/ar_gateway_h.erl
+++ b/src/ar_gateway_h.erl
@@ -1,0 +1,208 @@
+-module(ar_gateway_h).
+-behaviour(cowboy_handler).
+-export([init/2]).
+
+-include("ar.hrl").
+-define(BH_SEARCH_TIMEOUT, 25000).
+
+%%%===================================================================
+%%% Cowboy handler callback.
+%%%===================================================================
+
+%% @doc Handle gateway requests.
+%%
+%% When gateway mode is turned on, a domain name needs to be provided
+%% to act as the main domain name for this gateway. This domain name
+%% is referred to as the apex domain for this gateway. A number of
+%% custom domains that will map to specific transactions can also be
+%% provided.
+%%
+%% The main purpose of a gateway is to serve different transaction on
+%% different origins. This is done by deriving what will be referred
+%% to as a transaction label from the transaction's ID and its block's
+%% hash and prefixing that label to the apex domain of the gateway.
+%% For example:
+%%
+%%     Accessing    https://gateway.example/{txid}
+%%     redirects to https://{txlabel}.gateway.example/{txid}
+%%     where it then serves the transaction's content.
+%%
+%% A gateway also allows to configure custom domains which will
+%% redirect to specific transactions. For example, if
+%% custom.domain.example is defined as a custom domain:
+%%
+%%     Accessing https://custom.domain.example
+%%     triggers a TXT record lookup at _arweave.custom.domain.example
+%%     where a transaction ID is expected to be found.
+%%
+%% This transaction ID is then used to decide from which transaction
+%% to serve the content for this custom domain.
+%%
+%% The gateway also allows using relative links whether accessing a
+%% transaction's content through a labeled domain name or through a
+%% custom domain name. For example:
+%%
+%%     Accessing    https://{tx1label}.gateway.example/{tx2id}
+%%     redirects to https://{tx2label}.gateway.example/{tx2id}
+%%     where tx2's content is then served, and
+%%
+%%     Accessing    https://custom.domain.example/{txid}
+%%     redirects to https://{txlabel}.gateway.example/{txid}
+%%     where tx's content is then served.
+%%
+%% This allows webpages stored in transactions to link to each other
+%% without having to refer to any specific gateway. That is to say, to
+%% link to a different transaction in HTML, one would use
+%%
+%%     <a href="{txid}">Link</a>
+%%
+%% rather than
+%%
+%%     <a href="https://{txlabel}.gateway.example/{txid}">Link</a>
+init(Req, {Domain, CustomDomains} = State) ->
+	Hostname = cowboy_req:host(Req),
+	Req1 =
+		case ar_domain:get_labeling(Domain, CustomDomains, Hostname) of
+			apex -> handle_apex_request(Domain, Req);
+			{labeled, Label} -> handle_labeled_request(Domain, Label, Req);
+			{custom, CustomDomain} -> handle_custom_request(Domain, CustomDomain, Req);
+			unknown -> not_found(Req)
+		end,
+	{ok, Req1, State}.
+
+%%%===================================================================
+%%% Private functions.
+%%%===================================================================
+
+handle_apex_request(Domain, Req) ->
+	case resolve_path(cowboy_req:path(Req)) of
+		{tx, TXID, _} -> derive_label_and_redirect(Domain, TXID, Req);
+		root -> bad_request(Req);
+		invalid -> bad_request(Req);
+		not_found -> not_found(Req)
+	end.
+
+handle_labeled_request(Domain, Label, Req) ->
+	case resolve_path(cowboy_req:path(Req)) of
+		{tx, TXID, Filename} ->
+			handle_labeled_request_1(Domain, Label, TXID, Filename, Req);
+		root ->
+			bad_request(Req);
+		invalid ->
+			bad_request(Req);
+		not_found ->
+			not_found(Req)
+	end.
+
+handle_labeled_request_1(Domain, Label, TXID, Filename, Req) ->
+	case get_tx_block_hash(TXID) of
+		{ok, BH} ->
+			handle_labeled_request_2(Domain, Label, TXID, Filename, BH, Req);
+		not_found ->
+			not_found(Req)
+	end.
+
+handle_labeled_request_2(Domain, Label, TXID, Filename, BH, Req) ->
+	case ar_domain:derive_tx_label(TXID, BH) of
+		Label -> serve_tx(Filename, Req);
+		OtherLabel -> redirect_to_labeled_tx(Domain, OtherLabel, TXID, Req)
+	end.
+
+handle_custom_request(Domain, CustomDomain, Req) ->
+	case resolve_path(cowboy_req:path(Req)) of
+		root -> handle_custom_request_1(CustomDomain, Req);
+		{tx, TXID, _} -> derive_label_and_redirect(Domain, TXID, Req);
+		invalid -> bad_request(Req)
+	end.
+
+resolve_path(Path) ->
+	case Path of
+		<<"/">> -> root;
+		<<"/", Hash/binary>> -> resolve_path_1(Hash);
+		_ -> invalid
+	end.
+
+resolve_path_1(Hash) ->
+	case get_tx_from_hash(Hash) of
+		{ok, TXID, Filename} -> {tx, TXID, Filename};
+		invalid -> invalid;
+		not_found -> not_found
+	end.
+
+derive_label_and_redirect(Domain, TXID, Req) ->
+	case get_tx_block_hash(TXID) of
+		{ok, BH} -> derive_label_and_redirect_1(Domain, TXID, BH, Req);
+		not_found -> not_found(Req)
+	end.
+
+get_tx_block_hash(TXID) ->
+	HttpSearchNode = whereis(http_search_node),
+	case ar_tx_search:get_tags_by_id(HttpSearchNode, TXID, ?BH_SEARCH_TIMEOUT) of
+		{ok, PseudoTags} -> get_tx_block_hash_1(PseudoTags);
+		{error, _} -> not_found
+	end.
+
+get_tx_block_hash_1(PseudoTags) ->
+	case proplists:get_value(<<"block_indep_hash">>, PseudoTags) of
+		undefined -> not_found;
+		BH -> {ok, BH}
+	end.
+
+derive_label_and_redirect_1(Domain, TXID, BH, Req) ->
+	Label = ar_domain:derive_tx_label(TXID, BH),
+	redirect_to_labeled_tx(Domain, Label, TXID, Req).
+
+redirect_to_labeled_tx(Domain, Label, TXID, Req) ->
+	Scheme = cowboy_req:scheme(Req),
+	Port = integer_to_binary(cowboy_req:port(Req)),
+	Hash = ar_util:encode(TXID),
+	Location = <<
+		Scheme/binary, "://",
+		Label/binary, ".",
+		Domain/binary, ":",
+		Port/binary, "/",
+		Hash/binary
+	>>,
+	cowboy_req:reply(301, #{<<"location">> => Location}, Req).
+
+bad_request(Req) ->
+	cowboy_req:reply(400, Req).
+
+not_found(Req) ->
+	cowboy_req:reply(404, Req).
+
+handle_custom_request_1(CustomDomain, Req) ->
+	case ar_domain:lookup_arweave_txt_record(CustomDomain) of
+		not_found ->
+			domain_improperly_configured(Req);
+		TxtRecord ->
+			handle_custom_request_2(TxtRecord, Req)
+	end.
+
+handle_custom_request_2(TxtRecord, Req) ->
+	case get_tx_from_hash(TxtRecord) of
+		{ok, _, Filename} -> serve_tx(Filename, Req);
+		invalid -> domain_improperly_configured(Req);
+		not_found -> domain_improperly_configured(Req)
+	end.
+
+get_tx_from_hash(Hash) ->
+	case ar_util:safe_decode(Hash) of
+		{ok, TXID} -> get_tx_from_hash_1(TXID);
+		{error, _} -> invalid
+	end.
+
+get_tx_from_hash_1(TXID) ->
+	case ar_storage:lookup_tx_filename(TXID) of
+		unavailable -> not_found;
+		Filename -> {ok, TXID, Filename}
+	end.
+
+serve_tx(Filename, Req) ->
+	TX = ar_storage:read_tx_file(Filename),
+	ContentType = proplists:get_value(<<"Content-Type">>, TX#tx.tags, "text/html"),
+	Headers = #{<<"content-type">> => ContentType},
+	cowboy_req:reply(200, Headers, TX#tx.data, Req).
+
+domain_improperly_configured(Req) ->
+	cowboy_req:reply(502, #{}, <<"Domain improperly configured">>, Req).

--- a/src/ar_gateway_server.erl
+++ b/src/ar_gateway_server.erl
@@ -1,0 +1,36 @@
+-module(ar_gateway_server).
+-export([start/3]).
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+%% @doc Start the server that will handle gateway requests.
+start(Port, Domain, CustomDomains) ->
+	ProtocolOpts = #{
+		middlewares => [cowboy_handler],
+		env => #{
+			handler => ar_gateway_h,
+			handler_opts => {Domain, CustomDomains}
+		}
+	},
+	SniHosts = derive_sni_hosts(CustomDomains),
+	{ok, _} = cowboy:start_tls(ar_gateway_listener, [
+		{port, Port},
+		{certfile, "priv/tls/cert.pem"},
+		{keyfile, "priv/tls/key.pem"},
+		{sni_hosts, SniHosts}
+	], ProtocolOpts).
+
+%%%===================================================================
+%%% Private functions.
+%%%===================================================================
+
+derive_sni_hosts(Domains) ->
+	lists:map(fun(Domain) ->
+		SDomain = binary_to_list(Domain),
+		{SDomain, [
+			{certfile, "priv/tls/" ++ SDomain ++ "/cert.pem"},
+			{keyfile, "priv/tls/" ++ SDomain ++ "/key.pem"}
+		]}
+	end, Domains).

--- a/src/ar_http_iface_cowboy_handler.erl
+++ b/src/ar_http_iface_cowboy_handler.erl
@@ -8,7 +8,7 @@
 %%%===================================================================
 
 init(InitialReq, State) ->
-	{Status, Headers, Body, HandledReq} = do_handle(InitialReq),
+	{Status, Headers, Body, HandledReq} = handle(InitialReq),
 	CowboyStatus = handle208(Status),
 	RepliedReq = cowboy_req:reply(CowboyStatus, Headers, Body, HandledReq),
 	{ok, RepliedReq, State}.
@@ -17,13 +17,13 @@ init(InitialReq, State) ->
 %%% Private functions.
 %%%===================================================================
 
-do_handle(Req) ->
+handle(Req) ->
 	%% Inform ar_bridge about new peer, performance rec will be updated from cowboy_metrics_h
 	%% (this is leftover from update_performance_list)
 	Peer = arweave_peer(Req),
-	do_handle(Req, Peer).
+	handle(Req, Peer).
 
-do_handle(Req, Peer) ->
+handle(Req, Peer) ->
 	Method = cowboy_req:method(Req),
 	SplitPath = split_path(cowboy_req:path(Req)),
 	case ar_meta_db:get(http_logging) of
@@ -45,7 +45,7 @@ do_handle(Req, Peer) ->
 		_ ->
 			do_nothing
 	end,
-	case do_handle(Method, SplitPath, Req) of
+	case handle(Method, SplitPath, Req) of
 		{Status, Hdrs, Body, HandledReq} ->
 			{Status, maps:merge(?DEFAULT_RESPONSE_HEADERS, Hdrs), Body, HandledReq};
 		{Status, Body, HandledReq} ->
@@ -54,41 +54,41 @@ do_handle(Req, Peer) ->
 
 %% @doc Return network information from a given node.
 %% GET request to endpoint /info
-do_handle(<<"GET">>, [], Req) ->
+handle(<<"GET">>, [], Req) ->
 	return_info(Req);
-do_handle(<<"GET">>, [<<"info">>], Req) ->
+handle(<<"GET">>, [<<"info">>], Req) ->
 	return_info(Req);
 
 %% @doc Some load balancers use 'HEAD's rather than 'GET's to tell if a node
 %% is alive. Appease them.
-do_handle(<<"HEAD">>, [], Req) ->
+handle(<<"HEAD">>, [], Req) ->
 	{200, #{}, <<>>, Req};
-do_handle(<<"HEAD">>, [<<"info">>], Req) ->
+handle(<<"HEAD">>, [<<"info">>], Req) ->
 	{200, #{}, <<>>, Req};
 
 %% @doc Return permissive CORS headers for all endpoints
-do_handle(<<"OPTIONS">>, [<<"block">>], Req) ->
+handle(<<"OPTIONS">>, [<<"block">>], Req) ->
 	{200, #{<<"access-control-allow-methods">> => <<"GET, POST">>,
 		    <<"access-control-allow-headers">> => <<"Content-Type">>}, <<"OK">>, Req};
-do_handle(<<"OPTIONS">>, [<<"tx">>], Req) ->
+handle(<<"OPTIONS">>, [<<"tx">>], Req) ->
 	{200, #{<<"access-control-allow-methods">> => <<"GET, POST">>,
 		    <<"access-control-allow-headers">> => <<"Content-Type">>}, <<"OK">>, Req};
-do_handle(<<"OPTIONS">>, [<<"peer">>|_], Req) ->
+handle(<<"OPTIONS">>, [<<"peer">>|_], Req) ->
 	{200, #{<<"access-control-allow-methods">> => <<"GET, POST">>,
 		    <<"access-control-allow-headers">> => <<"Content-Type">>}, <<"OK">>, Req};
-do_handle(<<"OPTIONS">>, [<<"arql">>], Req) ->
+handle(<<"OPTIONS">>, [<<"arql">>], Req) ->
 	{200, #{<<"access-control-allow-methods">> => <<"GET, POST">>,
 		    <<"access-control-allow-headers">> => <<"Content-Type">>}, <<"OK">>, Req};
-do_handle(<<"OPTIONS">>, _, Req) ->
+handle(<<"OPTIONS">>, _, Req) ->
 	{200, #{<<"access-control-allow-methods">> => <<"GET">>}, <<"OK">>, Req};
 
 %% @doc Return the current universal time in seconds.
-do_handle(<<"GET">>, [<<"time">>], Req) ->
+handle(<<"GET">>, [<<"time">>], Req) ->
 	{200, #{}, integer_to_binary(os:system_time(second)), Req};
 
 %% @doc Return all transactions from node that are waiting to be mined into a block.
 %% GET request to endpoint /tx/pending
-do_handle(<<"GET">>, [<<"tx">>, <<"pending">>], Req) ->
+handle(<<"GET">>, [<<"tx">>, <<"pending">>], Req) ->
 	{200, #{},
 			ar_serialize:jsonify(
 				%% Should encode
@@ -101,7 +101,7 @@ do_handle(<<"GET">>, [<<"tx">>, <<"pending">>], Req) ->
 
 %% @doc Return additional information about the transaction with the given identifier (hash).
 %% GET request to endpoint /tx/{hash}.
-do_handle(<<"GET">>, [<<"tx">>, Hash, <<"status">>], Req) ->
+handle(<<"GET">>, [<<"tx">>, Hash, <<"status">>], Req) ->
 	case get_tx_filename(Hash) of
 		{ok, _} ->
 			TagsToInclude = [
@@ -142,7 +142,7 @@ do_handle(<<"GET">>, [<<"tx">>, Hash, <<"status">>], Req) ->
 
 % @doc Return a transaction specified via the the transaction id (hash)
 %% GET request to endpoint /tx/{hash}
-do_handle(<<"GET">>, [<<"tx">>, Hash], Req) ->
+handle(<<"GET">>, [<<"tx">>, Hash], Req) ->
 	case get_tx_filename(Hash) of
 		{ok, Filename} ->
 			{200, #{}, sendfile(Filename), Req};
@@ -160,7 +160,7 @@ do_handle(<<"GET">>, [<<"tx">>, Hash], Req) ->
 %%		expr2:	{ string | logical expression }
 %%	}
 %%
-do_handle(<<"POST">>, [<<"arql">>], Req) ->
+handle(<<"POST">>, [<<"arql">>], Req) ->
 	case read_complete_body(Req) of
 		{ok, QueryJson, ReadReq} ->
 			Query = ar_serialize:json_struct_to_query(
@@ -185,7 +185,7 @@ do_handle(<<"POST">>, [<<"arql">>], Req) ->
 
 %% @doc Return the data field of the transaction specified via the transaction ID (hash) served as HTML.
 %% GET request to endpoint /tx/{hash}/data.html
-do_handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req) ->
+handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req) ->
 	case hash_to_filename(tx, Hash) of
 		{error, invalid} ->
 			{400, #{}, <<"Invalid hash.">>, Req};
@@ -208,13 +208,13 @@ do_handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req) ->
 %% @doc Share a new block to a peer.
 %% POST request to endpoint /block with the body of the request being a JSON encoded block
 %% as specified in ar_serialize.
-do_handle(<<"POST">>, [<<"block">>], Req) ->
+handle(<<"POST">>, [<<"block">>], Req) ->
 	post_block(request, Req);
 
 %% @doc Generate a wallet and receive a secret key identifying it.
 %% Requires internal_api_secret startup option to be set.
 %% WARNING: only use it if you really really know what you are doing.
-do_handle(<<"POST">>, [<<"wallet">>], Req) ->
+handle(<<"POST">>, [<<"wallet">>], Req) ->
 	case check_internal_api_secret(Req) of
 		pass ->
 			WalletAccessCode = ar_util:encode(crypto:strong_rand_bytes(32)),
@@ -231,7 +231,7 @@ do_handle(<<"POST">>, [<<"wallet">>], Req) ->
 %% @doc Share a new transaction with a peer.
 %% POST request to endpoint /tx with the body of the request being a JSON encoded tx as
 %% specified in ar_serialize.
-do_handle(<<"POST">>, [<<"tx">>], Req) ->
+handle(<<"POST">>, [<<"tx">>], Req) ->
 	case read_complete_body(Req) of
 		{ok, TXJSON, ReadReq} ->
 			TX = ar_serialize:json_struct_to_tx(TXJSON),
@@ -249,7 +249,7 @@ do_handle(<<"POST">>, [<<"tx">>], Req) ->
 %% Fetches the wallet by the provided key generated via POST /wallet.
 %% Requires internal_api_secret startup option to be set.
 %% WARNING: only use it if you really really know what you are doing.
-do_handle(<<"POST">>, [<<"unsigned_tx">>], Req) ->
+handle(<<"POST">>, [<<"unsigned_tx">>], Req) ->
 	case check_internal_api_secret(Req) of
 		pass ->
 			case read_complete_body(Req) of
@@ -285,7 +285,7 @@ do_handle(<<"POST">>, [<<"unsigned_tx">>], Req) ->
 
 %% @doc Return the list of peers held by the node.
 %% GET request to endpoint /peers
-do_handle(<<"GET">>, [<<"peers">>], Req) ->
+handle(<<"GET">>, [<<"peers">>], Req) ->
 	{200, #{},
 		ar_serialize:jsonify(
 			[
@@ -300,7 +300,7 @@ do_handle(<<"GET">>, [<<"peers">>], Req) ->
 %% @doc Return the estimated reward cost of transactions with a data body size of 'bytes'.
 %% GET request to endpoint /price/{bytes}
 %% TODO: Change so current block does not need to be pulled to calculate cost
-do_handle(<<"GET">>, [<<"price">>, SizeInBytes], Req) ->
+handle(<<"GET">>, [<<"price">>, SizeInBytes], Req) ->
 	{200, #{},
 		integer_to_binary(
 			ar_tx:calculate_min_tx_cost(
@@ -313,7 +313,7 @@ do_handle(<<"GET">>, [<<"price">>, SizeInBytes], Req) ->
 %% @doc Return the estimated reward cost of transactions with a data body size of 'bytes'.
 %% GET request to endpoint /price/{bytes}/{address}
 %% TODO: Change so current block does not need to be pulled to calculate cost
-do_handle(<<"GET">>, [<<"price">>, SizeInBytes, Addr], Req) ->
+handle(<<"GET">>, [<<"price">>, SizeInBytes, Addr], Req) ->
 	case safe_decode(Addr) of
 		{error, invalid} ->
 			{400, #{}, <<"Invalid address.">>, Req};
@@ -332,7 +332,7 @@ do_handle(<<"GET">>, [<<"price">>, SizeInBytes, Addr], Req) ->
 
 %% @doc Return the current hash list held by the node.
 %% GET request to endpoint /hash_list
-do_handle(<<"GET">>, [<<"hash_list">>], Req) ->
+handle(<<"GET">>, [<<"hash_list">>], Req) ->
 	HashList = ar_node:get_hash_list(whereis(http_entrypoint_node)),
 	{200, #{},
 		ar_serialize:jsonify(
@@ -342,7 +342,7 @@ do_handle(<<"GET">>, [<<"hash_list">>], Req) ->
 
 %% @doc Return the current wallet list held by the node.
 %% GET request to endpoint /wallet_list
-do_handle(<<"GET">>, [<<"wallet_list">>], Req) ->
+handle(<<"GET">>, [<<"wallet_list">>], Req) ->
 	Node = whereis(http_entrypoint_node),
 	WalletList = ar_node:get_wallet_list(Node),
 	{200, #{},
@@ -355,7 +355,7 @@ do_handle(<<"GET">>, [<<"wallet_list">>], Req) ->
 %% POST request to endpoint /peers with the body of the request being your
 %% nodes network information JSON encoded as specified in ar_serialize.
 % NOTE: Consider returning remaining timeout on a failed request
-do_handle(<<"POST">>, [<<"peers">>], Req) ->
+handle(<<"POST">>, [<<"peers">>], Req) ->
 	case read_complete_body(Req) of
 		{ok, BlockJSON, ReadReq} ->
 			case ar_serialize:dejsonify(BlockJSON) of
@@ -380,7 +380,7 @@ do_handle(<<"POST">>, [<<"peers">>], Req) ->
 	end;
 %% @doc Return the balance of the wallet specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/balance
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"balance">>], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"balance">>], Req) ->
 	case safe_decode(Addr) of
 		{error, invalid} ->
 			{400, #{}, <<"Invalid address.">>, Req};
@@ -398,7 +398,7 @@ do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"balance">>], Req) ->
 
 %% @doc Return the last transaction ID (hash) for the wallet specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/last_tx
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"last_tx">>], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"last_tx">>], Req) ->
 	case safe_decode(Addr) of
 		{error, invalid} ->
 			{400, #{}, <<"Invalid address.">>, Req};
@@ -412,20 +412,20 @@ do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"last_tx">>], Req) ->
 
 %% @doc Return transaction identifiers (hashes) for the wallet specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/txs
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"txs">>], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"txs">>], Req) ->
 	{Status, Headers, Body} = handle_get_wallet_txs(Addr, none),
 	{Status, Headers, Body, Req};
 
 %% @doc Return transaction identifiers (hashes) starting from the earliest_tx for the wallet
 %% specified via wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/txs/{earliest_tx}
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"txs">>, EarliestTX], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"txs">>, EarliestTX], Req) ->
 	{Status, Headers, Body} = handle_get_wallet_txs(Addr, ar_util:decode(EarliestTX)),
 	{Status, Headers, Body, Req};
 
 %% @doc Return identifiers (hashes) of transfer transactions depositing to the given wallet_address.
 %% GET request to endpoint /wallet/{wallet_address}/deposits
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>], Req) ->
 	TXIDs = lists:reverse(
 		lists:map(fun ar_util:encode/1, ar_tx_search:get_entries(<<"to">>, Addr))
 	),
@@ -434,7 +434,7 @@ do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>], Req) ->
 %% @doc Return identifiers (hashes) of transfer transactions depositing to the given wallet_address
 %% starting from the earliest_deposit.
 %% GET request to endpoint /wallet/{wallet_address}/deposits/{earliest_deposit}
-do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>, EarliestDeposit], Req) ->
+handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>, EarliestDeposit], Req) ->
 	TXIDs = lists:reverse(
 		lists:map(fun ar_util:encode/1, ar_tx_search:get_entries(<<"to">>, Addr))
 	),
@@ -449,7 +449,7 @@ do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>, EarliestDeposit], Req)
 
 %% @doc Return the encrypted blockshadow corresponding to the indep_hash.
 %% GET request to endpoint /block/hash/{indep_hash}/encrypted
-%do_handle(<<"GET">>, [<<"block">>, <<"hash">>, Hash, <<"encrypted">>], _Req) ->
+%handle(<<"GET">>, [<<"block">>, <<"hash">>, Hash, <<"encrypted">>], _Req) ->
 	%ar:d({resp_block_hash, Hash}),
 	%ar:report_console([{resp_getting_block_by_hash, Hash}, {path, split_path(cowboy_req:path(Req))}]),
 	%case ar_key_db:get(ar_util:decode(Hash)) of
@@ -469,7 +469,7 @@ do_handle(<<"GET">>, [<<"wallet">>, Addr, <<"deposits">>, EarliestDeposit], Req)
 
 %% @doc Return the blockshadow corresponding to the indep_hash / height.
 %% GET request to endpoint /block/{height|hash}/{indep_hash|height}
-do_handle(<<"GET">>, [<<"block">>, Type, ID], Req) ->
+handle(<<"GET">>, [<<"block">>, Type, ID], Req) ->
 	Filename =
 		case Type of
 			<<"hash">> ->
@@ -536,7 +536,7 @@ do_handle(<<"GET">>, [<<"block">>, Type, ID], Req) ->
 	end;
 
 %% @doc Return block or block field.
-do_handle(<<"GET">>, [<<"block">>, Type, IDBin, Field], Req) ->
+handle(<<"GET">>, [<<"block">>, Type, IDBin, Field], Req) ->
 	case validate_get_block_type_id(Type, IDBin) of
 		{error, {Status, Headers, Body}} ->
 			{Status, Headers, Body, Req};
@@ -547,20 +547,20 @@ do_handle(<<"GET">>, [<<"block">>, Type, IDBin, Field], Req) ->
 %% @doc Return the current block.
 %% GET request to endpoint /current_block
 %% GET request to endpoint /block/current
-do_handle(<<"GET">>, [<<"block">>, <<"current">>], Req) ->
+handle(<<"GET">>, [<<"block">>, <<"current">>], Req) ->
 	case ar_node:get_hash_list(whereis(http_entrypoint_node)) of
 		[] -> {404, #{}, <<"Block not found.">>, Req};
 		[IndepHash|_] ->
-			do_handle(<<"GET">>, [<<"block">>, <<"hash">>, ar_util:encode(IndepHash)], Req)
+			handle(<<"GET">>, [<<"block">>, <<"hash">>, ar_util:encode(IndepHash)], Req)
 	end;
 
 %% DEPRECATED (12/07/2018)
-do_handle(<<"GET">>, [<<"current_block">>], Req) ->
-	do_handle(<<"GET">>, [<<"block">>, <<"current">>], Req);
+handle(<<"GET">>, [<<"current_block">>], Req) ->
+	handle(<<"GET">>, [<<"block">>, <<"current">>], Req);
 
 %% @doc Return a list of known services.
 %% GET request to endpoint /services
-do_handle(<<"GET">>, [<<"services">>], Req) ->
+handle(<<"GET">>, [<<"services">>], Req) ->
 	{200, #{},
 		ar_serialize:jsonify(
 			{
@@ -588,7 +588,7 @@ do_handle(<<"GET">>, [<<"services">>], Req) ->
 %%
 %% {field} := { id | last_tx | owner | tags | target | quantity | data | signature | reward }
 %%
-do_handle(<<"GET">>, [<<"tx">>, Hash, Field], Req) ->
+handle(<<"GET">>, [<<"tx">>, Hash, Field], Req) ->
 	case hash_to_filename(tx, Hash) of
 		{error, invalid} ->
 			{400, #{}, <<"Invalid hash.">>, Req};
@@ -627,7 +627,7 @@ do_handle(<<"GET">>, [<<"tx">>, Hash, Field], Req) ->
 %% @doc Share the location of a given service with a peer.
 %% POST request to endpoint /services where the body of the request is a JSON encoded serivce as
 %% specified in ar_serialize.
-do_handle(<<"POST">>, [<<"services">>], Req) ->
+handle(<<"POST">>, [<<"services">>], Req) ->
 	case read_complete_body(Req) of
 		{ok, BodyBin, ReadReq} ->
 			{ServicesJSON} = ar_serialize:jsonify(BodyBin),
@@ -649,7 +649,7 @@ do_handle(<<"POST">>, [<<"services">>], Req) ->
 	end;
 
 %% @doc Return the current block hieght, or 500
-do_handle(Method, [<<"height">>], Req)
+handle(Method, [<<"height">>], Req)
 		when (Method == <<"GET">>) or (Method == <<"HEAD">>) ->
 	case ar_node:get_height(whereis(http_entrypoint_node)) of
 		-1 -> {503, #{}, <<"Node has not joined the network yet.">>, Req};
@@ -659,19 +659,19 @@ do_handle(Method, [<<"height">>], Req)
 %% @doc If we are given a hash with no specifier (block, tx, etc), assume that
 %% the user is requesting the data from the TX associated with that hash.
 %% Optionally allow a file extension.
-do_handle(<<"GET">>, [<< Hash:43/binary, MaybeExt/binary >>], Req) ->
+handle(<<"GET">>, [<< Hash:43/binary, MaybeExt/binary >>], Req) ->
 	case MaybeExt of
 		<< ".", Part/binary >> ->
-			do_handle(<<"GET">>, [<<"tx">>, Hash, <<"data.", Part/binary>>], Req);
+			handle(<<"GET">>, [<<"tx">>, Hash, <<"data.", Part/binary>>], Req);
 		<<>> ->
-			do_handle(<<"GET">>, [<<"tx">>, Hash, <<"data.html">>], Req);
+			handle(<<"GET">>, [<<"tx">>, Hash, <<"data.html">>], Req);
 		_ ->
 			not_found(Req)
 	end;
 
 %% @doc Catch case for requests made to unknown endpoints.
 %% Returns error code 400 - Request type not found.
-do_handle(_, _, Req) ->
+handle(_, _, Req) ->
 	not_found(Req).
 
 % Cowlib does not yet support status code 208 properly.

--- a/src/ar_http_iface_cowboy_handler.erl
+++ b/src/ar_http_iface_cowboy_handler.erl
@@ -192,7 +192,7 @@ do_handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req) ->
 		{error, _, unavailable} ->
 			{404, #{}, sendfile("data/not_found.html"), Req};
 		{ok, Filename} ->
-			T = ar_storage:do_read_tx(Filename),
+			T = ar_storage:read_tx_file(Filename),
 			{
 				200,
 				#{
@@ -500,7 +500,7 @@ do_handle(<<"GET">>, [<<"block">>, Type, ID], Req) ->
 				{_, <<"1">>} ->
 					% Supprt for legacy nodes (pre-1.5).
 					BHL = ar_node:get_hash_list(whereis(http_entrypoint_node)),
-					try ar_storage:do_read_block(Filename, BHL) of
+					try ar_storage:read_block_file(Filename, BHL) of
 						B ->
 							{JSONStruct} =
 								ar_serialize:block_to_json_struct(
@@ -602,7 +602,7 @@ do_handle(<<"GET">>, [<<"tx">>, Hash, Field], Req) ->
 		{ok, Filename} ->
 			case Field of
 				<<"tags">> ->
-					TX = ar_storage:do_read_tx(Filename),
+					TX = ar_storage:read_tx_file(Filename),
 					{200, #{}, ar_serialize:jsonify(
 						lists:map(
 							fun({Name, Value}) ->

--- a/src/ar_http_iface_server.erl
+++ b/src/ar_http_iface_server.erl
@@ -4,7 +4,7 @@
 
 -module(ar_http_iface_server).
 
--export([start/5]).
+-export([start/2]).
 -export([reregister/1, reregister/2]).
 
 -include("ar.hrl").
@@ -15,12 +15,19 @@
 %%%
 
 %% @doc Start the Arweave HTTP API and returns a process ID.
-start(Port, Node, SearchNode, ServiceNode, BridgeNode) ->
-	reregister(http_entrypoint_node, Node),
-	reregister(http_search_node, SearchNode),
-	reregister(http_service_node, ServiceNode),
-	reregister(http_bridge_node, BridgeNode),
+start(Port, HttpNodes) ->
+	reregister_from_proplist([
+		http_entrypoint_node,
+		http_search_node,
+		http_service_node,
+		http_bridge_node
+	], HttpNodes),
 	do_start(Port).
+
+reregister_from_proplist(Names, HttpNodes) ->
+	lists:foreach(fun(Name) ->
+		reregister(Name, proplists:get_value(Name, HttpNodes))
+	end, Names).
 
 %% @doc Helper function : registers a new node as the entrypoint.
 reregister(Node) ->

--- a/src/ar_http_iface_server.erl
+++ b/src/ar_http_iface_server.erl
@@ -50,7 +50,7 @@ do_start(Port) ->
 	Routes = [
 		{'_', [
 			{"/metrics/[:registry]", prometheus_cowboy2_handler, []},
-			{"/[...]", ar_http_iface_cowboy_handler, []}
+			{"/[...]", ar_http_iface_h, []}
 		]}
 	],
 	Dispatch = cowboy_router:compile(Routes),
@@ -65,10 +65,9 @@ do_start(Port) ->
 			metrics_callback => fun prometheus_cowboy2_instrumenter:observe/1,
 			stream_handlers => [cowboy_metrics_h, cowboy_stream_h]
 		},
+	{ok, _} = cowboy:start_clear(
+		ar_http_iface_listener,
+		[{port, Port}],
+		ProtocolOpts
+	).
 
-	{ok, _} =
-		cowboy:start_clear(
-			ar_cowboy_listener,
-			[{port, Port}],
-			ProtocolOpts
-		).

--- a/src/ar_util.erl
+++ b/src/ar_util.erl
@@ -5,7 +5,7 @@
 -module(ar_util).
 
 -export([pick_random/1, pick_random/2]).
--export([encode/1, decode/1]).
+-export([encode/1, decode/1, safe_decode/1]).
 -export([parse_peer/1, parse_port/1, format_peer/1, unique/1, count/2]).
 -export([replace/3]).
 -export([block_from_hash_list/2, hash_from_hash_list/2]).
@@ -40,12 +40,24 @@ pick_random(Xs) ->
 encode(Bin) ->
 	base64url:encode(Bin).
 
-%% @doc Decode a URL safe base64 to binary.
+%% @doc Try to decode a URL safe base64 into a binary or throw an error when
+%% invalid.
 decode([]) -> [];
-decode(Bin) when is_list(Bin) ->
-	decode(list_to_binary(Bin));
+decode(List) when is_list(List) ->
+	decode(list_to_binary(List));
 decode(Bin) when is_binary(Bin) ->
 	base64url:decode(Bin).
+
+%% @doc Safely decode a URL safe base64 into a binary returning an ok or error
+%% tuple.
+safe_decode(E) ->
+	try
+		D = decode(E),
+		{ok, D}
+	catch
+		_:_ ->
+			{error, invalid}
+	end.
 
 %% @doc Reverse a binary
 rev_bin(Bin) ->

--- a/test/ar_base32_tests.erl
+++ b/test/ar_base32_tests.erl
@@ -1,0 +1,23 @@
+%% @doc These tests are very strongly inspired by Elixir's Base tests.
+%% See https://github.com/elixir-lang/elixir/blob/511a51ba8925daa025d3c2fd410e170c1b651013/lib/elixir/test/elixir/base_test.exs
+-module(ar_base32_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+encode_empty_string_test() ->
+	?assertEqual(<<>>, ar_base32:encode(<<>>)).
+
+encode_with_one_pad_test() ->
+	?assertEqual(<<"mzxw6yq">>, ar_base32:encode(<<"foob">>)).
+
+encode_with_three_pads_test() ->
+	?assertEqual(<<"mzxw6">>, ar_base32:encode(<<"foo">>)).
+
+encode_with_four_pads_test() ->
+	?assertEqual(<<"mzxq">>, ar_base32:encode(<<"fo">>)).
+
+encode_with_six_pads_test() ->
+	?assertEqual(<<"mzxw6ytboi">>, ar_base32:encode(<<"foobar">>)),
+	?assertEqual(<<"my">>, ar_base32:encode(<<"f">>)).
+
+encode_with_no_pads_test() ->
+	?assertEqual(<<"mzxw6ytb">>, ar_base32:encode(<<"fooba">>)).


### PR DESCRIPTION
This PR implements the logic to serve each transaction under its own origin. This is done by deriving a _label_ from the transaction and its containing block's hash.

For example, for the transaction `vP_3_IZBng33AaW8MCfTqseJxdG-OWbfOb_ZU1UhR7s`, the generated label is `xvc4dssncn5p`, so accessing https://gateway.example/vP_3_IZBng33AaW8MCfTqseJxdG-OWbfOb_ZU1UhR7s will redirect to https://xvc4dssncn5p.gateway.example/vP_3_IZBng33AaW8MCfTqseJxdG-OWbfOb_ZU1UhR7s.

This PR also implements the logic to associate a custom domain name with a specific transaction. This is done by specifying a list of known custom domains at node startup. These domains should point to the node either with an A or CNAME record. The association of the domain to the transaction is then done by looking for a TXT record for that domain with the name `_arweave.<custom domain name>` and the transaction id as its value.

There's a few points I still want to discuss, although I would still appreciate feedback on what's been done so far.

The points I still want to discuss are the following:

- Currently, the location of the certificate files is inferred: the main certificate and key are expected to live at `priv/tls/{cert,key}.pem` and the certificate files for the custom domains are expected to live under `priv/tls/<custom domain>/{cert,key}.pem`. Symlinking to these locations seems to work fine. I feel like this should be good enough for this first iteration. What do you think?
- Currently, most of the business logic still lives in the cowboy handler. I feel like it might be nice to split as much of it as possible into a separate module. What do you think?
- Currently, the configuration for the domains is done through CLI arguments. Specifying the `apex_domain` value (the main domain name for the node) triggers the new behaviour. Leaving it absent will retain the old behaviour. It might be nice to turn this into a more explicit flag. What do you think?
- There's also currently no interface to reconfigure the domains without restarting the node and passing in other CLI arguments. Again, I feel like this should be good enough for this first iteration. What do you think?