### PR TITLE
Make polling mode more efficient

### DIFF
--- a/apps/arweave/src/ar_miner_log.erl
+++ b/apps/arweave/src/ar_miner_log.erl
@@ -46,21 +46,10 @@ watchdog() ->
 		fork_recovered -> watchdog();
 		stop -> ok
 	after ?FOREIGN_BLOCK_ALERT_TIME ->
-		case ar_meta_db:get(polling_mode) of
-			true ->
-				log(
-					"WARNING: No foreign blocks fetched from the network. "
-					"Please check your internet connection and the logs for errors."
-				);
-			_ ->
-				log(
-					"WARNING: No foreign blocks received from the network. "
-					"Please confirm your node is available on port ~B "
-					"on your Internet IP address. E.g. browse to http://[Internet IP address]:~B/info. "
-					"If so, please check the logs for errors.",
-					[ar_meta_db:get(port), ar_meta_db:get(port)]
-				)
-		end,
+		log(
+			"WARNING: No foreign blocks received from the network or found by trusted peers. "
+			"Please check your internet connection and the logs for errors."
+		),
 		watchdog()
 	end.
 

--- a/apps/arweave/src/ar_node.erl
+++ b/apps/arweave/src/ar_node.erl
@@ -47,9 +47,6 @@
 %% @doc Ensure this number of the last blocks are not dropped.
 -define(KEEP_LAST_BLOCKS, 5).
 
-%% @doc The time to poll peers for a new current block.
--define(POLL_TIME, 60*100).
-
 %%%
 %%% Public API.
 %%%

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -408,7 +408,6 @@ integrate_new_block(
 		NewB#block.height,
 		NewB#block.wallet_list
 	),
-	%% Recurse over the new block.
 	ar_miner_log:foreign_block(NewB#block.indep_hash),
 	ar:report_console(
 		[

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -421,7 +421,16 @@ generate_block_from_shadow(StateIn, BShadow, Recall, TXs, Peer) ->
 
 generate_block_from_shadow(StateIn, BShadow, Recall, TXs, NewHashList, Peer) ->
 	#{ hash_list := HashList } = StateIn,
-	{RecallIndepHash, _, Key, Nonce} = Recall,
+	{RecallIndepHash, Key, Nonce} = case Recall of
+		no_recall ->
+			{
+				ar_util:get_recall_hash(BShadow#block.previous_block, NewHashList),
+				<<>>,
+				<<>>
+			};
+		{RecallH, _, K, N} ->
+			{RecallH, K, N}
+	end,
 	MaybeRecallB = case ar_block:get_recall_block(Peer, RecallIndepHash, NewHashList, Key, Nonce) of
 		unavailable ->
 			RecallHash = ar_node_utils:find_recall_hash(BShadow, HashList),

--- a/apps/arweave/src/ar_poller_sup.erl
+++ b/apps/arweave/src/ar_poller_sup.erl
@@ -1,0 +1,21 @@
+-module(ar_poller_sup).
+-behaviour(supervisor).
+
+-export([start_link/1]).
+-export([init/1]).
+
+%%%===================================================================
+%%% Public API.
+%%%===================================================================
+
+start_link(Args) ->
+	supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
+
+%%%===================================================================
+%%% Supervisor callbacks.
+%%%===================================================================
+
+init(Args) ->
+	SupFlags = #{strategy => one_for_one, intensity => 10, period => 1},
+	ChildSpec = #{ id => ar_poller, start => {ar_poller, start_link, [Args]} },
+	{ok, {SupFlags, [ChildSpec]}}.


### PR DESCRIPTION
Motivated by the possibility of the connectivity issues.

The improvement includes:

- Get rid of extra hash list, blocks, and txs downloads - fetch block shadows by height.
- Synchronize the polling server with the bridge to avoid double work.
- Check for new blocks every minute even if polling is not enabled explicitly, because it's very cheap now.