### PR TITLE
Configurable Webhooks

### DIFF
--- a/src/ar.erl
+++ b/src/ar.erl
@@ -254,7 +254,8 @@ start(
 		gateway_custom_domains = GatewayCustomDomains,
 		requests_per_minute_limit = RequestsPerMinuteLimit,
 		ipfs_pin = IPFSPin,
-		ipfs_import = IPFSImport
+		ipfs_import = IPFSImport,
+		webhooks = WebhookConfigs
 	}) ->
 	%% Start the logging system.
 	error_logger:logfile({open, Filename = generate_logfile_name()}),
@@ -439,6 +440,7 @@ start(
 		false -> ok;
 		true  -> app_ipfs_daemon_server:start()
 	end,
+	ar_node:add_peers(Node, ar_webhook:start(WebhookConfigs)),
 	case Pause of
 		false ->
 			ok;

--- a/src/ar.hrl
+++ b/src/ar.hrl
@@ -248,7 +248,7 @@
 %% @doc Adjust the difficulty up to the limit.
 -define(DIFF_ADJUSTMENT_UP_LIMIT(Diff), (Diff * 4)).
 
-%% @doc A block on the weave.
+%% @doc A full block or block shadow (see more on txs field).
 -record(block, {
 	nonce = <<>>, % The nonce used to satisfy the mining problem when mined
 	previous_block = <<>>, % indep_hash of the previous block in the weave
@@ -258,7 +258,7 @@
 	height = -1, % How many blocks have passed since the Genesis block?
 	hash = <<>>, % A hash of this block, the previous block and the recall block.
 	indep_hash = [], % A hash of this block JSON encoded. (TODO: Shouldn't it be a binary as it is a hash?)
-	txs = [], % A list of transaction records associated with this block.
+	txs = [], % A list of tx records in full blocks, or a list of tx ids in block shadows.
 	hash_list = unset, % A list of all previous indep hashes.
 	hash_list_merkle = <<>>, % The merkle root of the block's BHL.
 	wallet_list = [], % A map of wallet balances, or undefined.

--- a/src/ar_config.hrl
+++ b/src/ar_config.hrl
@@ -3,6 +3,12 @@
 
 -include("ar.hrl").
 
+-record(config_webhook, {
+	events = [],
+	url = undefined,
+	headers = []
+}).
+
 %% Start options with default values.
 -record(config, {
 	benchmark = false,
@@ -34,7 +40,8 @@
 	gateway_custom_domains = [],
 	requests_per_minute_limit = ?DEFAULT_REQUESTS_PER_MINUTE_LIMIT,
 	ipfs_pin = false,
-	ipfs_import = false
+	ipfs_import = false,
+	webhooks = []
 }).
 
 -endif.

--- a/src/ar_webhook.erl
+++ b/src/ar_webhook.erl
@@ -1,0 +1,30 @@
+-module(ar_webhook).
+-export([start/1, new_block/2, new_transaction/2]).
+
+start(Configs) ->
+	Workers = lists:map(
+		fun(Config) ->
+			{ok, Worker} = ar_webhook_worker:start_link(Config),
+			Worker
+		end,
+		Configs
+	),
+	adt_simple:start(?MODULE, Workers).
+
+new_block(Workers, Block) ->
+	lists:foreach(
+		fun(Worker) ->
+			ok = ar_webhook_worker:cast_webhook(Worker, {block, Block})
+		end,
+		Workers
+	),
+	Workers.
+
+new_transaction(Workers, TX) ->
+	lists:foreach(
+		fun(Worker) ->
+			ok = ar_webhook_worker:cast_webhook(Worker, {transaction, TX})
+		end,
+		Workers
+	),
+	Workers.

--- a/src/ar_webhook_worker.erl
+++ b/src/ar_webhook_worker.erl
@@ -1,0 +1,113 @@
+-module(ar_webhook_worker).
+-behaviour(gen_server).
+
+-export([start_link/1, cast_webhook/2]).
+-export([init/1, handle_call/3, handle_cast/2]).
+
+-include("ar_config.hrl").
+
+-define(NUMBER_OF_TRIES, 10).
+-define(WAIT_BETWEEN_TRIES, 30 * 1000).
+
+-define(BASE_HEADERS, [
+	{<<"content-type">>, <<"application/json">>}
+]).
+
+%% Public API
+
+start_link(Config) ->
+	gen_server:start_link(?MODULE, [Config], []).
+
+cast_webhook(Worker, Event) ->
+	gen_server:cast(Worker, {call_webhook, Event}).
+
+%% Generic server callbacks
+
+init([Config]) ->
+	{ok, Config}.
+
+handle_call(_, _, Config) ->
+	{noreply, Config}.
+
+handle_cast({call_webhook, Event}, Config) ->
+	ok = call_webhook(Event, Config),
+	{noreply, Config}.
+
+%% Private functions
+
+call_webhook({EventType, Entity}, #config_webhook { events = Events } = Config) ->
+	case lists:member(EventType, Events) of
+		true -> do_call_webhook({EventType, Entity}, Config, 0);
+		false -> ok
+	end.
+
+do_call_webhook({EventType, Entity}, Config, N) when N < ?NUMBER_OF_TRIES ->
+	#config_webhook{
+		url = URL,
+		headers = Headers
+	} = Config,
+	{ok, {Scheme, _UserInfo, Host, Port, Path, Query}} = http_uri:parse(URL),
+	{ok, Client} = fusco:start(atom_to_list(Scheme) ++ "://" ++ binary_to_list(Host) ++ ":" ++ integer_to_list(Port), []),
+	Result =
+		fusco:request(
+			Client,
+			<<Path/binary, Query/binary>>,
+			<<"POST">>,
+			?BASE_HEADERS ++ Headers,
+			to_json(Entity),
+			10000
+		),
+	case Result of
+		{ok, {{<<"200">>, _}, _, _, _, _}} ->
+			ok = fusco:disconnect(Client),
+			ar:info([
+				{ar_webhook_worker, webhook_call_success},
+				{event, EventType},
+				{id, entity_id(Entity)},
+				{url, URL},
+				{headers, Headers},
+				{response, Result}
+			]),
+			ok;
+		UnsuccessfulResult ->
+			ar:warn([
+				{ar_webhook_worker, webhook_call_failure},
+				{event, EventType},
+				{id, entity_id(Entity)},
+				{url, URL},
+				{headers, Headers},
+				{response, UnsuccessfulResult},
+				{retry_in, ?WAIT_BETWEEN_TRIES}
+			]),
+			timer:sleep(?WAIT_BETWEEN_TRIES),
+			do_call_webhook({EventType, Entity}, Config, N+1)
+	end;
+do_call_webhook({EventType, Entity}, Config, _) ->
+	#config_webhook{
+		url = URL,
+		headers = Headers
+	} = Config,
+	ar:warn([gave_up_webhook_call,
+		{event, EventType},
+		{id, entity_id(Entity)},
+		{url, URL},
+		{headers, Headers},
+		{number_of_tries, ?NUMBER_OF_TRIES},
+		{wait_between_tries, ?WAIT_BETWEEN_TRIES}
+	]),
+	ok.
+
+entity_id(#block { indep_hash = ID }) -> ar_util:encode(ID);
+entity_id(#tx { id = ID }) -> ar_util:encode(ID).
+
+to_json(#block {} = Block) ->
+	{JSONKVPairs} = ar_serialize:block_to_json_struct(Block),
+	JSONStruct = {lists:keydelete(wallet_list, 1, JSONKVPairs)},
+	ar_serialize:jsonify({[{block, JSONStruct}]});
+to_json(#tx {} = TX) ->
+	{JSONKVPairs1} = ar_serialize:tx_to_json_struct(TX),
+	{value, {data, Data}, JSONKVPairs2} = lists:keytake(data, 1, JSONKVPairs1),
+	JSONKVPairs3 = [{data_size, byte_size(Data)} | JSONKVPairs2],
+	JSONStruct = {JSONKVPairs3},
+	ar_serialize:jsonify({[{transaction, JSONStruct}]}).
+

--- a/test/ar_config_tests.erl
+++ b/test/ar_config_tests.erl
@@ -9,7 +9,8 @@ parse_config() ->
 	ExpectedMiningAddr = ar_util:decode(<<"LKC84RnISouGUw4uMQGCpPS9yDC-tIoqM2UVbUIt-Sw">>),
 	ExpectedStartHashList = ar_util:decode(<<"ZFTD3ne7_U3BONHi8O-QpBv0ZQTAXJ2eFIih8dod0f8">>),
 	ExpectedUpdateAddr = ar_util:decode(<<"V_zW1A2HeqWFBpwKCjyd8V6eI8S3ia8GOVA6g7YXAdU">>),
-	?assertMatch({ok, #config{
+	{ok, ParsedConfig} = ar_config:parse(config_fixture()),
+	?assertMatch(#config{
 		benchmark = true,
 		port = 1985,
 		init = true,
@@ -44,8 +45,15 @@ parse_config() ->
 		content_policy_files = ["some_content_policy_1", "some_content_policy_2"],
 		transaction_blacklist_files = ["some_blacklist_1", "some_blacklist_2"],
 		gateway_domain = <<"gateway.localhost">>,
-		gateway_custom_domains = [<<"domain1.example">>, <<"domain2.example">>]
-	}}, ar_config:parse(config_fixture())).
+		gateway_custom_domains = [<<"domain1.example">>, <<"domain2.example">>],
+		webhooks = [
+			#config_webhook{
+				events = [transaction, block],
+				url = <<"https://example.com/hook">>,
+				headers = [{<<"Authorization">>, <<"Bearer 123456">>}]
+			}
+		]
+	}, ParsedConfig).
 
 config_fixture() ->
 	Dir = filename:dirname(?FILE),

--- a/test/ar_config_tests_config_fixture.json
+++ b/test/ar_config_tests_config_fixture.json
@@ -46,5 +46,14 @@
   "custom_domains": [
     "domain1.example",
     "domain2.example"
+  ],
+  "webhooks": [
+    {
+      "events": ["transaction", "block"],
+      "url": "https://example.com/hook",
+      "headers": {
+        "Authorization": "Bearer 123456"
+      }
+    }
   ]
 }


### PR DESCRIPTION
This PR adds the ability to call configurable web hooks when the node receives new blocks or new transactions.

This is done by adding a `webhooks` field in the config file with the a list of webhook configuration objects with the following fields:
- `events`: an array or either `"transaction"`, `"block"` or both, specifying which events should be communicated to the webhook
- `url`: the URL where the webhook should be called
- `headers`: an object with HTTP header keys and values

For example:
```jsonc
{
  //...
  "webhooks": [
    {
      "events": ["transaction", "block"],
      "url": "https://example.com/hook",
      "headers": {
        "Authorization": "Bearer 123456"
      }
    }
  ]
}
```