### PR TITLE
Remove Warnings

### DIFF
--- a/apps/arweave/src/apps/app_monitor.erl
+++ b/apps/arweave/src/apps/app_monitor.erl
@@ -17,8 +17,3 @@ start() ->
 new_block(B) ->
 	io:format("New block: ~p. Number of transactions: ~p.~n",
 		[B#block.height, length(B#block.txs)]).
-
-%% Report that a new transaction meets our criteria.
-report(T) ->
-	% Log the transaction information to the console.
-	io:format("TX ~p matches selection criteria!~n", [T#tx.id]).

--- a/apps/arweave/src/apps/app_page_archiver.erl
+++ b/apps/arweave/src/apps/app_page_archiver.erl
@@ -95,7 +95,7 @@ archive_multiple_times_test() ->
         Wallet = {_Priv1, Pub1} = ar_wallet:new(),
         Bs = ar_weave:init([{ar_wallet:to_address(Pub1), ?AR(10000), <<>>}]),
         Node1 = ar_node:start([], Bs),
-        Archiver = start(Node1, Wallet, "http://127.0.0.1:1984/info", 1),
+        _ = start(Node1, Wallet, "http://127.0.0.1:1984/info", 1),
         Res = lists:map(
             fun(_) ->
                 ar_node:mine(Node1),
@@ -113,7 +113,7 @@ archive_multiple_urls_at_once_test() ->
         Wallet = {_Priv1, Pub1} = ar_wallet:new(),
         Bs = ar_weave:init([{ar_wallet:to_address(Pub1), ?AR(10000), <<>>}]),
         Node1 = ar_node:start([], Bs),
-        Archiver = start(Node1, Wallet, ["http://127.0.0.1:1984/info", "http://127.0.0.1:1984/info"], 100),
+        _ = start(Node1, Wallet, ["http://127.0.0.1:1984/info", "http://127.0.0.1:1984/info"], 100),
         Res = lists:map(
             fun(_) ->
                 ar_node:mine(Node1),

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -14,6 +14,7 @@
 -export([scale_time/1, timestamp/0]).
 -export([start_link/0, start_link/1, init/1]).
 -export([start_for_tests/0]).
+-export([fixed_diff_option/0, fixed_delay_option/0]).
 
 -include("ar.hrl").
 -include("ar_config.hrl").
@@ -246,7 +247,7 @@ parse_cli_args([Arg|_Rest], _O) ->
 start() -> start(?DEFAULT_HTTP_IFACE_PORT).
 start(Port) when is_integer(Port) -> start(#config { port = Port });
 start(#config { benchmark = true, benchmark_algorithm = Algorithm, max_miners = MaxMiners, disable = Disable, enable = Enable }) ->
-	error_logger:logfile({open, Filename = generate_logfile_name()}),
+	error_logger:logfile({open, generate_logfile_name()}),
 	error_logger:tty(false),
 	ar_meta_db:start(),
 	lists:foreach(fun(Feature) -> ar_meta_db:put(Feature, false) end, Disable),
@@ -554,18 +555,8 @@ tests() ->
 	tests(?CORE_TEST_MODS, #config {}).
 
 tests(Mods, Config) when is_list(Mods) ->
-	case ?DEFAULT_DIFF of
-		X when X > 8 ->
-			ar:report_console(
-				[
-					diff_too_high_for_tests,
-					terminating
-				]
-			);
-		_ ->
-			start_for_tests(Config),
-			eunit:test({timeout, ?TEST_TIMEOUT, Mods}, [verbose])
-	end.
+        start_for_tests(Config),
+        eunit:test({timeout, ?TEST_TIMEOUT, Mods}, [verbose]).
 
 start_for_tests() ->
 	start_for_tests(#config { }).

--- a/apps/arweave/src/ar_bridge.erl
+++ b/apps/arweave/src/ar_bridge.erl
@@ -142,8 +142,8 @@ server(S) ->
 				exit:Term ->
 					ar:report( [ {'BridgeEXIT', Term} ]),
 					server(S);
-				error:Term ->
-					ar:report( [ {'BridgeEXIT', {Term, erlang:get_stacktrace()}} ]),
+				error:Term:Stacktrace ->
+					ar:report( [ {'BridgeEXIT', {Term, Stacktrace}} ]),
 					server(S)
 			end
 	end.

--- a/apps/arweave/src/ar_firewall.erl
+++ b/apps/arweave/src/ar_firewall.erl
@@ -73,7 +73,7 @@ do_scan_and_clean_disk() ->
 				fun(File) ->
 					Filepath = filename:join(TXDir, File),
 					case scan_file(Filepath) of
-						{reject, TXID} ->
+						{reject, _} ->
 							ar:info([
 								{ar_firewall, scan_and_clean_disk},
 								{removing_file, File}

--- a/apps/arweave/src/ar_node.erl
+++ b/apps/arweave/src/ar_node.erl
@@ -641,8 +641,8 @@ server(SPid, WPid, TaskQueue) ->
 				exit:Term ->
 					ar:report([ {'NodeEXIT', Term} ]),
 					server(SPid, WPid, TaskQueue);
-				error:Term ->
-					ar:report([ {'NodeERROR', {Term, erlang:get_stacktrace()}} ]),
+				error:Term:Stacktrace ->
+					ar:report([ {'NodeERROR', {Term, Stacktrace}} ]),
 					server(SPid, WPid, TaskQueue)
 			end
 	end.

--- a/apps/arweave/src/ar_node_state.erl
+++ b/apps/arweave/src/ar_node_state.erl
@@ -105,8 +105,8 @@ server(Tid) ->
 				exit:Term ->
 					ar:report( [ {'NodeStateEXIT', Term} ] ),
 					server(Tid);
-				error:Term ->
-					ar:report( [ {'NodeStateERROR', {Term, erlang:get_stacktrace()} } ]),
+				error:Term:Stacktrace ->
+					ar:report( [ {'NodeStateERROR', {Term, Stacktrace} } ]),
 					server(Tid)
 			end;
 		stop ->

--- a/apps/arweave/src/ar_node_tests.erl
+++ b/apps/arweave/src/ar_node_tests.erl
@@ -4,8 +4,6 @@
 
 -module(ar_node_tests).
 
--compile(export_all).
-
 -include("ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
 

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -67,8 +67,8 @@ server(NPid, SPid) ->
 					ar:err( [ {'NodeWorkerEXIT', Term} ] ),
 					NPid ! {worker, {error, Term}},
 					server(NPid, SPid);
-				error:Term ->
-					ar:err( [ {'NodeWorkerERROR', {Term, erlang:get_stacktrace()} } ]),
+				error:Term:Stacktrace ->
+					ar:err( [ {'NodeWorkerERROR', {Term, Stacktrace} } ]),
 					NPid ! {worker, {error, Term}},
 					server(NPid, SPid)
 			end;

--- a/apps/arweave/src/ar_sim_client.erl
+++ b/apps/arweave/src/ar_sim_client.erl
@@ -93,8 +93,6 @@ server(
 	S = #state {
 		key_file = KeyList,
 		max_tx_len = MaxTXLen,
-		max_data_len = MaxDataLen,
-		action_time = ActionTime,
 		peers = Peers
 	}) ->
 	receive
@@ -238,22 +236,6 @@ create_random_data_tx(KeyList, MaxTxLen) ->
 		),
 	ar_tx:sign(TX#tx{reward = Reward}, Priv, Pub).
 
-create_random_data_tx({Priv, Pub}, MaxTxLen, OldTX) ->
-	% Generate and dispatch a new data transaction.
-	LastTx = OldTX#tx.id,
-	%ar:d({random_data_tx_pub, ar_util:encode(ar_wallet:to_address(Pub))}),
-	Diff = ar_node:get_diff(whereis(http_entrypoint_node)),
-	Data = << 0:(rand:uniform(MaxTxLen) * 8) >>,
-	TX = ar_tx:new(Data, 0, LastTx),
-	Cost = ar_tx:calculate_min_tx_cost(
-		byte_size(ar_tx:tx_to_binary(TX)) + 550,
-		Diff
-		),
-	Reward = Cost + ar_tx:calculate_min_tx_cost(
-		byte_size(<<Cost>>),
-		Diff
-		),
-	ar_tx:sign(TX#tx{reward = Reward}, Priv, Pub).
 %% @doc Create a random financial TX between two wallets of amount MaxAmount
 create_random_fin_tx(KeyList, MaxAmount) ->
 	{Priv, Pub} = lists:nth(rand:uniform(50), KeyList),

--- a/apps/arweave/src/ar_sqlite3.erl
+++ b/apps/arweave/src/ar_sqlite3.erl
@@ -267,7 +267,7 @@ handle_call({select_tags_by_tx_id, TXID}, _, State) ->
 	end,
 	{reply, Reply, State};
 handle_call({eval_legacy_arql, Query}, _, #{ conn := Conn } = State) ->
-	{Time, {Reply, SQL, Params}} = timer:tc(fun() ->
+	{Time, {Reply, _, _}} = timer:tc(fun() ->
 		case catch eval_legacy_arql_where_clause(Query) of
 			{WhereClause, Params} ->
 				SQL = lists:concat([


### PR DESCRIPTION
Propose remove `Warnings` when project building from source:
```sh
apps/arweave/src/apps/app_page_archiver.erl:98: Warning: variable 'Archiver' is unused
apps/arweave/src/apps/app_page_archiver.erl:116: Warning: variable 'Archiver' is unused
apps/arweave/src/ar_node_state.erl:109: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
apps/arweave/src/ar_firewall.erl:76: Warning: variable 'TXID' is unused
apps/arweave/src/ar_node.erl:645: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
apps/arweave/src/apps/app_monitor.erl:22: Warning: function report/1 is unused
apps/arweave/src/ar_sqlite3.erl:270: Warning: variable 'Params' is unused
apps/arweave/src/ar_sqlite3.erl:270: Warning: variable 'SQL' is unused
apps/arweave/src/ar_bridge.erl:146: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
apps/arweave/src/ar.erl:249: Warning: variable 'Filename' is unused
apps/arweave/src/ar.erl:521: Warning: function fixed_diff_option/0 is unused
apps/arweave/src/ar.erl:527: Warning: function fixed_delay_option/0 is unused
apps/arweave/src/ar.erl:558: Warning: the guard for this clause evaluates to 'false'
apps/arweave/src/ar_node_worker.erl:71: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace
apps/arweave/src/ar_sim_client.erl:96: Warning: variable 'MaxDataLen' is unused
apps/arweave/src/ar_sim_client.erl:97: Warning: variable 'ActionTime' is unused
apps/arweave/src/ar_sim_client.erl:241: Warning: function create_random_data_tx/3 is unused
apps/arweave/src/ar_node_tests.erl:7: Warning: export_all flag enabled - all functions will be exported
```