### PR TITLE
Fix a bug where sometimes nodes fail to join the network

### DIFF
--- a/src/ar.hrl
+++ b/src/ar.hrl
@@ -190,6 +190,9 @@
 %% @doc The number of the best peers to send new blocks to in parallel.
 -define(BLOCK_PROPAGATION_PARALLELIZATION, 30).
 
+%% @doc The maximum number of peers to propagate blocks or txs to.
+-define(MAX_PROPAGATION_PEERS, 65).
+
 %% @doc When the transaction data size is smaller than this number of bytes,
 %% the transaction is gossiped to the peer without a prior check if the peer
 %% already has this transaction.

--- a/src/ar_node_utils.erl
+++ b/src/ar_node_utils.erl
@@ -464,6 +464,7 @@ fork_recover(#{ node := Node, hash_list := HashList, block_txs_pairs := BlockTXP
 				process,
 				PID = ar_fork_recovery:start(
 					PrioritisedPeers,
+					maps:get(trusted_peers, StateIn),
 					NewB,
 					HashList,
 					Node,

--- a/src/ar_node_worker.erl
+++ b/src/ar_node_worker.erl
@@ -270,7 +270,6 @@ add_tx_to_mining_pool(StateIn, TX, NewGS) ->
 		txs := TXs,
 		waiting_txs := WaitingTXs
 	} = StateIn,
-	memsup:start_link(),
 	{ok, [
 		{txs, TXs ++ [TX]},
 		{gossip, NewGS},


### PR DESCRIPTION
If a node joins on a block whose predecessors get overwritten, it lacks the blocks
below the predecessor height - 50 required for verifying transactions for replay.
The commit downloads those blocks from the trusted peers when needed.