### PR TITLE
Optimize transaction data overhead on HTTP GET /tx/[TXHash] operations

### DIFF
--- a/apps/arweave/src/ar.hrl
+++ b/apps/arweave/src/ar.hrl
@@ -209,6 +209,11 @@
 %% already has this transaction.
 -define(TX_SEND_WITHOUT_ASKING_SIZE_LIMIT, 1000).
 
+%% @doc Transaction data structure format. The main difference is that format 2
+%% doesn't contain transaction data in the #tx{} record. Format 1 has data.
+-define(TX_WITH_DATA_FORMAT, <<"1">>).
+-define(TX_WITHOUT_DATA_FORMAT, <<"2">>).
+
 %% @doc Log output directory
 -define(LOG_DIR, "logs").
 -define(BLOCK_DIR, "blocks").

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -48,7 +48,7 @@ has_tx(Peer, ID) ->
 			<<"GET">>,
 			Peer,
 			"/tx/" ++ binary_to_list(ar_util:encode(ID)) ++ "/id",
-			p2p_headers(),
+			p2p_headers() ++ [{<<"x-tx-format">>, ?TX_WITHOUT_DATA_FORMAT}],
 			[],
 			500,
 			3 * 1000


### PR DESCRIPTION
Not all operations on transactions require it's data to be present.
This change introduces a configurable HTTP header option for
specifying and controlling the type of formatting of the acquired
transaction record. Specifying `"x-tx-format"` header will dictate
whether or not, the retrieved transaction contains the data, or not.
Values can either be `"1"` or `"2"`, indicating whether transaction
data is included in the retrieved record, or not, respectively.

**NOTE:** Some gossip operations should also be further extended to
exclude data overheads as more `ansyc` coordination operations
are introduced in the network. These will be looked at case-by-case. 