### PR TITLE
Rollback Erlang IO threads to 1 (the default)

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -1,3 +1,2 @@
 -name 'arweave@127.0.0.1'
 -setcookie arweave
-+A10


### PR DESCRIPTION
10 IO threads lead to an increased memory footprint and did not
display any visible benefits.