### PR TITLE
Remove unstable memsup monitor

### DIFF
--- a/src/ar_node_worker.erl
+++ b/src/ar_node_worker.erl
@@ -270,7 +270,6 @@ add_tx_to_mining_pool(StateIn, TX, NewGS) ->
 		txs := TXs,
 		waiting_txs := WaitingTXs
 	} = StateIn,
-	memsup:start_link(),
 	{ok, [
 		{txs, TXs ++ [TX]},
 		{gossip, NewGS},


### PR DESCRIPTION
Remove as it has little value and crashes under certain circumstances
bringing the worker down. memsup:start_link should only be used to monitor
supervised processes.