### PR TITLE
Use a bigger safety buffer when estimating TX prices

### DIFF
--- a/src/ar_difficulty.erl
+++ b/src/ar_difficulty.erl
@@ -1,6 +1,6 @@
 -module(ar_difficulty).
 
--export([next_cumulative_diff/3]).
+-export([next_cumulative_diff/3, twice_smaller_diff/1]).
 
 %% @doc Calculate the cumulative difficulty for the next block.
 next_cumulative_diff(OldCDiff, NewDiff, Height) ->
@@ -8,8 +8,12 @@ next_cumulative_diff(OldCDiff, NewDiff, Height) ->
 		false ->
 			NewDiff * NewDiff;
 		true  ->
-			MaxDiff = ar_mine:max_difficulty(Height),
+			MaxDiff = ar_mine:max_difficulty(),
 			%% The number of hashes to try on average to find a solution.
 			erlang:trunc(MaxDiff / (MaxDiff - NewDiff))
 	end,
 	OldCDiff + Delta.
+
+twice_smaller_diff(Diff) ->
+	MaxDiff = ar_mine:max_difficulty(),
+	MaxDiff - 2 * (MaxDiff - Diff).

--- a/src/ar_http_iface_middleware.erl
+++ b/src/ar_http_iface_middleware.erl
@@ -691,7 +691,10 @@ estimate_tx_price(SizeInBytesBinary, WalletAddr) ->
 	Node = whereis(http_entrypoint_node),
 	Height = ar_node:get_height(Node),
 	CurrentDiff = ar_node:get_diff(Node),
-	NextDiff = ar_node:get_current_diff(Node),
+	%% Add a safety buffer to prevent transactions
+	%% from being rejected after a retarget when the
+	%% difficulty drops
+	NextDiff = ar_difficulty:twice_smaller_diff(CurrentDiff),
 	Timestamp  = os:system_time(seconds),
 	CurrentDiffPrice = estimate_tx_price(SizeInBytes, CurrentDiff, Height, WalletAddr, Timestamp),
 	NextDiffPrice = estimate_tx_price(SizeInBytes, NextDiff, Height + 1, WalletAddr, Timestamp),

--- a/src/ar_mine.erl
+++ b/src/ar_mine.erl
@@ -1,7 +1,7 @@
 -module(ar_mine).
 -export([start/7, start/8, stop/1, mine/2]).
 -export([validate/4, validate/3]).
--export([min_difficulty/1, genesis_difficulty/0, max_difficulty/1]).
+-export([min_difficulty/1, genesis_difficulty/0, max_difficulty/0]).
 -export([sha384_diff_to_randomx_diff/1]).
 -include("ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -89,7 +89,7 @@ validate(BDSHash, Diff, Height) ->
 
 %% @doc Maximum linear difficulty.
 %% Assumes using 256 bit RandomX hashes.
-max_difficulty(_Height) ->
+max_difficulty() ->
 	erlang:trunc(math:pow(2, 256)).
 
 min_difficulty(Height) ->

--- a/src/ar_retarget.erl
+++ b/src/ar_retarget.erl
@@ -87,7 +87,7 @@ calculate_difficulty_linear(OldDiff, TS, Last, Height) ->
 		true ->
 			OldDiff;
 		false ->
-			MaxDiff = ar_mine:max_difficulty(Height),
+			MaxDiff = ar_mine:max_difficulty(),
 			MinDiff = ar_mine:min_difficulty(Height),
 			between(
 				MaxDiff - (MaxDiff - OldDiff) * ActualTime div TargetTime,

--- a/test/ar_tx_perpetual_storage_tests.erl
+++ b/test/ar_tx_perpetual_storage_tests.erl
@@ -4,6 +4,8 @@
 -include("src/perpetual_storage.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-import(ar_difficulty, [twice_smaller_diff/1]).
+
 -import(ar_test_node, [start/2, slave_start/2, connect_to_slave/0]).
 -import(ar_test_node, [slave_mine/1]).
 -import(ar_test_node, [sign_tx/1, sign_tx/2]).
@@ -47,7 +49,7 @@ updates_pool_and_assigns_rewards_correctly() ->
 	B2 = ar_storage:read_block(hd(BHL2), BHL2),
 	RewardPoolIncrement1 = ar_tx_perpetual_storage:calculate_tx_cost(
 		0,
-		B2#block.diff,
+		twice_smaller_diff(B2#block.diff),
 		2,
 		B2#block.timestamp
 	),
@@ -69,7 +71,7 @@ updates_pool_and_assigns_rewards_correctly() ->
 	B3 = ar_storage:read_block(hd(BHL3), BHL3),
 	RewardPoolIncrement2 = ar_tx_perpetual_storage:calculate_tx_cost(
 		byte_size(Data),
-		B3#block.diff,
+		twice_smaller_diff(B3#block.diff),
 		3,
 		B3#block.timestamp
 	),
@@ -105,7 +107,7 @@ updates_pool_and_assigns_rewards_correctly() ->
 		fun(Chunk, {Sum, Size}) ->
 			{Sum + ar_tx_perpetual_storage:calculate_tx_cost(
 				byte_size(Chunk),
-				B4#block.diff,
+				twice_smaller_diff(B4#block.diff),
 				4,
 				B4#block.timestamp
 			), Size + byte_size(Chunk)}
@@ -133,7 +135,7 @@ updates_pool_and_assigns_rewards_correctly() ->
 	RecallB = ar_storage:read_block(ar_weave:calculate_recall_block(hd(BHL4), BHL4), BHL4),
 	RewardPoolIncrement4 = ar_tx_perpetual_storage:calculate_tx_cost(
 		byte_size(BigChunk),
-		B5#block.diff,
+		twice_smaller_diff(B5#block.diff),
 		5,
 		B5#block.timestamp
 	),

--- a/test/ar_tx_replay_pool_tests.erl
+++ b/test/ar_tx_replay_pool_tests.erl
@@ -267,5 +267,5 @@ fee(Diff, Height, Timestamp) ->
 
 random_diff() ->
 	MinDiff = ar_mine:min_difficulty(ar_fork:height_1_8()),
-	MaxDiff = ar_mine:max_difficulty(ar_fork:height_1_8()),
+	MaxDiff = ar_mine:max_difficulty(),
 	MinDiff + rand:uniform(MaxDiff - MinDiff).


### PR DESCRIPTION
The buffer is the same to that used before the switch to the linear difficulty. A more optimistic estimation does not perform well under the present difficulty fluctuations.