### PR TITLE
Reconstruct hash list in polling mode efficiently

### DIFF
--- a/apps/arweave/src/apps/app_block_tx_export.erl
+++ b/apps/arweave/src/apps/app_block_tx_export.erl
@@ -210,7 +210,7 @@ reward_pool(S, B) ->
 	reward_pool(S, B, PreviousB).
 
 reward_pool(S, B, PreviousB) ->
-	PreviousRecallBH = ar_node_utils:find_recall_hash(PreviousB, S#state.bhl),
+	PreviousRecallBH = ar_util:get_recall_hash(PreviousB, S#state.bhl),
 	{ok, PreviousRecallB} = get_block(PreviousRecallBH, S#state.bhl, S#state.peers),
 	FullB = full_block(B, S#state.peers),
 	reward_pool1(FullB, PreviousB, PreviousRecallB).

--- a/apps/arweave/src/ar_bridge.erl
+++ b/apps/arweave/src/ar_bridge.erl
@@ -4,7 +4,7 @@
 -export([add_remote_peer/2, add_local_peer/2]).
 -export([get_remote_peers/1, set_remote_peers/2]).
 -export([start_link/1]).
--export([ignore_id/1, is_id_ignored/1]).
+-export([ignore_id/1, unignore_id/1, is_id_ignored/1]).
 -export([drop_waiting_txs/2]).
 -include("ar.hrl").
 
@@ -112,6 +112,9 @@ add_local_peer(PID, Node) ->
 %% @doc Ignore messages matching the given ID.
 ignore_id(ID) ->
 	ets:insert(ignored_ids, {ID, ignored}).
+
+unignore_id(ID) ->
+	ets:delete_object(ignored_ids, {ID, ignored}).
 
 %% @doc Schedule a message timer.
 reset_timer(PID, get_more_peers) ->

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -1241,7 +1241,7 @@ validate_get_block_type_id(<<"height">>, ID) ->
 validate_get_block_type_id(<<"hash">>, ID) ->
 	case ar_util:safe_decode(ID) of
 		{ok, Hash} -> {ok, Hash};
-		invalid    -> {error, {400, #{}, <<"Invalid hash.">>}}
+		{error, invalid} -> {error, {400, #{}, <<"Invalid hash.">>}}
 	end.
 
 %% @doc Take a block type specifier, an ID, and a BHL, returning whether the

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -467,7 +467,7 @@ generate_block_from_shadow(StateIn, BShadow, Recall, TXs, NewHashList, Peer) ->
 	{RecallIndepHash, Key, Nonce} = case Recall of
 		no_recall ->
 			{
-				ar_util:get_recall_hash(BShadow#block.previous_block, NewHashList),
+				ar_util:get_recall_hash(BShadow#block.previous_block, BShadow#block.height - 1, NewHashList),
 				<<>>,
 				<<>>
 			};
@@ -476,7 +476,7 @@ generate_block_from_shadow(StateIn, BShadow, Recall, TXs, NewHashList, Peer) ->
 	end,
 	MaybeRecallB = case ar_block:get_recall_block(Peer, RecallIndepHash, NewHashList, Key, Nonce) of
 		unavailable ->
-			RecallHash = ar_node_utils:find_recall_hash(BShadow, HashList),
+			RecallHash = ar_util:get_recall_hash(BShadow, HashList),
 			FetchedRecallB = ar_node_utils:get_full_block(Peer, RecallHash, HashList),
 			case ?IS_BLOCK(FetchedRecallB) of
 				true ->

--- a/apps/arweave/src/ar_poller.erl
+++ b/apps/arweave/src/ar_poller.erl
@@ -90,19 +90,16 @@ poll_block_step(check_ignore_list, {Peer, BShadow}) ->
 			{error, block_already_received};
 		false ->
 			ar_bridge:ignore_id(BShadow#block.indep_hash),
-			poll_block_step(check_hash_list, {Peer, BShadow})
+			poll_block_step(construct_hash_list, {Peer, BShadow})
 	end;
-poll_block_step(check_hash_list, {Peer, BShadow}) ->
+poll_block_step(construct_hash_list, {Peer, BShadow}) ->
 	{ok, BlockTXsPairs} = ar_node:get_block_txs_pairs(whereis(http_entrypoint_node)),
 	HL = lists:map(fun({BH, _}) -> BH end, BlockTXsPairs),
-	PrevH = BShadow#block.previous_block,
-	case HL of
-		[PrevH | _] ->
-			poll_block_step(accept_block, {Peer, BShadow#block{ hash_list = HL }});
-		_ ->
-			PeerHL = ar_http_iface_client:get_hash_list(Peer),
-			BlockHL = reconstruct_block_hash_list(BShadow#block.indep_hash, PeerHL),
-			poll_block_step(accept_block, {Peer, BShadow#block{ hash_list = BlockHL }})
+	case reconstruct_block_hash_list(Peer, BShadow, HL) of
+		{ok, BHL} ->
+			poll_block_step(accept_block, {Peer, BShadow#block{ hash_list = BHL }});
+		{error, _} = Error ->
+			Error
 	end;
 poll_block_step(accept_block, {Peer, BShadow}) ->
 	Node = whereis(http_entrypoint_node),
@@ -110,9 +107,21 @@ poll_block_step(accept_block, {Peer, BShadow}) ->
 	Node ! {new_block, Peer, BShadowHeight, BShadow, no_data_segment, no_recall},
 	ok.
 
-reconstruct_block_hash_list(_H, []) ->
-	{error, failed_to_reconstruct_block_hash_list};
-reconstruct_block_hash_list(H, [H | Rest]) ->
-	lists:sublist(Rest, ?STORE_BLOCKS_BEHIND_CURRENT);
-reconstruct_block_hash_list(H, [_ | HL]) ->
-	reconstruct_block_hash_list(H, HL).
+reconstruct_block_hash_list(Peer, BShadow, HL) ->
+	reconstruct_block_hash_list(Peer, BShadow, HL, []).
+
+reconstruct_block_hash_list(Peer, BShadow, HL, BHL) ->
+	PrevH = BShadow#block.previous_block,
+	case HL of
+		[PrevH | _] = L ->
+			{ok, lists:reverse(BHL) ++ L};
+		[_ | HLTail] ->
+			case ar_http_iface_client:get_block_shadow([Peer], PrevH) of
+				unavailable ->
+					{error, previous_block_not_found};
+				{_, PrevBShadow} ->
+					reconstruct_block_hash_list(Peer, PrevBShadow, HLTail, [PrevH | BHL])
+			end;
+		[] ->
+			{error, failed_to_reconstruct_block_hash_list}
+	end.

--- a/apps/arweave/src/ar_poller.erl
+++ b/apps/arweave/src/ar_poller.erl
@@ -4,6 +4,7 @@
 -export([start_link/1]).
 -export([init/1]).
 -export([handle_cast/2, handle_call/3]).
+-export([handle_info/2]).
 
 -include("ar.hrl").
 
@@ -65,6 +66,14 @@ handle_cast(poll_block, State) ->
 	{noreply, NewState}.
 
 handle_call(_Request, _From, State) ->
+	{noreply, State}.
+
+handle_info(_Info, State) ->
+	%% Ignore unexpected messages. Some unexpected messages are received
+	%% during startup (and sometimes later on) from ar_node
+	%% after the get function times out, but the reply still arrives then.
+	%% This handler only avoids a few warnings in the logs -
+	%% the ar_node functions have to be changed to address the problem.
 	{noreply, State}.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_weave.erl
+++ b/apps/arweave/src/ar_weave.erl
@@ -2,7 +2,6 @@
 -export([init/0, init/1, init/2, init/3, add/1, add/2, add/3, add/4, add/6, add/7, add/11]).
 -export([hash/3, indep_hash/1]).
 -export([verify_indep/2]).
--export([calculate_recall_block/2, calculate_recall_block/3]).
 -export([generate_hash_list/1]).
 -export([is_data_on_block_list/2, is_tx_on_block_list/2]).
 -export([create_genesis_txs/0]).
@@ -72,7 +71,7 @@ add(Bs, TXs, HashList) ->
 add(Bs, TXs, HashList, unclaimed) ->
 	add(Bs, TXs, HashList, <<>>);
 add([B|Bs], TXs, HashList, RewardAddr) ->
-	RecallHash = ar_util:get_recall_hash(hd([B|Bs]), HashList),
+	RecallHash = ar_util:get_recall_hash(B, HashList),
 	RecallB = ar_storage:read_block(RecallHash, HashList),
 	{FinderReward, RewardPool} =
 		ar_node_utils:calculate_reward_pool(
@@ -243,17 +242,6 @@ verify_indep(B = #block { height = Height }, HashList) ->
 			]),
 			false
 	end.
-
-%% @doc Generate a recall block number from a block or a hash and block height.
-calculate_recall_block(Hash, HashList) when is_binary(Hash) ->
-	calculate_recall_block(ar_storage:read_block(Hash, HashList), HashList);
-calculate_recall_block(B, HashList) when is_record(B, block) ->
-	case B#block.height of
-		0 -> 0;
-		_ -> calculate_recall_block(B#block.indep_hash, B#block.height, HashList)
-	end.
-calculate_recall_block(IndepHash, Height, _HashList) ->
-	binary:decode_unsigned(IndepHash) rem Height.
 
 %% @doc Create the hash of the next block in the list, given a previous block,
 %% and the TXs and the nonce.

--- a/apps/arweave/test/ar_tx_perpetual_storage_tests.erl
+++ b/apps/arweave/test/ar_tx_perpetual_storage_tests.erl
@@ -271,7 +271,7 @@ updates_pool_and_assigns_rewards_correctly_after_burden() ->
 	BHL2 = wait_until_height(Master, 2),
 	B2 = ar_storage:read_block(hd(BHL2), BHL2),
 	RecallB2 = ar_storage:read_block(
-		ar_weave:calculate_recall_block(hd(BHL1), BHL1),
+		ar_util:get_recall_hash(hd(BHL1), 1, BHL1),
 		BHL1
 	),
 	BaseReward2 = ar_inflation:calculate(2),

--- a/bin/logs
+++ b/bin/logs
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 LOGS_DIR="$(cd $SCRIPT_DIR/../logs && pwd -P)"
 
-ls -t logs \
+ls -t $LOGS_DIR \
     | grep -F -v slave \
     | head -1 \
     | xargs -I % tail "$@" "$LOGS_DIR/%"


### PR DESCRIPTION
In the polling mode, in case the block shadow does not match
the current hash, download preceding shadows until the hashes match.