### PR TITLE
Reduce the state passed on to mining workers

### DIFF
--- a/apps/arweave/src/ar_mine.erl
+++ b/apps/arweave/src/ar_mine.erl
@@ -488,7 +488,7 @@ server(
 		%% Count the number of hashes tried by all workers.
 		{hashes_tried, HashesTried} ->
 			server(S#state { total_hashes_tried = TotalHashesTried + HashesTried });
-		{solution, Hash, Nonce, MinedTXs, Diff, Timestamp} ->
+		{solution, Hash, Nonce, Timestamp} ->
 			case filter_by_valid_tx_fee(MinedTXs, Diff, Height, WL, Timestamp) of
 				MinedTXs ->
 					process_solution(S, Hash, Nonce, MinedTXs, Diff, Timestamp);
@@ -610,12 +610,29 @@ log_performance(TotalHashesTried, StartedAt) ->
 	]).
 
 %% @doc Start the workers and return the new state.
-start_miners(S = #state {max_miners = MaxMiners}) ->
-	Miners =
-		lists:map(
-			fun(_) -> spawn(?MODULE, mine, [S, self()]) end,
-			lists:seq(1, MaxMiners)
-		),
+start_miners(
+	S = #state{
+		max_miners = MaxMiners,
+		candidate_block = #block{ height = Height },
+		poa = POA,
+		diff = Diff,
+		data_segment = BDS,
+		timestamp = Timestamp
+	}
+) ->
+	ModifiedDiff = case Height >= ar_fork:height_2_0() of
+		true ->
+			ar_poa:modify_diff(Diff, POA#poa.option);
+		false ->
+			Diff
+	end,
+	WorkerState = #{
+		data_segment => BDS,
+		diff => ModifiedDiff,
+		timestamp => Timestamp,
+		height => Height
+	},
+	Miners = [spawn(?MODULE, mine, [WorkerState, self()]) || _ <- lists:seq(1, MaxMiners)],
 	S#state {miners = Miners}.
 
 %% @doc Stop all workers.
@@ -635,25 +652,17 @@ restart_miners(S) ->
 %% @doc A worker process to hash the data segment searching for a solution
 %% for the given diff.
 mine(
-	#state {
-		data_segment = BDS,
-		diff = Diff,
-		poa = POA,
-		txs = TXs,
-		timestamp = Timestamp,
-		current_block = #block{ height = CurrentHeight }
+	#{
+		data_segment := BDS,
+		diff := Diff,
+		timestamp := Timestamp,
+		height := Height
 	},
 	Supervisor
 ) ->
 	process_flag(priority, low),
-	MineDiff = case CurrentHeight + 1 >= ar_fork:height_2_0() of
-		true ->
-			ar_poa:modify_diff(Diff, POA#poa.option);
-		false ->
-			Diff
-	end,
-	{Nonce, Hash} = find_nonce(BDS, MineDiff, CurrentHeight + 1, Supervisor),
-	Supervisor ! {solution, Hash, Nonce, TXs, Diff, Timestamp}.
+	{Nonce, Hash} = find_nonce(BDS, Diff, Height, Supervisor),
+	Supervisor ! {solution, Hash, Nonce, Timestamp}.
 
 find_nonce(BDS, Diff, Height, Supervisor) ->
 	case Height >= ar_fork:height_1_7() of
@@ -818,8 +827,12 @@ start_stop_test() ->
 
 %% @doc Ensures a miner can be started and stopped.
 miner_start_stop_test() ->
-	[B] = ar_weave:init(),
-	S = #state{ diff = trunc(math:pow(2, 1000)), current_block = B },
+	S = #{
+		diff => trunc(math:pow(2, 1000)),
+		timestamp => os:system_time(seconds),
+		data_segment => <<>>,
+		height => 1
+	},
 	PID = spawn(?MODULE, mine, [S, self()]),
 	timer:sleep(500),
 	assert_alive(PID),


### PR DESCRIPTION
Each mining worker currently consumes around 85 MB of heap memory as of the current weave height
of ~400k. On big machines with >20 miners it contributes gigabytes to the memory footprint.
The commit reduces this amount substantially.