### PR TITLE
Upgrade RandomX to v1.1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ For more information, refer to the [mining guide](https://docs.arweave.org/info/
 - Erlang OTP v21+
 - GCC or Clang
 - GNU Make
+- CMake
 - SQLite3 headers (libsqlite3-dev on Ubuntu)
 
 ```shell script

--- a/apps/arweave/c_src/Makefile
+++ b/apps/arweave/c_src/Makefile
@@ -34,7 +34,7 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I ../lib/RandomX/src
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I ../lib/RandomX/src
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei ../lib/RandomX/bin/randomx.a
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei ../lib/RandomX/build/librandomx.a
 LDFLAGS += -shared
 
 # Verbosity.

--- a/apps/arweave/c_src/ar_mine_randomx.c
+++ b/apps/arweave/c_src/ar_mine_randomx.c
@@ -10,7 +10,7 @@ static ErlNifFunc nif_funcs[] = {
 	{"init_light_nif", 3, init_light_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 	{"hash_fast_nif", 5, hash_fast_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 	{"hash_light_nif", 5, hash_light_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
-	{"bulk_hash_fast_nif", 7, bulk_hash_fast_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
+	{"bulk_hash_fast_nif", 8, bulk_hash_fast_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND},
 	{"release_state_nif", 1, release_state_nif, ERL_NIF_DIRTY_JOB_CPU_BOUND}
 };
 
@@ -291,42 +291,49 @@ static ERL_NIF_TERM bulk_hash_fast_nif(ErlNifEnv* envPtr, int argc, const ERL_NI
 	randomx_flags flags;
 	char hashPtr[RANDOMX_HASH_SIZE];
 	struct state* statePtr;
-	ErlNifBinary nonceBinary, inputData, difficulty;
+	ErlNifBinary firstNonceBinary, secondNonceBinary, inputData, difficulty;
 	char nonce[RANDOMX_HASH_SIZE];
+	char prevNonce[RANDOMX_HASH_SIZE];
 	char segment[RANDOMX_HASH_SIZE + ARWEAVE_INPUT_DATA_SIZE];
 	int hashesTried;
 
-	if (argc != 7) {
+	if (argc != 8) {
 		return enif_make_badarg(envPtr);
 	}
 	if (!enif_get_resource(envPtr, argv[0], stateType, (void**) &statePtr)) {
 		return error(envPtr, "failed to read state");
 	}
-	if (!enif_inspect_binary(envPtr, argv[1], &nonceBinary)) {
+	if (!enif_inspect_binary(envPtr, argv[1], &firstNonceBinary)) {
 		return enif_make_badarg(envPtr);
 	}
-	if (nonceBinary.size != RANDOMX_HASH_SIZE) {
+	if (firstNonceBinary.size != RANDOMX_HASH_SIZE) {
 		return enif_make_badarg(envPtr);
 	}
-	if (!enif_inspect_binary(envPtr, argv[2], &inputData)) {
+	if (!enif_inspect_binary(envPtr, argv[2], &secondNonceBinary)) {
+		return enif_make_badarg(envPtr);
+	}
+	if (secondNonceBinary.size != RANDOMX_HASH_SIZE) {
+		return enif_make_badarg(envPtr);
+	}
+	if (!enif_inspect_binary(envPtr, argv[3], &inputData)) {
 		return enif_make_badarg(envPtr);
 	}
 	if (inputData.size != ARWEAVE_INPUT_DATA_SIZE) {
 		return enif_make_badarg(envPtr);
 	}
-	if (!enif_inspect_binary(envPtr, argv[3], &difficulty)) {
+	if (!enif_inspect_binary(envPtr, argv[4], &difficulty)) {
 		return enif_make_badarg(envPtr);
 	}
 	if (difficulty.size != RANDOMX_HASH_SIZE) {
 		return enif_make_badarg(envPtr);
 	}
-	if (!enif_get_int(envPtr, argv[4], &jitEnabled)) {
+	if (!enif_get_int(envPtr, argv[5], &jitEnabled)) {
 		return enif_make_badarg(envPtr);
 	}
-	if (!enif_get_int(envPtr, argv[5], &largePagesEnabled)) {
+	if (!enif_get_int(envPtr, argv[6], &largePagesEnabled)) {
 		return enif_make_badarg(envPtr);
 	}
-	if (!enif_get_int(envPtr, argv[6], &hardwareAESEnabled)) {
+	if (!enif_get_int(envPtr, argv[7], &hardwareAESEnabled)) {
 		return enif_make_badarg(envPtr);
 	}
 
@@ -351,24 +358,36 @@ static ERL_NIF_TERM bulk_hash_fast_nif(ErlNifEnv* envPtr, int argc, const ERL_NI
 		enif_rwlock_runlock(statePtr->lockPtr);
 		return error(envPtr, "randomx_create_vm failed");
 	}
-	memcpy(nonce, nonceBinary.data, RANDOMX_HASH_SIZE);
+	memcpy(nonce, firstNonceBinary.data, RANDOMX_HASH_SIZE);
 	memcpy(segment, nonce, RANDOMX_HASH_SIZE);
 	memcpy(segment + RANDOMX_HASH_SIZE, inputData.data, ARWEAVE_INPUT_DATA_SIZE);
+
+	randomx_calculate_hash_first(vmPtr, segment, RANDOMX_HASH_SIZE + ARWEAVE_INPUT_DATA_SIZE);
 	for (int i = 0; i < BULK_HASHING_ITERATIONS; i++) {
-		randomx_calculate_hash(vmPtr, segment, RANDOMX_HASH_SIZE + ARWEAVE_INPUT_DATA_SIZE, hashPtr);
+		memcpy(prevNonce, nonce, RANDOMX_HASH_SIZE);
+		if (i == 0) {
+			memcpy(nonce, secondNonceBinary.data, RANDOMX_HASH_SIZE);
+		} else {
+			memcpy(nonce, hashPtr, RANDOMX_HASH_SIZE);
+		}
+		if (i == BULK_HASHING_ITERATIONS - 1) {
+			randomx_calculate_hash_last(vmPtr, hashPtr);
+		} else {
+			memcpy(segment, nonce, RANDOMX_HASH_SIZE);
+			memcpy(segment + RANDOMX_HASH_SIZE, inputData.data, ARWEAVE_INPUT_DATA_SIZE);
+			randomx_calculate_hash_next(vmPtr, segment, RANDOMX_HASH_SIZE + ARWEAVE_INPUT_DATA_SIZE, hashPtr);
+		}
 		hashesTried = i + 1;
 		if (validate_hash(hashPtr, difficulty.data) > 0) {
 			break;
 		}
-		memcpy(nonce, hashPtr, RANDOMX_HASH_SIZE);
-		memcpy(segment, nonce, RANDOMX_HASH_SIZE);
-		memcpy(segment + RANDOMX_HASH_SIZE, inputData.data, ARWEAVE_INPUT_DATA_SIZE);
 	}
 	randomx_destroy_vm(vmPtr);
 	enif_rwlock_runlock(statePtr->lockPtr);
-	return ok_tuple3(
+	return ok_tuple4(
 		envPtr,
 		make_output_binary(envPtr, hashPtr, RANDOMX_HASH_SIZE),
+		make_output_binary(envPtr, prevNonce, RANDOMX_HASH_SIZE),
 		make_output_binary(envPtr, nonce, RANDOMX_HASH_SIZE),
 		enif_make_int(envPtr, hashesTried)
 	);
@@ -399,9 +418,9 @@ static ERL_NIF_TERM ok_tuple(ErlNifEnv* envPtr, ERL_NIF_TERM term)
 	return enif_make_tuple2(envPtr, enif_make_atom(envPtr, "ok"), term);
 }
 
-static ERL_NIF_TERM ok_tuple3(ErlNifEnv* envPtr, ERL_NIF_TERM term1, ERL_NIF_TERM term2, ERL_NIF_TERM term3)
+static ERL_NIF_TERM ok_tuple4(ErlNifEnv* envPtr, ERL_NIF_TERM term1, ERL_NIF_TERM term2, ERL_NIF_TERM term3, ERL_NIF_TERM term4)
 {
-	return enif_make_tuple4(envPtr, enif_make_atom(envPtr, "ok"), term1, term2, term3);
+	return enif_make_tuple5(envPtr, enif_make_atom(envPtr, "ok"), term1, term2, term3, term4);
 }
 
 static ERL_NIF_TERM error_tuple(ErlNifEnv* envPtr, ERL_NIF_TERM term)

--- a/apps/arweave/c_src/ar_mine_randomx.h
+++ b/apps/arweave/c_src/ar_mine_randomx.h
@@ -24,7 +24,7 @@ struct state {
 };
 
 const int ARWEAVE_INPUT_DATA_SIZE = 48;
-const int BULK_HASHING_ITERATIONS = 8;
+const int BULK_HASHING_ITERATIONS = 12;
 
 static int load(ErlNifEnv*, void**, ERL_NIF_TERM);
 static void state_dtor(ErlNifEnv*, void*);
@@ -46,7 +46,7 @@ static ERL_NIF_TERM bulk_hash_fast_nif(ErlNifEnv*, int, const ERL_NIF_TERM []);
 static ERL_NIF_TERM release_state_nif(ErlNifEnv*, int, const ERL_NIF_TERM []);
 
 static ERL_NIF_TERM ok_tuple(ErlNifEnv*, ERL_NIF_TERM);
-static ERL_NIF_TERM ok_tuple3(ErlNifEnv*, ERL_NIF_TERM, ERL_NIF_TERM, ERL_NIF_TERM);
+static ERL_NIF_TERM ok_tuple4(ErlNifEnv*, ERL_NIF_TERM, ERL_NIF_TERM, ERL_NIF_TERM, ERL_NIF_TERM);
 static ERL_NIF_TERM error_tuple(ErlNifEnv*, ERL_NIF_TERM);
 static ERL_NIF_TERM error(ErlNifEnv*, const char*);
 static ERL_NIF_TERM make_output_binary(ErlNifEnv*, char*, size_t);

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -59,6 +59,7 @@
 		ar_tx_perpetual_storage_tests,
 		ar_gateway_middleware_tests,
 		ar_http_util_tests,
+		ar_mine_randomx_tests,
 		% ar_meta_db must be the last in the list since it resets global configuration
 		ar_meta_db
 	]

--- a/apps/arweave/test/ar_mine_randomx_tests.erl
+++ b/apps/arweave/test/ar_mine_randomx_tests.erl
@@ -1,0 +1,31 @@
+-module(ar_mine_randomx_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ENCODED_KEY, <<"UbkeSd5Det8s6uLyuNJwCDFOZMQFa2zvsdKJ0k694LM">>).
+-define(ENCODED_HASH, <<"QQYWA46qnFENL4OTQdGU8bWBj5OKZ2OOPyynY3izung">>).
+-define(ENCODED_NONCE, <<"f_z7RLug8etm3SrmRf-xPwXEL0ZQ_xHng2A5emRDQBw">>).
+-define(ENCODED_SEGMENT,
+    <<"7XM3fgTCAY2GFpDjPZxlw4yw5cv8jNzZSZawywZGQ6_Ca-JDy2nX_MC2vjrIoDGp">>
+).
+-define(ENCODED_TENTH_HASH, <<"DmwCVUMtDnUCwxcTClAOhNjxk1am6030OwGDSHfaOh4">>).
+
+randomx_backwards_compatibility_test_() ->
+    {timeout, 240, fun test_randomx_backwards_compatibility/0}.
+
+test_randomx_backwards_compatibility() ->
+    Key = ar_util:decode(?ENCODED_KEY), 
+    {ok, State} = ar_mine_randomx:init_fast_nif(Key, 0, 0, 4),
+    ExpectedHash = ar_util:decode(?ENCODED_HASH),
+    Nonce = ar_util:decode(?ENCODED_NONCE),
+    Segment = ar_util:decode(?ENCODED_SEGMENT),
+    Input = << Nonce/binary, Segment/binary >>,
+    {ok, Hash} = ar_mine_randomx:hash_fast_nif(State, Input, 0, 0, 0),
+    ?assertEqual(ExpectedHash, Hash),
+    Diff = binary:encode_unsigned(ar_mine:max_difficulty() - 1, big),
+    {ok, _, TenthHash, _, _} =
+        ar_mine_randomx:bulk_hash_fast_nif(State, Nonce, Nonce, Segment, Diff, 0, 0, 0),
+    ExpectedTenthHash = ar_util:decode(?ENCODED_TENTH_HASH),
+    ?assertEqual(ExpectedTenthHash, TenthHash),
+    {ok, LightState} = ar_mine_randomx:init_light_nif(Key, 0, 0),
+    ?assertEqual({ok, ExpectedHash}, ar_mine_randomx:hash_light_nif(LightState, Input, 0, 0, 0)).

--- a/rebar.config
+++ b/rebar.config
@@ -44,13 +44,13 @@
 ]}.
 
 {pre_hooks, [
-	{"(linux)", compile, "env AR=gcc-ar make -C apps/arweave/lib/RandomX"},
-	{"(darwin)", compile, "make -C apps/arweave/lib/RandomX"},
+	{"(linux|darwin)", compile, "bash -c \"mkdir -p apps/arweave/lib/RandomX/build && cd apps/arweave/lib/RandomX/build && cmake .. > /dev/null\""},
+	{"(linux|darwin)", compile, "make -C apps/arweave/lib/RandomX/build"},
 	{"(linux)", compile, "env AR=gcc-ar make -C apps/arweave/c_src"},
 	{"(darwin)", compile, "make -C apps/arweave/c_src"}
 ]}.
 {post_hooks, [
-	{"(linux|darwin)", clean, "make -C apps/arweave/lib/RandomX clean"},
+	{"(linux|darwin)", clean, "bash -c \"if [ -d apps/arweave/lib/RandomX/build ]; then make -C apps/arweave/lib/RandomX/build clean; fi\""},
 	{"(linux|darwin)", clean, "make -C apps/arweave/c_src clean"}
 ]}.
 


### PR DESCRIPTION
v1.1.7 is the latest version of RandomX, which contains major performance improvements (up to 20%).

The commit includes a test for the RandomX compatibility, which can be used in the future
compatible upgrades.

bulk_hash_fast_nif was switched to the new RandomX API, functions calculate_hash_first,
calculate_hash_next, and calculate_hash_last, which provide the main perfomance increase.