### PR TITLE
Make max_connections configurable

### DIFF
--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -194,6 +194,10 @@ parse_options([{<<"webhooks">>, WebhookConfigs} | Rest], Config) when is_list(We
 	end;
 parse_options([{<<"webhooks">>, Webhooks} | _], _) ->
 	{error, {bad_type, webhooks, array}, Webhooks};
+parse_options([{<<"max_connections">>, MaxConnections} | Rest], Config) when is_integer(MaxConnections) ->
+	parse_options(Rest, Config#config { max_connections = MaxConnections });
+parse_options([{<<"max_gateway_connections">>, MaxGatewayConnections} | Rest], Config) when is_integer(MaxGatewayConnections) ->
+	parse_options(Rest, Config#config { max_gateway_connections = MaxGatewayConnections });
 parse_options([Opt | _], _) ->
 	{error, unknown, Opt};
 parse_options([], Config) ->

--- a/apps/arweave/src/ar_config.hrl
+++ b/apps/arweave/src/ar_config.hrl
@@ -42,7 +42,9 @@
 	requests_per_minute_limit = ?DEFAULT_REQUESTS_PER_MINUTE_LIMIT,
 	max_propagation_peers = ?DEFAULT_MAX_PROPAGATION_PEERS,
 	ipfs_pin = false,
-	webhooks = []
+	webhooks = [],
+	max_connections = 1024,
+	max_gateway_connections = 128
 }).
 
 -endif.

--- a/apps/arweave/test/ar_config_tests.erl
+++ b/apps/arweave/test/ar_config_tests.erl
@@ -52,7 +52,9 @@ parse_config() ->
 				url = <<"https://example.com/hook">>,
 				headers = [{<<"Authorization">>, <<"Bearer 123456">>}]
 			}
-		]
+		],
+		max_connections = 512,
+		max_gateway_connections = 64
 	}, ParsedConfig).
 
 config_fixture() ->

--- a/apps/arweave/test/ar_config_tests_config_fixture.json
+++ b/apps/arweave/test/ar_config_tests_config_fixture.json
@@ -55,5 +55,7 @@
         "Authorization": "Bearer 123456"
       }
     }
-  ]
+  ],
+  "max_connections": 512,
+  "max_gateway_connections": 64
 }

--- a/bin/check-nofile
+++ b/bin/check-nofile
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+limit="$(ulimit -n)"
+recommendation="10000"
+
+if [ "$limit" -lt "$recommendation" ]; then
+  echo "WARN: ************************************************************************"
+  echo "WARN: Your maximum number of open file descriptors is currently set to $limit."
+  echo "WARN: We recommend setting that limit to $recommendation or higher."
+  echo "WARN: "
+  echo "WARN: Otherwise, consider setting your max_connections setting to something"
+  echo "WARN: lower than your file descriptor limit."
+  echo "WARN: ************************************************************************"
+  echo
+fi

--- a/bin/start-dev
+++ b/bin/start-dev
@@ -5,6 +5,8 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 cd "$SCRIPT_DIR/.."
 
+bin/check-nofile
+
 echo Building dependencies...
 ./rebar3 compile
 

--- a/rebar.config
+++ b/rebar.config
@@ -32,6 +32,7 @@
 	{overlay, [
 		{copy, "scripts/start", "bin/start"},
 		{copy, "bin/logs", "bin/logs"},
+		{copy, "bin/check-nofile", "bin/check-nofile"},
 		{copy, "data/not_found.html", "data/not_found.html"},
 		{copy, "data/genesis_wallets.csv", "data/genesis_wallets.csv"},
 		{copy, "data/genesis_txs", "data/genesis_txs"}

--- a/scripts/start
+++ b/scripts/start
@@ -3,6 +3,9 @@
 set -e
 
 SCRIPT_DIR="$(dirname "$0")"
+cd "$SCRIPT_DIR/.."
+
+bin/check-nofile
 
 if [ $# -gt 0 ] && [ `uname -s` == "Darwin" ]; then
     RANDOMX_JIT="disable randomx_jit"
@@ -15,7 +18,7 @@ export ERL_EPMD_ADDRESS=127.0.0.1
 while true; do
     echo Launching Erlang Virtual Machine...
     if
-        "$SCRIPT_DIR/arweave" foreground -run ar main $RANDOMX_JIT "$@"
+        "bin/arweave" foreground -run ar main $RANDOMX_JIT "$@"
     then
         echo "Arweave Heartbeat: Server terminated safely."
         exit 0


### PR DESCRIPTION
This PR allows configuring the maximum number of concurrent connections for both the node API listener and the gateway listener.

The current defaults are:
- `max_connections`: 1024
- `max_gateway_connections`: 128

The gateway listener on port 80 whose only purpose is to redirect to port 443 has a constant number of maximum connections currently set to 10.

The startup script will also warn if `ulimit -n` returns less than 10000.