### PR TITLE
WIP: Implement data sync server initialization and processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ apps/arweave/c_src/*.o
 data_test_master
 data_test_slave
 erl_crash.dump
+rocksdb
+kv-tx-index
+kv-data-sync
+kv-tx-root-index
+kv-block-offset-index

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -46,6 +46,7 @@
 		ar_retarget,
 		ar_weave,
 		ar_join,
+		ar_data_sync_tests,
 		ar_poa_tests,
 		ar_node_tests,
 		ar_fork_recovery,

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -242,6 +242,8 @@ parse_cli_args(["max_gateway_connections", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config { max_gateway_connections = list_to_integer(Num) });
 parse_cli_args(["max_poa_option_depth", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config { max_poa_option_depth = list_to_integer(Num) });
+parse_cli_args(["kv_engine", KVEngine | Rest], C) ->
+	parse_cli_args(Rest, C#config { kv_engine = list_to_atom(KVEngine) });
 parse_cli_args([Arg|_Rest], _O) ->
 	io:format("~nUnknown argument: ~s.~n", [Arg]),
 	show_help().
@@ -292,7 +294,8 @@ start(
 		webhooks = WebhookConfigs,
 		max_connections = MaxConnections,
 		max_gateway_connections = MaxGatewayConnections,
-		max_poa_option_depth = MaxPOAOptionDepth
+		max_poa_option_depth = MaxPOAOptionDepth,
+		kv_engine = KVEngine
 	}) ->
 	%% Start the logging system.
 	filelib:ensure_dir(?LOG_DIR ++ "/"),
@@ -323,6 +326,7 @@ start(
 	ar_meta_db:put(requests_per_minute_limit, RequestsPerMinuteLimit),
 	ar_meta_db:put(max_propagation_peers, MaxPropagationPeers),
 	ar_meta_db:put(max_poa_option_depth, MaxPOAOptionDepth),
+	ar_meta_db:put(kv_engine, KVEngine),
 	%% Prepare the storage for operation.
 	ar_storage:start(),
 	%% Optionally clear the block cache.

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -242,8 +242,6 @@ parse_cli_args(["max_gateway_connections", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config { max_gateway_connections = list_to_integer(Num) });
 parse_cli_args(["max_poa_option_depth", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config { max_poa_option_depth = list_to_integer(Num) });
-parse_cli_args(["kv_engine", KVEngine | Rest], C) ->
-	parse_cli_args(Rest, C#config { kv_engine = list_to_atom(KVEngine) });
 parse_cli_args([Arg|_Rest], _O) ->
 	io:format("~nUnknown argument: ~s.~n", [Arg]),
 	show_help().
@@ -294,8 +292,7 @@ start(
 		webhooks = WebhookConfigs,
 		max_connections = MaxConnections,
 		max_gateway_connections = MaxGatewayConnections,
-		max_poa_option_depth = MaxPOAOptionDepth,
-		kv_engine = KVEngine
+		max_poa_option_depth = MaxPOAOptionDepth
 	}) ->
 	%% Start the logging system.
 	filelib:ensure_dir(?LOG_DIR ++ "/"),
@@ -326,7 +323,7 @@ start(
 	ar_meta_db:put(requests_per_minute_limit, RequestsPerMinuteLimit),
 	ar_meta_db:put(max_propagation_peers, MaxPropagationPeers),
 	ar_meta_db:put(max_poa_option_depth, MaxPOAOptionDepth),
-	ar_meta_db:put(kv_engine, KVEngine),
+	ar_meta_db:put(kv_engine, ar_kv_rocksdb),
 	%% Prepare the storage for operation.
 	ar_storage:start(),
 	%% Optionally clear the block cache.

--- a/apps/arweave/src/ar.hrl
+++ b/apps/arweave/src/ar.hrl
@@ -326,6 +326,7 @@
 -define(MAX_PATH_SIZE, (256 * 1024)).
 %% @doc The size of data chunk hashes, in bytes.
 -define(CHUNK_ID_HASH_SIZE, 32).
+-define(NOTE_SIZE, 32).
 
 %% @doc A succinct proof of access to a recall byte found in a TX.
 -record(poa, {

--- a/apps/arweave/src/ar_block.erl
+++ b/apps/arweave/src/ar_block.erl
@@ -93,11 +93,8 @@ generate_size_tagged_tx_ids(TXs) ->
 			2,
 			lists:foldl(
 				fun(TX = #tx{id = TXID}, {Pos, List}) ->
-						End = Pos + get_tx_data_size(TX),
-						{End, [{TXID, End} | List]};
-				   (TXID, {Pos, List}) when is_binary(TXID) ->
-						End = Pos + get_tx_data_size(TXID),
-						{End, [{TXID, End} | List]}
+					End = Pos + TX#tx.data_size,
+					{End, [{TXID, End} | List]}
 				end,
 				{0, []},
 				TXs
@@ -460,20 +457,6 @@ get_tx_data_root(#tx{ format = 2, data_root = DataRoot }) ->
 	DataRoot;
 get_tx_data_root(TX) ->
 	(ar_tx:generate_chunk_tree(TX))#tx.data_root.
-
-get_tx_data_size(#tx{ format = 1, data_size = DataSize }) when DataSize > 0 ->
-	DataSize;
-get_tx_data_size(#tx{ format = 2, data_size = DataSize, id = ID }) when DataSize > 0 ->
-	case filelib:is_file(ar_storage:tx_data_filepath(ID)) of
-		true ->
-			DataSize;
-		false ->
-			{error, not_found}
-	end;
-get_tx_data_size(#tx{ id = ID, data_size = 0 }) ->
-	get_tx_data_size(ID);
-get_tx_data_size(ID) when is_binary(ID) ->
-	(ar_storage:read_tx(ID))#tx.data_size.
 
 %% @doc Verify the block timestamp is not too far in the future nor too far in
 %% the past. We calculate the maximum reasonable clock difference between any

--- a/apps/arweave/src/ar_config.hrl
+++ b/apps/arweave/src/ar_config.hrl
@@ -43,7 +43,8 @@
 	webhooks = [],
 	max_connections = 1024,
 	max_gateway_connections = 128,
-	max_poa_option_depth = 8
+	max_poa_option_depth = 8,
+	kv_engine = ar_kv_rocksdb
 }).
 
 -endif.

--- a/apps/arweave/src/ar_config.hrl
+++ b/apps/arweave/src/ar_config.hrl
@@ -43,8 +43,7 @@
 	webhooks = [],
 	max_connections = 1024,
 	max_gateway_connections = 128,
-	max_poa_option_depth = 8,
-	kv_engine = ar_kv_rocksdb
+	max_poa_option_depth = 8
 }).
 
 -endif.

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -42,7 +42,7 @@ add_chunk(ChunkID, Chunk, Offset, #poa{ tx_path = TXPath } = POA) ->
 add_chunk(ChunkID, Chunk, Offset, TXRoot, POA) ->
 	%% If TXRoot is not in #sync_tip.block_offset_by_tx_root and
 	%% not in #state.block_offset_index, return {error, tx_root_not_found}.
-	%% The global offset for the chunk is Offset + BlockOffset.
+	%% The global offset for the chunk is Offset + BlockStartOffset.
 	case validate_proof(POA, TXRoot, Offset) of
 		invalid ->
 			{error, invalid_proof};
@@ -77,9 +77,9 @@ get_tx_data(TXID) ->
 	%%   If not, return tx data.
 	ok.
 
-%% Pick a random [start, end) half-closed interval of
+%% Pick a random (start, end] half-closed interval of
 %% ?SYNC_CHUNK_SIZE or smaller which is not synced and sync it. The
-%% intervals are chosen from [0, confirmed weave size).
+%% intervals are chosen from (0, confirmed weave size].
 sync_random_chunk() ->
 	%% Pick a random not synced interval =< ?SYNC_CHUNK_SIZE.
 

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -1,0 +1,77 @@
+-module(ar_data_sync).
+-behaviour(gen_server).
+
+-export([start_link/1]).
+
+-export([add_block/4, add_chunk/3, get_chunk/1, get_tx_data/1]).
+
+-include("ar_data_sync.hrl").
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+start_link(Args) ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
+
+add_block(TXRoot, Height, SizeTaggedTXIDs, WeaveSize) ->
+	%% Updates
+	%% - #state.sync_tip:
+	%%   - tx_roots_by_height
+	%%   - confirmed_height (if unconfirmed_tx_roots grows enough)
+	%%   - confirmed_tx_root (if unconfirmed_tx_roots grows enough)
+	%%   - unconfirmed_tx_roots
+	%%   - size_tagged_tx_ids_by_tx_root (if maintain_tx_index is true)
+	%% - #state.confirmed_size
+	%% - #state.sync_record (if #sync_tip.confirmed_height is advanced)
+	%% - #state.tx_root_index (if #sync_tip.confirmed_height is advanced)
+	%% - #state.chunk_index (if #sync_tip.confirmed_height is advanced & there are new chunks)
+	%% - #state.tx_index (if #sync_tip.confirmed_height is advanced & there are new txs)
+	ok.
+
+add_chunk(ChunkID, Chunk, Proof) ->
+	%% If the transaction root (part of the proof) is found in
+	%% #sync_tip.unconfirmed_tx_roots, update sync_tip:
+	%% - chunk_ids_by_tx_root
+	%% - tx_roots_with_proofs_by_chunk_id
+	%% - chunk_ids_by_tx_id (if maintain_tx_index is true)
+	%% - size_tagged_tx_ids_by_tx_root (if maintain_tx_index is true)
+	%% Else if the transaction root is found in #state.tx_root_index, update:
+	%% - #state.sync_record
+	%% - #state.chunks_index
+	%% Otherwise return {error, tx_root_not_found}.
+	ok.
+
+get_chunk(Offset) ->
+	%% Look if the offset is synced in #state.sync_record.
+	%% If yes, fetch the chunk with its proof from #state.chunk_index.
+	%% If not, return {error, chunk_not_found}.
+	ok.
+
+get_tx_data(TXID) ->
+	%% Look if there are chunk identifiers in #sync_tip.chunk_ids_by_tx_id.
+	%% If yes, try to reconstruct the transaction data.
+	%%   If chunks are missing, return {error, tx_data_not_found}.
+	%%   If not, return tx data.
+	%% If not, look for the tx offset in #state.tx_index.
+	%%   If present, try to reconstruct tx data by fetching chunks by offset
+	%%   from state#chunk_index.
+	%%   If chunks are missing, return {error, tx_data_not_found}.
+	%%   If not, return tx data.
+	ok.
+
+%% Pick a random [start, end) half-closed interval of
+%% ?SYNC_CHUNK_SIZE which is not synced and sync it. The
+%% intervals are chosen from [0, confirmed weave size).
+sync_random_chunk() ->
+	ok.
+
+%%%===================================================================
+%%% Generic server callbacks.
+%%%===================================================================
+
+init(#{ block_index := BI, maintain_tx_index := MaintainTXIndex }) ->
+	%% Load state from disk, if any, otherwise construct it from the
+	%% block index. Store the new state.
+	State = #state{},
+	{ok, State}.

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -32,12 +32,13 @@ add_block(TXRoot, Height, SizeTaggedTXIDs, WeaveSize) ->
 
 add_chunk(ChunkID, Chunk, Proof) ->
 	%% If the transaction root (part of the proof) is found in
-	%% #sync_tip.unconfirmed_tx_roots, update sync_tip:
+	%% #sync_tip.unconfirmed_tx_roots, validate proof; if valid, update sync_tip:
 	%% - chunk_ids_by_tx_root
 	%% - tx_roots_with_proofs_by_chunk_id
 	%% - chunk_ids_by_tx_id (if maintain_tx_index is true)
 	%% - size_tagged_tx_ids_by_tx_root (if maintain_tx_index is true)
-	%% Else if the transaction root is found in #state.tx_root_index, update:
+	%% If proof is not valid, return {error, invalid_proof}.
+	%% Else if the transaction root is found in #state.tx_root_index, validate proof; update:
 	%% - #state.sync_record
 	%% - #state.chunks_index
 	%% Otherwise return {error, tx_root_not_found}.
@@ -62,7 +63,7 @@ get_tx_data(TXID) ->
 	ok.
 
 %% Pick a random [start, end) half-closed interval of
-%% ?SYNC_CHUNK_SIZE which is not synced and sync it. The
+%% ?SYNC_CHUNK_SIZE or smaller which is not synced and sync it. The
 %% intervals are chosen from [0, confirmed weave size).
 sync_random_chunk() ->
 	ok.
@@ -126,6 +127,11 @@ sync_record_from_txs([TXID | TXIDs], SyncRecord, Offset) ->
 	end;
 sync_record_from_txs([], SyncRecord, _Offset) ->
 	SyncRecord.
+
+tx_root_index_and_block_offset_index_from_block_index([{_, WeaveSize, TXRoot} | BI]) ->
+	ok;
+tx_root_index_and_block_offset_index_from_block_index([]) ->
+	ok.
 
 compact_intervals([{Start, End}, {End, NextStart} | Rest]) ->
 	compact_intervals([{Start, NextStart} | Rest]);

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -2,11 +2,15 @@
 -behaviour(gen_server).
 
 -export([start_link/1]).
-
--export([add_block/4, add_chunk/4, get_chunk/1, get_tx_data/1]).
+-export([init/1, handle_call/3, handle_cast/2]).
+-export([add_block/6, add_chunk/4, get_chunk/1, get_tx_data/1]).
 
 -include("ar.hrl").
 -include("ar_data_sync.hrl").
+-include("ar_kv.hrl").
+
+-define(INIT_KV(NAME), (ar_kv:init(NAME, ?ROCKSDB_OPTIONS))).
+-define(INIT_KV_SEEK(DB), (ar_kv:init_seek(DB, ?ROCKSDB_ITR_OPTIONS))).
 
 %%%===================================================================
 %%% Public interface.
@@ -15,7 +19,7 @@
 start_link(Args) ->
 	gen_server:start_link({local, ?MODULE}, ?MODULE, Args, []).
 
-add_block(TXRoot, Height, SizeTaggedTXIDs, WeaveSize) ->
+add_block(TXRoot, Height, SizeTaggedTXIDs, WeaveSize, BI, POA) ->
 	%% Updates
 	%% - #state.sync_tip:
 	%%   - tx_roots_by_height
@@ -29,7 +33,7 @@ add_block(TXRoot, Height, SizeTaggedTXIDs, WeaveSize) ->
 	%% - #state.tx_root_index (if #sync_tip.confirmed_height is advanced)
 	%% - #state.chunk_index (if #sync_tip.confirmed_height is advanced & there are new chunks)
 	%% - #state.tx_index (if #sync_tip.confirmed_height is advanced & there are new txs)
-	ok.
+	gen_server:call(?MODULE, {add_block, TXRoot, Height, SizeTaggedTXIDs, WeaveSize, BI, POA}).
 
 add_chunk(ChunkID, Chunk, Offset, #poa{ tx_path = TXPath } = POA) ->
 	case ar_merkle:extract_root(TXPath) of
@@ -55,15 +59,15 @@ add_chunk(ChunkID, Chunk, Offset, TXRoot, POA) ->
 			%% - size_tagged_tx_ids_by_tx_root (if maintain_tx_index is true)
 			%% In #state, update:
 			%% - #state.sync_record
-			%% - #state.chunks_index
-			ok
+			%% - #state.chunks_index,
+			gen_server:call(?MODULE, {add_chunk, ChunkID, Chunk, Offset, TXRoot, POA})
 	end.
 
 get_chunk(Offset) ->
 	%% Look if the offset is synced in #state.sync_record.
 	%% If yes, fetch the chunk with its proof from #state.chunk_index.
 	%% If not, return {error, chunk_not_found}.
-	ok.
+	gen_server:call(?MODULE, {get_chunk, Offset}).
 
 get_tx_data(TXID) ->
 	%% Look if there are chunk identifiers in #sync_tip.chunk_ids_by_tx_id.
@@ -75,7 +79,7 @@ get_tx_data(TXID) ->
 	%%   from state#chunk_index.
 	%%   If chunks are missing, return {error, tx_data_not_found}.
 	%%   If not, return tx data.
-	ok.
+	gen_server:call(?MODULE, {get_tx_data, TXID}).
 
 %% Pick a random (start, end] half-closed interval of
 %% ?SYNC_CHUNK_SIZE or smaller which is not synced and sync it. The
@@ -92,7 +96,7 @@ sync_random_chunk() ->
 	%%   from the chosen byte;
 	%% - validate the proof via validate_proof/3;
 	%% - update #state.chunk_index.
-	ok.
+	gen_server:call(?MODULE, sync_random_chunk).
 
 %%%===================================================================
 %%% Generic server callbacks.
@@ -101,16 +105,216 @@ sync_random_chunk() ->
 init(#{ block_index := BI, maintain_tx_index := MaintainTXIndex }) ->
 	%% Load state from disk, if any, otherwise construct it from the
 	%% block index. Store the new state.
-	State = #state{},
-	{ok, State}.
+	gen_server:cast(?MODULE, {init, BI}),
+	{ok, #state{
+			db = ?INIT_KV("kv-data-sync"),
+			tx_root_index = ?INIT_KV("kv-tx-root-index"),
+			block_offset_index = ?INIT_KV("kv-block-offset-index"),
+			tx_index = init_tx_index(MaintainTXIndex),
+			maintain_tx_index = MaintainTXIndex}}.
+
+handle_call({add_block, TXRoot, Height, SizeTaggedTXIDs, WeaveSize, BI, POA}, _From, State) ->
+	%% extract state fileds
+	#state{	db = DB,
+		sync_record = SyncRecord,
+		sync_tip = SyncTip =
+			#sync_tip{
+				tx_roots_by_height= TXRootsByHeight,
+				confirmed_height = ConfirmedHeight,
+				unconfirmed_tx_roots = UnConfirmedTXRoots,
+				size_tagged_tx_ids_by_tx_root = SizeTaggedTXIDsByRoot,
+				block_offset_by_tx_root = BlockOffsetByTXRoot},
+		maintain_tx_index  = MaintainTXIndex,
+		chunks_index = ChunksIndex,
+		tx_root_index = TXRootIndex,
+		tx_index = TXIndex} = State,
+
+	%% update 'tx_roots_by_height'
+	TxRootsByHeight0 = map:put(TXRoot, Height, TXRootsByHeight),
+	ar_kv:put(DB, tx_roots_by_height, TxRootsByHeight0),
+	SyncTip1 = SyncTip#sync_tip{tx_roots_by_height = TxRootsByHeight0},
+
+	%% update 'unconfirmed_tx_roots'
+	UnConfirmedTXRoots0 = [TXRoot | UnConfirmedTXRoots],
+	SyncTip2 = SyncTip1#sync_tip{unconfirmed_tx_roots = UnConfirmedTXRoots0},
+
+	% update 'confirmed_height' and 'confirmed_tx_root'
+	SyncTip3 = if length(UnConfirmedTXRoots0) >= ?TRACK_CONFIRMATIONS ->
+			%% 1. Erase synched data from 'orphaned' TX roots
+			%% 2. Update 'confirmed_height' and 'confirmed_tx_root'
+			SyncTip2#sync_tip{confirmed_height = Height,
+							  confirmed_tx_root = TXRoot};
+		true ->
+			SyncTip2
+	end,
+
+	%% update 'size_tagged_tx_ids_by_tx_root' if 'maintain_tx_index' = true
+	SyncTip4 = if MaintainTXIndex ->
+			SizeTaggedTXIDsByRoot0 = map:put(TXRoot, SizeTaggedTXIDs, SizeTaggedTXIDsByRoot),
+			ar_kv:put(DB, size_tagged_tx_ids_by_tx_root, SizeTaggedTXIDsByRoot0),
+			SyncTip3#sync_tip{size_tagged_tx_ids_by_tx_root = SizeTaggedTXIDsByRoot0};
+		true ->
+			SyncTip3
+	end,
+
+	%% update 'block_offset_by_tx_root'
+	{_, BlockSize} = hd(lists:reverse(SizeTaggedTXIDs)),
+	BlockOffset = WeaveSize - BlockSize,
+	BlockOffsetByTXRoot0 = map:put(TXRoot, BlockOffset, BlockOffsetByTXRoot),
+	ar_kv:put(DB, block_offset_by_tx_root, BlockOffsetByTXRoot0),
+	SyncTip5 = SyncTip4#sync_tip{block_offset_by_tx_root = BlockOffsetByTXRoot0},
+
+	%% update 'sync_record'
+	NewSyncRecord =
+		if ConfirmedHeight =/= SyncTip5#sync_tip.confirmed_height ->
+			TXRootSyncRec =
+				sync_record_from_block_index(
+					[hd(BI)],
+					TXRoot,
+					TXIndex,
+					TXRootIndex,
+					ChunksIndex,
+					POA),
+			[TXRootSyncRec | SyncRecord];
+		true ->
+			SyncRecord
+	end,
+
+	{reply, ok, State#state{
+				 sync_record = NewSyncRecord,
+				 confirmed_size = WeaveSize,
+				 sync_tip = SyncTip5}};
+
+handle_call({add_chunk, ChunkID, Chunk, Offset, TXRoot, POA}, _From, State) ->
+	%% extract state fileds
+	#state{
+		db = DB,
+		sync_record = SyncRecord,
+		sync_tip = SyncTip =
+			#sync_tip{
+				chunk_ids_by_tx_id = ChunkIDsByTXID,
+				chunk_ids_by_tx_root = ChunkIDsByTXRoot,
+				tx_roots_with_proofs_by_chunk_id = TXRootsPOAByChunkID,
+				block_offset_by_tx_root = BlockOffsetByTXRoot},
+		maintain_tx_index  = MaintainTXIndex,
+		chunks_index = ChunksIndex} = State,
+
+	{Reply, FinalState} =
+		case map:get(TXRoot, BlockOffsetByTXRoot) of
+			true ->
+				%% update 'chunk_ids_by_tx_root'
+				TXRootChunkIDs = map:get(TXRoot, ChunkIDsByTXRoot, []),
+				ChunkIDsByTXRoot0 = map:put(TXRoot, [ChunkID | TXRootChunkIDs], ChunkIDsByTXRoot),
+				ar_kv:put(DB, chunk_ids_by_tx_root, ChunkIDsByTXRoot0),
+				SyncTip1 = SyncTip#sync_tip{chunk_ids_by_tx_root = ChunkIDsByTXRoot0},
+
+				%% update 'tx_roots_with_proofs_by_chunk_id'
+				TXRootPOA = map:get(ChunkID, TXRootsPOAByChunkID, []),
+				TXRootsPOAByChunkID = map:put(ChunkID, [{TXRoot, POA} | TXRootPOA], TXRootsPOAByChunkID),
+				ar_kv:put(DB, tx_roots_with_proofs_by_chunk_id, TXRootsPOAByChunkID),
+				SyncTip2 = SyncTip1#sync_tip{tx_roots_with_proofs_by_chunk_id = TXRootsPOAByChunkID},
+
+				%% update 'chunk_ids_by_tx_id'
+				SyncTip3 =
+					if MaintainTXIndex ->
+							%% seek TXID
+							{_Offset0, TXID} = ar_kv:seek(erlang:get(<<"itr-tx-index">>), Offset),
+							ChunkIDs = map:get(TXID, ChunkIDsByTXID),
+							ChunkIDsByTXID0 = map:put(TXID, [ChunkID | ChunkIDs], ChunkIDsByTXID),
+							SyncTip2#sync_tip{chunk_ids_by_tx_id = ChunkIDsByTXID0};
+						true ->
+							SyncTip2
+					end,
+
+				%% update 'sync_record' and 'chunks_index'
+				SyncRecord0 = map:put(Offset, Offset + byte_size(Chunk), SyncRecord),
+				NewChunksIndexEntry = case ar_kv:get(ChunksIndex, Offset) of
+					{ChunkIDs0, POA} ->
+						{[ChunkID | ChunkIDs0], POA};
+					_ ->
+						{[ChunkID], POA}
+				end,
+				ar_kv:put(ChunksIndex, Offset, NewChunksIndexEntry),
+
+				{ok, State#state{sync_record = SyncRecord0, sync_tip = SyncTip3}};
+			{_, _} ->
+				{{error, tx_root_not_found}, State}
+		end,
+	{reply, Reply, FinalState};
+
+handle_call({get_chunk, Offset}, _From, State) ->
+	%% Look if the offset is synced in #state.sync_record.
+	%% If yes, fetch the chunk with its proof from #state.chunk_index.
+	%% If not, return {error, chunk_not_found}.
+	#state{
+		sync_record = SyncRecord,
+		chunks_index = ChunksIndex} = State,
+	Reply =
+		%% seek offset interval
+		case get_synched_offset(Offset, SyncRecord) of
+			chunk_not_found = Reason ->
+				{error, Reason};
+			{_Start, EndOffset} ->
+				ar_kv:get(ChunksIndex, EndOffset)
+		end,
+	{reply, Reply, State};
+
+handle_call({get_tx_data, TXID}, _From, State) ->
+	% case map:get(TXID, ChunkIDsByTXID, undefined) of
+	% 	ChunkIDs = [_|_] ->
+	% 		if MissingChunks ->
+	% 				{error, not_found};
+	% 			true ->
+	% 				"construct TX from ChunkIDs"
+	% 		end;
+	% 	undefined ->
+	% 		case ar_kv:get(TXIndex, TXID) of
+	% 			Offset ->
+	% 				"construct TX from Offset";
+	% 			_ ->
+	% 				{error, not_found}
+	% 		end
+	% end,
+	{reply, ok, State};
+
+handle_call(sync_random_chunk, _From,
+	State = #state{
+		sync_record = SyncRecord,
+		confirmed_size = ConfirmedSize}) when ConfirmedSize > 0 ->
+	UnsynchedInterval =
+		if length(SyncRecord) > 0 ->
+			EnsureSortedSyncRecord = lists:keysort(2, SyncRecord),
+			unsynched_interval(EnsureSortedSyncRecord);
+		true ->
+			unavailable
+		end,
+
+	{Reply, NewState} = get_interval_chunks(UnsynchedInterval, State),
+
+	{reply, Reply, NewState}.
+
+handle_cast({init, _BI}, State = #state{db = DB}) ->
+	RestoreFromDisk = load_state_from_disk(DB),
+	UpdatedState =
+		if RestoreFromDisk ->
+				restore_state(DB, State#state{});
+			true ->
+				%% State#state{sync_record = sync_record_from_block_index(BI)}
+				State#state{}
+		end,
+	init_iterators(UpdatedState),
+	{noreply, UpdatedState};
+
+handle_cast(_Msg, State) ->
+	{noreply, State}.
 
 %%%===================================================================
 %%% Private functions.
 %%%===================================================================
 
-sync_record_from_block_index(BI) ->
+sync_record_from_block_index(BI, TXRoot, TXIndex, TXRootIndex, ChunksIndex, POA) ->
 	Intervals = sync_record_from_block_index([], BI),
-	compact_intervals(Intervals).
+	compact_intervals(Intervals, TXRoot, TXIndex, TXRootIndex, ChunksIndex, POA).
 
 sync_record_from_block_index(SyncRecord, [{BH, WeaveSize, _} | BI]) ->
 	case ar_storage:read_block_shadow(BH) of
@@ -137,14 +341,21 @@ sync_record_from_txs([TXID | TXIDs], SyncRecord, Offset) ->
 	case ar_storage:read_tx(TXID) of
 		unavailable ->
 			SyncRecord;
-		#tx{ format = 1, data_size = DataSize } when DataSize > 0 ->
+		#tx{ format = 1, data_size = DataSize, id = ID } = TX when DataSize > 0 ->
+			TXSizedChunkIDs = tx_sized_chunk_ids(TX),
 			sync_record_from_txs(
-				TXIDs, [{Offset - DataSize, Offset} | SyncRecord], Offset - DataSize);
-		#tx{ format = 2, data_size = DataSize, id = ID } when DataSize > 0 ->
+				TXIDs,
+				[{Offset - DataSize, Offset, ID, TXSizedChunkIDs} | SyncRecord],
+				Offset - DataSize);
+		#tx{ format = 2, data_size = DataSize, id = ID } = TX when DataSize > 0 ->
 			case filelib:is_file(ar_storage:tx_data_filepath(ID)) of
 				true ->
+					TXSizedChunkIDs = tx_sized_chunk_ids(TX),
 					sync_record_from_txs(
-						TXIDs, [{Offset - DataSize, Offset} | SyncRecord], Offset - DataSize);
+						TXIDs,
+						[{Offset - DataSize, Offset, ID, TXSizedChunkIDs} | SyncRecord],
+						Offset - DataSize
+					);
 				false ->
 					sync_record_from_txs(TXIDs, SyncRecord, Offset - DataSize)
 			end;
@@ -154,17 +365,49 @@ sync_record_from_txs([TXID | TXIDs], SyncRecord, Offset) ->
 sync_record_from_txs([], SyncRecord, _Offset) ->
 	SyncRecord.
 
+tx_sized_chunk_ids(TX) ->
+	ar_tx:sized_chunks_to_sized_chunk_ids(
+				ar_tx:chunks_to_size_tagged_chunks(
+					ar_tx:chunk_binary(?DATA_CHUNK_SIZE, TX#tx.data)
+				)
+			).
+
 tx_root_index_and_block_offset_index_from_block_index([{_, WeaveSize, TXRoot} | BI]) ->
 	ok;
 tx_root_index_and_block_offset_index_from_block_index([]) ->
 	ok.
 
-compact_intervals([{Start, End}, {End, NextStart} | Rest]) ->
-	compact_intervals([{Start, NextStart} | Rest]);
-compact_intervals([Interval | Rest]) ->
-	[Interval | compact_intervals(Rest)];
-compact_intervals([]) ->
+compact_intervals(
+	[{Start, End, TXID, ChunkIDs}, {End, NextStart, NextTXID, NextChunkIDs} | Rest],
+	TXRoot,
+	TXIndex,
+	TXRootIndex,
+	ChunksIndex,
+	POA) ->
+		update_records(End, TXRoot, TXIndex, TXRootIndex, ChunksIndex, TXID, ChunkIDs, POA),
+		compact_intervals(
+			[{Start, NextStart, NextTXID, NextChunkIDs} | Rest],
+			TXRoot,
+			TXIndex,
+			TXRootIndex,
+			ChunksIndex,
+			POA);
+compact_intervals(
+	[{Start, End, TXIDs, ChunkIDs} | Rest],
+	TXRoot,
+	TXIndex,
+	TXRootIndex,
+	ChunksIndex,
+	POA) ->
+		update_records(End, TXRoot, TXIndex, TXRootIndex, ChunksIndex, TXIDs, ChunkIDs, POA),
+		[{Start, End} | compact_intervals(Rest, TXRoot, TXIndex, TXRootIndex, ChunksIndex, POA)];
+compact_intervals([], _TXRoot, _TXIndex, _TXRootIndex, _ChunksIndex, _POA) ->
 	[].
+
+update_records(EndOffset, TXRoot, TXIndex, TXRootIndex, ChunksIndex, TXID, ChunkIDs, POA) ->
+	ar_kv:put(TXIndex, TXID, EndOffset),
+	ar_kv:put(TXRootIndex, EndOffset, TXRoot),
+	ar_kv:put(ChunksIndex, EndOffset, {ChunkIDs, POA}).
 
 validate_proof(
 	#poa{ tx_path = TXPath, data_path = DataPath, chunk = Chunk },
@@ -187,3 +430,66 @@ validate_proof(
 					end
 			end
 	end.
+
+load_state_from_disk(DB) ->
+	case ar_kv:get(DB, load_state_from_disk) of
+		LoadFromDisk when is_boolean(LoadFromDisk) ->
+			LoadFromDisk;
+		_ ->
+			false
+	end.
+
+restore_state(DB, State) ->
+	State#state{
+		sync_record = ar_kv:get(DB, sync_record),
+		confirmed_size = ar_kv:get(DB, confirmed_size),
+		sync_tip =
+			#sync_tip{
+				tx_roots_by_height = ar_kv:get(DB, tx_roots_by_height),
+				chunk_ids_by_tx_root = ar_kv:get(DB, chunk_ids_by_tx_root),
+				tx_roots_with_proofs_by_chunk_id = ar_kv:get(DB, tx_roots_with_proofs_by_chunk_id),
+				confirmed_height = ar_kv:get(DB, confirmed_height),
+				confirmed_tx_root = ar_kv:get(DB, confirmed_tx_root),
+				chunk_ids_by_tx_id = ar_kv:get(DB, chunk_ids_by_tx_id),
+				size_tagged_tx_ids_by_tx_root = ar_kv:get(DB, size_tagged_tx_ids_by_tx_root),
+				block_offset_by_tx_root = ar_kv:get(DB, block_offset_by_tx_root)
+			}
+	}.
+
+init_tx_index(true) -> ?INIT_KV("kv-tx-index");
+init_tx_index(_)    -> unavailable.
+
+unsynched_interval([]) -> not_found;
+unsynched_interval([{_Start, End}, Next = {End, _NextEnd} | Rem]) ->
+	unsynched_interval([Next | Rem]);
+unsynched_interval([{_Start, End}, {NextStart, _NextEnd} | _Rem]) ->
+	{End, NextStart};
+unsynched_interval([_| Rem]) -> unsynched_interval(Rem).
+
+get_synched_offset(_Offset, []) -> chunk_not_found;
+get_synched_offset(Offset, [{Start, End} = Interval | _Rem])
+	when Offset >= Start; Offset < End -> Interval;
+get_synched_offset(Offset, [_| Rem]) ->
+	get_synched_offset(Offset, Rem).
+
+init_iterators(
+	#state{
+		db = DB,
+		tx_index = TXIndex,
+		tx_root_index = TXRootIndex,
+		block_offset_index = BlockOffsetIndex,
+		maintain_tx_index = MaintainTXIndex}) ->
+	erlang:put(<<"itr-data-sync">>, ?INIT_KV_SEEK(DB)),
+	erlang:put(<<"itr-tx-root-index">>, ?INIT_KV_SEEK(TXRootIndex)),
+	erlang:put(<<"itr-block-offset-index">>, ?INIT_KV_SEEK(BlockOffsetIndex)),
+	erlang:put(<<"itr-data-sync">>, ?INIT_KV_SEEK(BlockOffsetIndex)),
+	if MaintainTXIndex ->
+			erlang:put(<<"itr-tx-index">>, ?INIT_KV_SEEK(TXIndex));
+		true ->
+			ok
+	end,
+	ok.
+
+get_interval_chunks(UnsynchedInterval, State) ->
+	%% fetch unsyched interval chunks...
+	{ok, State}.

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -1,5 +1,13 @@
+-ifdef(DEBUG).
+-define(TRACK_CONFIRMATIONS, 5).
+-else.
 -define(TRACK_CONFIRMATIONS, ?STORE_BLOCKS_BEHIND_CURRENT).
+-endif.
+
 -define(SYNC_CHUNK_SIZE, 20 * 1024 * 1024).
+
+-define(MAX_SERIALIZED_CHUNK_PROOF_SIZE,
+	?MAX_PATH_SIZE * 2 + ?DATA_CHUNK_SIZE + ?NOTE_SIZE + 200). % Extra space for special chars.
 
 -record(state, {
 	%% An end offset -> start offset mapping sorted

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -85,5 +85,6 @@
 	%% Each time the confirmed height is advanced, the transaction identifiers
 	%% from the orphaned blocks are removed from chunk_ids_by_tx_id, if the
 	%% mapping is maintained.
-	size_tagged_tx_ids_by_tx_root
+	size_tagged_tx_ids_by_tx_root,
+	block_offset_by_tx_root
 }).

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -34,9 +34,17 @@
 	%% Chunks are identified by offset. A proof is stored
 	%% along with every chunk. Only confirmed chunks are stored.
 	chunks_index,
-	%% A reference to the on-disk key-value storage of offsets of
-	%% all confirmed transaction roots.
+	%% A reference to the on-disk key-value storage mapping
+	%% block end offsets (keys) to their transaction roots (values).
+	%% Used when syncing a random chunk of the weave. A transaction root
+	%% is looked up and used in proof verification.
 	tx_root_index,
+	%% A reference to the on-disk key-value storage mapping
+	%% transaction roots (keys) to their block end offsets (values).
+	%% Used when accepting a chunk. Users do not need to look up
+	%% block offsets to submit data so when a node accepts a chunk,
+	%% it needs to lookup the block end offset for the given transaction root.
+	block_offset_index,
 	%% A reference to the on-disk key value storage of the offsets
 	%% of synced transaction identifiers. Only confirmed transactions
 	%% are stored. Consulted by GET /tx/<id>/data. The index is not

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -6,8 +6,12 @@
 
 -define(SYNC_CHUNK_SIZE, 20 * 1024 * 1024).
 
--define(MAX_SERIALIZED_CHUNK_PROOF_SIZE,
-	?MAX_PATH_SIZE * 2 + ?DATA_CHUNK_SIZE + ?NOTE_SIZE + 200). % Extra space for special chars.
+%% 2 * ?MAX_PATH_SIZE
+%% + DATA_CHUNK_SIZE
+%% + log10(2 ^ (NOTE_SIZE * 8))
+%% + some space for JSON special chars
+%% multiplied by ~1.4 to account for Base64.
+-define(MAX_SERIALIZED_CHUNK_PROOF_SIZE, 1100000).
 
 -record(state, {
 	%% An end offset -> start offset mapping sorted

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -1,0 +1,81 @@
+-define(TRACK_CONFIRMATIONS, ?STORE_BLOCKS_BEHIND_CURRENT).
+-define(SYNC_CHUNK_SIZE, 20 * 1024 * 1024).
+
+-record(state, {
+	%% An end offset -> start offset mapping sorted
+	%% by end offset. Every such pair denotes a synced
+	%% half-closed interval on the [0, confirmed weave size)
+	%% half-closed interval. The confirmed weave size is
+	%% from the block with ?TRACK_CONFIRMATIONS confirmations.
+	%%
+	%% This mapping serves as a compact map of what is synced
+	%% by the node. No matter how big the weave is or how much
+	%% of it the node stores, this record can remain very small,
+	%% compared to storing all chunk and transaction identifiers,
+	%% whose number can effectively grow unlimited with time.
+	%% We do not keep unconfirmed data in this mapping as
+	%% chunks from different forks can have the same offsets,
+	%% what is easier to manage via chunk and transaction
+	%% identifiers.
+	%%
+	%% Every time a chunk is written to sync_record, it is also
+	%% written to the chunk_index.
+	%%
+	%% The record is consulted by GET /chunk/<offset>,
+	%% GET /tx/<id>/data, and POST /chunk.
+	sync_record,
+	%% The weave size from the block with ?TRACK_CONFIRMATIONS
+	%% confirmations. Must be bigger than or equal the biggest
+	%% key in sync_record.
+	confirmed_size,
+	%% See comments on the sync_tip record fields.
+	sync_tip,
+	%% A reference to the on-disk key-value storage of synced chunks.
+	%% Chunks are identified by offset. A proof is stored
+	%% along with every chunk. Only confirmed chunks are stored.
+	chunks_index,
+	%% A reference to the on-disk key-value storage of offsets of
+	%% all confirmed transaction roots.
+	tx_root_index,
+	%% A reference to the on-disk key value storage of the offsets
+	%% of synced transaction identifiers. Only confirmed transactions
+	%% are stored. Consulted by GET /tx/<id>/data. The index is not
+	%% maintained by default as miners do not need it.
+	tx_index
+}).
+
+%% The record keeps track of all the unconfirmed synced
+%% chunks, transactions, and transaction roots. The orphaned
+%% data is not erased immediately, but after ?TRACK_CONFIRMATIONS.
+%% The record is consulted by POST /chunk, GET /tx/<id>/data,
+%% and when transaction data is written in ar_storage:write_tx_data/1,
+%% but not by GET /chunk/<offset>.
+-record(sync_tip, {
+	%% Every time a new block gets ?TRACK_CONFIRMATIONS confirmations,
+	%% this map is used to erase uncle data. To collect synced chunk ids
+	%% to erase, we consult chunk_ids_by_tx_root and
+	%% tx_roots_with_proofs_by_chunk_id (note that the same chunk can
+	%% belong to mulitple different transactions).
+	tx_roots_by_height,
+	chunk_ids_by_tx_root,
+	tx_roots_with_proofs_by_chunk_id,
+	%% The confirmed height is advanced each time unconfirmed_tx_roots
+	%% grows longer than ?TRACK_CONFIRMATIONS.
+	%% Each time the confirmed height is advanced, the synced data
+	%% from the orphaned transaction roots is erased, the synced
+	%% data from the new confirmed transaction root is recorded in sync_record.
+	confirmed_height,
+	%% Must be updated every time the confirmed height is updated.
+	confirmed_tx_root,
+	%% The list of unconfirmed transaction roots ordered from most recent
+	%% to least recent, no longer than ?TRACK_CONFIRMATIONS.
+	unconfirmed_tx_roots,
+	%% Keeps track of the transaction identifiers of the unconfirmed synced
+	%% chunks. Consulted by GET /tx/<id>/data. The mapping is not maintained
+	%% by default as miners do not need it.
+	chunk_ids_by_tx_id,
+	%% Each time the confirmed height is advanced, the transaction identifiers
+	%% from the orphaned blocks are removed from chunk_ids_by_tx_id, if the
+	%% mapping is maintained.
+	size_tagged_tx_ids_by_tx_root
+}).

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -61,7 +61,9 @@
 	%% of synced transaction identifiers. Only confirmed transactions
 	%% are stored. Consulted by GET /tx/<id>/data. The index is not
 	%% maintained by default as miners do not need it.
-	tx_index
+	tx_index,
+	maintain_tx_index,
+	db
 }).
 
 %% The record keeps track of all the unconfirmed synced

--- a/apps/arweave/src/ar_data_sync.hrl
+++ b/apps/arweave/src/ar_data_sync.hrl
@@ -4,7 +4,7 @@
 -record(state, {
 	%% An end offset -> start offset mapping sorted
 	%% by end offset. Every such pair denotes a synced
-	%% half-closed interval on the [0, confirmed weave size)
+	%% half-closed interval on the (0, confirmed weave size]
 	%% half-closed interval. The confirmed weave size is
 	%% from the block with ?TRACK_CONFIRMATIONS confirmations.
 	%%
@@ -35,15 +35,15 @@
 	%% along with every chunk. Only confirmed chunks are stored.
 	chunks_index,
 	%% A reference to the on-disk key-value storage mapping
-	%% block end offsets (keys) to their transaction roots (values).
+	%% block start offsets (keys) to their transaction roots (values).
 	%% Used when syncing a random chunk of the weave. A transaction root
 	%% is looked up and used in proof verification.
 	tx_root_index,
 	%% A reference to the on-disk key-value storage mapping
-	%% transaction roots (keys) to their block end offsets (values).
+	%% transaction roots (keys) to their block start offsets (values).
 	%% Used when accepting a chunk. Users do not need to look up
 	%% block offsets to submit data so when a node accepts a chunk,
-	%% it needs to lookup the block end offset for the given transaction root.
+	%% it needs to lookup the block start offset for the given transaction root.
 	block_offset_index,
 	%% A reference to the on-disk key value storage of the offsets
 	%% of synced transaction identifiers. Only confirmed transactions
@@ -68,7 +68,7 @@
 	chunk_ids_by_tx_root,
 	tx_roots_with_proofs_by_chunk_id,
 	%% The confirmed height is advanced each time unconfirmed_tx_roots
-	%% grows longer than ?TRACK_CONFIRMATIONS.
+	%% grows longer than ?TRACK_CONFIRMATIONS - 1.
 	%% Each time the confirmed height is advanced, the synced data
 	%% from the orphaned transaction roots is erased, the synced
 	%% data from the new confirmed transaction root is recorded in sync_record.
@@ -76,7 +76,7 @@
 	%% Must be updated every time the confirmed height is updated.
 	confirmed_tx_root,
 	%% The list of unconfirmed transaction roots ordered from most recent
-	%% to least recent, no longer than ?TRACK_CONFIRMATIONS.
+	%% to least recent, no longer than ?TRACK_CONFIRMATIONS - 1.
 	unconfirmed_tx_roots,
 	%% Keeps track of the transaction identifiers of the unconfirmed synced
 	%% chunks. Consulted by GET /tx/<id>/data. The mapping is not maintained

--- a/apps/arweave/src/ar_data_sync_sup.erl
+++ b/apps/arweave/src/ar_data_sync_sup.erl
@@ -1,0 +1,24 @@
+-module(ar_data_sync_sup).
+-behaviour(supervisor).
+
+-export([start_link/1]).
+-export([init/1]).
+
+%%%===================================================================
+%%% Public API.
+%%%===================================================================
+
+start_link(Args) ->
+	supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
+
+%%%===================================================================
+%%% Supervisor callbacks.
+%%%===================================================================
+
+init(Args) ->
+	SupFlags = #{strategy => one_for_one, intensity => 10, period => 1},
+	ChildSpec = #{
+		id => ar_data_sync,
+		start => {ar_data_sync, start_link, [Args]}
+	},
+	{ok, {SupFlags, [ChildSpec]}}.

--- a/apps/arweave/src/ar_downloader.erl
+++ b/apps/arweave/src/ar_downloader.erl
@@ -12,6 +12,8 @@
 -define(INITIAL_BACKOFF_INTERVAL_S, 30).
 %% The maximum exponential backoff interval for failing requests.
 -define(MAX_BACKOFF_INTERVAL_S, 2 * 60 * 60).
+%% The data above this size is synced chunk by chunk in ar_data_sync.
+-define(SYNC_DATA_BELOW_SIZE, 10 * 1024 * 1024).
 
 %%% This module contains the core transaction and block downloader.
 %%% After the node has joined the network, this process is started,
@@ -99,6 +101,8 @@ has_item({tx_data, {ID, _DataRoot}}) when is_binary(ID) ->
 tx_needs_data(#tx{ format = 1 }) ->
 	false;
 tx_needs_data(#tx{ format = 2, data_size = 0 }) ->
+	false;
+tx_needs_data(#tx{ format = 2, data_size = DataSize }) when DataSize > ?SYNC_DATA_BELOW_SIZE ->
 	false;
 tx_needs_data(#tx{ format = 2 } = TX) ->
 	not filelib:is_file(ar_storage:tx_data_filepath(TX)).

--- a/apps/arweave/src/ar_fork_recovery.erl
+++ b/apps/arweave/src/ar_fork_recovery.erl
@@ -284,6 +284,7 @@ apply_next_block(State, NextB, B) ->
 				end,
 				NextB#block.txs
 			),
+			%% Update the sync record via ar_data_sync:add_block/3.
 			case ar_meta_db:get(partial_fork_recovery) of
 				true ->
 					ar:info(

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -254,6 +254,14 @@ handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req, _Pid) ->
 			serve_tx_html_data(Req, TX)
 	end;
 
+handle(<<"GET">>, [<<"chunk">>, Offset], Req, _Pid) ->
+	%% Fetch chunk if any via ar_sync_data:get_chunk/1.
+	{200, #{}, <<>>, Req}.
+
+handle(<<"POST">>, [<<"chunk">>], Req, _Pid) ->
+	%% Parse the proof and the chunk out of body. Try to add chunk via ar_data_sync:add_chunk/3.
+	{200, #{}, <<>>, Req}.
+
 %% @doc Share a new block to a peer.
 %% POST request to endpoint /block with the body of the request being a JSON encoded block
 %% as specified in ar_serialize.
@@ -619,6 +627,8 @@ handle(<<"GET">>, [<<"tx">>, Hash, Field], Req, _Pid) ->
 				true ->
 					{202, #{}, <<"Pending">>, Req};
 				false ->
+					%% If tx index flag is set, try to fetch
+					%% tx data via ar_data_sync:get_tx_data/1.
 					{404, #{}, <<"Not Found.">>, Req}
 			end;
 		{ok, Filename} ->
@@ -730,6 +740,8 @@ serve_tx_data(Req, #tx{ format = 2 } = TX) ->
 		true ->
 			{200, #{}, sendfile(DataFilename), Req};
 		false ->
+			%% If tx index flag is set, try to fetch
+			%% tx data via ar_data_sync:get_tx_data/1.
 			{200, #{}, <<>>, Req}
 	end.
 

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -256,11 +256,11 @@ handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req, _Pid) ->
 
 handle(<<"GET">>, [<<"chunk">>, Offset], Req, _Pid) ->
 	%% Fetch chunk if any via ar_sync_data:get_chunk/1.
-	{200, #{}, <<>>, Req}.
+	{200, #{}, <<>>, Req};
 
 handle(<<"POST">>, [<<"chunk">>], Req, _Pid) ->
 	%% Parse the proof and the chunk out of body. Try to add chunk via ar_data_sync:add_chunk/3.
-	{200, #{}, <<>>, Req}.
+	{200, #{}, <<>>, Req};
 
 %% @doc Share a new block to a peer.
 %% POST request to endpoint /block with the body of the request being a JSON encoded block

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -259,7 +259,12 @@ handle(<<"GET">>, [<<"chunk">>, Offset], Req, _Pid) ->
 	{200, #{}, <<>>, Req};
 
 handle(<<"POST">>, [<<"chunk">>], Req, _Pid) ->
-	%% Parse the proof and the chunk out of body. Try to add chunk via ar_data_sync:add_chunk/3.
+	%% The body must contain:
+	%% - a data_path
+	%% - a chunk
+	%% - an offset (of the chunk, relative to the block)
+	%% - a tx_path
+	%% Try to add chunk via ar_data_sync:add_chunk/4.
 	{200, #{}, <<>>, Req};
 
 %% @doc Share a new block to a peer.

--- a/apps/arweave/src/ar_kv.erl
+++ b/apps/arweave/src/ar_kv.erl
@@ -1,0 +1,57 @@
+-module(ar_kv).
+
+-callback init(term(), term()) -> term().
+-callback init_seek(term(), term()) -> term().
+-callback put(term(), term(), term()) -> ok.
+-callback get(term(), term()) -> term().
+-callback seek(term(), term()) -> {term(), term()}.
+-callback seek_next(term(), term()) -> {term(), term()}.
+-callback erase(term(), term()) -> ok.
+-callback close(term()) -> ok.
+
+-optional_callbacks([init/2, init_seek/2, seek/2, seek_next/2, close/1]).
+
+-export([init/2, init_seek/2]).
+-export([put/3, get/2, seek/2,seek_next/2, erase/2, close/1]).
+
+-define(KV_ENGINE, (ar_meta_db:get(kv_engine))).
+
+%% @doc Initialise the KV store
+init(Name, Args) ->
+    backend_op(fun() -> ?KV_ENGINE:init(Name, Args) end).
+
+%% @doc Initialise seek iterator for KV store
+init_seek(Ref, Args) ->
+    backend_op(fun() -> ?KV_ENGINE:init_seek(Ref, Args) end).
+
+%% @doc Put an entry, Value, by Key
+put(Ref, Key, Value) ->
+    backend_op(fun() -> ?KV_ENGINE:put(Ref, Key, Value) end).
+
+%% @doc Get an entry by Key
+get(Ref, Key) ->
+    backend_op(fun() -> ?KV_ENGINE:get(Ref, Key) end).
+
+%% @doc Seek nearest Key by Position
+seek(Ref, Pos) ->
+    backend_op(fun() -> ?KV_ENGINE:seek(Ref, Pos) end).
+
+%% @doc Seek next nearest Key by Position
+seek_next(Ref, Pos) ->
+    backend_op(fun() -> ?KV_ENGINE:seek_next(Ref, Pos) end).
+
+%% @doc Erase an entry by Key
+erase(Ref, Key) ->
+    backend_op(fun() -> ?KV_ENGINE:get(Ref, Key) end).
+
+%% @doc Close the KV store
+close(Ref) ->
+    backend_op(fun() -> ?KV_ENGINE:close(Ref) end).
+
+%% internal backend operation
+backend_op(Op) ->
+    try
+        Op()
+    catch
+        _:Reason -> {error, Reason}
+    end.

--- a/apps/arweave/src/ar_kv.hrl
+++ b/apps/arweave/src/ar_kv.hrl
@@ -1,0 +1,3 @@
+
+-define(ROCKSDB_OPTIONS, [{create_if_missing, true}, {prefix_extractor, {capped_prefix_transform, 28}}]).
+-define(ROCKSDB_ITR_OPTIONS, []).

--- a/apps/arweave/src/ar_kv_rocksdb.erl
+++ b/apps/arweave/src/ar_kv_rocksdb.erl
@@ -22,19 +22,19 @@ put(Ref, Key, Value) ->
 
 %% @doc Get an item from rocksdb
 get(Ref, Key) ->
-    rocksdb:get(Ref, binary_to_term(binary_to_term(Key)), []).
+    rocksdb:get(Ref, term_to_binary(Key), []).
 
 %% @doc Seek an item from rocksdb
-seek(Itr, Key) ->
-    handle_itr(rocksdb:iterator_move(Itr, {seek, binary_to_term(binary_to_term(Key))})).
+seek(Itr, Key) when is_reference(Itr) ->
+    handle_itr(rocksdb:iterator_move(Itr, {seek, term_to_binary(Key)})).
 
 %% @doc Seek next an item from rocksdb
-seek_next(Itr) ->
+seek_next(Itr) when is_reference(Itr) ->
     handle_itr(rocksdb:iterator_move(Itr, next)).
 
 %% @doc Erase an item from rocksdb
 erase(Ref, Key) ->
-    rocksdb:delete(Ref, binary_to_term(Key), []),
+    rocksdb:delete(Ref, term_to_binary(Key), []),
     ok.
 
 %% @doc Erase an item from rocksdb

--- a/apps/arweave/src/ar_merkle.erl
+++ b/apps/arweave/src/ar_merkle.erl
@@ -21,7 +21,6 @@
 }).
 
 -define(HASH_SIZE, ?CHUNK_ID_HASH_SIZE).
--define(NOTE_SIZE, 32).
 
 %%% Tree generation.
 %%% Returns the merkle root and the tree data structure.

--- a/apps/arweave/src/ar_merkle.erl
+++ b/apps/arweave/src/ar_merkle.erl
@@ -1,7 +1,8 @@
 -module(ar_merkle).
+
 -export([generate_tree/1, generate_path/3]).
 -export([validate_path/3]).
--export([extract_note/1]).
+-export([extract_note/1, extract_root/1]).
 
 -include("ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -135,6 +136,13 @@ extract_note(Path) ->
 	binary:decode_unsigned(
 		binary:part(Path, byte_size(Path) - ?NOTE_SIZE, ?NOTE_SIZE)
 	).
+
+extract_root(<< Data:?HASH_SIZE/binary, EndOffset:(?NOTE_SIZE*8) >>) ->
+	{ok, hash([hash(Data), hash(note_to_binary(EndOffset))])};
+extract_root(<< L:?HASH_SIZE/binary, R:?HASH_SIZE/binary, Note:(?NOTE_SIZE*8), _/binary >>) ->
+	{ok, hash([hash(L), hash(R), hash(note_to_binary(Note))])};
+extract_root(_) ->
+	{error, invalid_proof}.
 
 %%% Helper functions for managing the tree data structure.
 %%% Abstracted so that the concrete data type can be replaced later.

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -293,6 +293,8 @@ integrate_new_block(
 	%% for the next block because even if the next difficulty makes the price go
 	%% up, it should be fine.
 	%% Write new block and included TXs to local storage.
+
+	%% Update the sync record via ar_data_sync:add_block/3.
 	ar_storage:write_full_block(NewB, BlockTXs),
 	NewBI = update_block_index(NewB#block{ txs = BlockTXs }, BI),
 	NewBlockTXPairs = update_block_txs_pairs(NewB, BlockTXPairs),

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -639,6 +639,7 @@ integrate_block_from_miner(StateIn, NewB, MinedTXs, BDS, _POA) ->
 		gossip           := GS,
 		block_txs_pairs  := BlockTXPairs
 	} = StateIn,
+	%% Update the sync record via ar_data_sync:add_block/3.
 	ar_storage:write_full_block(NewB, MinedTXs),
 	NewBI = ar_node_utils:update_block_index(NewB#block{ txs = MinedTXs }, BI),
 	NewBlockTXPairs = ar_node_utils:update_block_txs_pairs(NewB, BlockTXPairs),
@@ -713,6 +714,7 @@ recovered_from_fork(#{ block_index := not_joined } = StateIn, BI, BlockTXPairs) 
 		NewB#block.height,
 		NewB#block.wallet_list
 	),
+	%% Update the sync record via ar_data_sync:add_block/3.
 	{ok, ar_node_utils:reset_miner(
 		StateIn#{
 			block_index          => BI,

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -644,7 +644,7 @@ integrate_block_from_miner(StateIn, NewB, MinedTXs, BDS, _POA) ->
 	ar_data_sync:add_block(
 		NewB#block.tx_root,
 		NewB#block.height,
-		ar_block:generate_size_tagged_tx_ids(NewB#block.txs),
+		ar_block:generate_size_tagged_tx_ids(MinedTXs),
 		NewB#block.weave_size,
 		NewBI,
 		NewB#block.poa),

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -639,9 +639,15 @@ integrate_block_from_miner(StateIn, NewB, MinedTXs, BDS, _POA) ->
 		gossip           := GS,
 		block_txs_pairs  := BlockTXPairs
 	} = StateIn,
-	%% Update the sync record via ar_data_sync:add_block/3.
 	ar_storage:write_full_block(NewB, MinedTXs),
 	NewBI = ar_node_utils:update_block_index(NewB#block{ txs = MinedTXs }, BI),
+	ar_data_sync:add_block(
+		NewB#block.tx_root,
+		NewB#block.height,
+		ar_block:generate_size_tagged_tx_ids(NewB#block.txs),
+		NewB#block.weave_size,
+		NewBI,
+		NewB#block.poa),
 	NewBlockTXPairs = ar_node_utils:update_block_txs_pairs(NewB, BlockTXPairs),
 	ValidTXs =
 		ar_tx_replay_pool:pick_txs_to_keep_in_mempool(

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -349,6 +349,7 @@ write_tx_header_after_scan(TX) ->
 write_tx_data(ID, ExpectedDataRoot, Data) ->
 	case (ar_tx:generate_chunk_tree(#tx{ data = Data }))#tx.data_root of
 		ExpectedDataRoot ->
+			%% Add all chunks to the sync record via ar_data_sync:add_chunk/3.
 			write_tx_data(tx_data_filepath(ID), ar_util:encode(Data));
 		_ ->
 			{error, invalid_data_root}

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -327,6 +327,7 @@ write_tx_header_after_scan(TX) ->
 	ByteSize = byte_size(TXJSON),
 	case enough_space(ByteSize) of
 		true ->
+			%% Add all v1 chunks to the sync record via ar_data_sync:add_chunk/3.
 			write_file_atomic(
 				tx_filepath(TX),
 				TXJSON

--- a/apps/arweave/test/ar_data_sync_tests.erl
+++ b/apps/arweave/test/ar_data_sync_tests.erl
@@ -1,0 +1,378 @@
+-module(ar_data_sync_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("src/ar.hrl").
+-include("src/ar_data_sync.hrl").
+
+-import(ar_test_node, [start/1, slave_start/1, connect_to_slave/0, sign_tx/2, sign_v1_tx/2]).
+-import(ar_test_node, [assert_post_tx_to_master/2]).
+-import(ar_test_node, [wait_until_height/2, assert_slave_wait_until_height/2]).
+
+rejects_invalid_chunks_test() ->
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"chunk_too_big\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{ chunk => ar_util:encode(crypto:strong_rand_bytes(?DATA_CHUNK_SIZE + 1)) }))
+	),
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"tx_path_too_big\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{ tx_path => ar_util:encode(crypto:strong_rand_bytes(?MAX_PATH_SIZE)) }))
+	),
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"data_path_too_big\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{ data_path => ar_util:encode(crypto:strong_rand_bytes(?MAX_PATH_SIZE)) }))
+	),
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"offset_too_big\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{ offset => integer_to_binary(trunc(math:pow(2, 256))) }))
+	),
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"chunk_proof_ratio_not_attractive\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{ chunk => <<"a">>, proof => <<"bb">> }))
+	),
+	?assertMatch(
+		{ok, {{<<"400">>, _}, _, <<"{\"error\":\"invalid_proof\"}">>, _, _}},
+		post_chunk(jiffy:encode(#{
+			chunk => <<"a">>,
+			proof => <<"b">>,
+			tx_path => <<"a">>,
+			data_path => <<"b">>
+		}))
+	),
+	?assertMatch(
+		{ok, {{<<"413">>, _}, _, <<"Payload too large">>, _, _}},
+		post_chunk(<< <<0>> || _ <- lists:seq(1, ?MAX_SERIALIZED_CHUNK_PROOF_SIZE + 1) >>)
+	).
+
+accepts_confirmed_chunk_test_() ->
+	{timeout, 60, fun test_accepts_confirmed_chunk/0}.
+
+test_accepts_confirmed_chunk() ->
+	{Master, Wallet} = setup_node(),
+	{TX, Chunks} = tx(Wallet, #{ chunks => 2 }),
+	B = post_and_wait_until_confirmed(Master, TX#tx{ data = <<>> }, ?TRACK_CONFIRMATIONS),
+	[FirstProof, SecondProof] = build_proofs(B, TX, Chunks),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, _, _, _}},
+		post_chunk(jiffy:encode(FirstProof))
+	),
+	%% Expect the chunk to be retrieved by any offset within
+	%% (EndOffset - ChunkSize, EndOffset], but not outside of it.
+	EndOffset = B#block.weave_size - B#block.block_size + binary_to_integer(maps:get(offset, FirstProof)),
+	FirstChunk = maps:get(chunk, FirstProof),
+	FirstChunkSize = byte_size(FirstChunk),
+	ExpectedProof = jiiffy:encode(#{
+		data_path => maps:get(data_path, FirstProof),
+		tx_path => maps:get(tx_path, FirstProof),
+		chunk => FirstChunk
+	}),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, ExpectedProof, _, _}},
+		get_chunk(EndOffset)
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, ExpectedProof, _, _}},
+		get_chunk(EndOffset - FirstChunkSize + 2 + rand:uniform(FirstChunkSize - 1))
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, ExpectedProof, _, _}},
+		get_chunk(EndOffset - FirstChunkSize + 1)
+	),
+	?assertMatch(
+		{ok, {{<<"404">>, _}, _, _, _, _}},
+		get_chunk(EndOffset - FirstChunkSize)
+	),
+	?assertMatch(
+		{ok, {{<<"404">>, _}, _, _, _, _}},
+		get_chunk(EndOffset + 1)
+	),
+	%% Expect the transaction data to be empty because the second chunk
+	%% is not synced yet.
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, <<>>, _, _}},
+		get_tx_data(TX#tx.id)
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, _, _, _}},
+		post_chunk(jiffy:encode(SecondProof))
+	),
+	ExpectedSecondProof = jiiffy:encode(#{
+		data_path => maps:get(data_path, SecondProof),
+		tx_path => maps:get(tx_path, SecondProof),
+		chunk => maps:get(chunk, SecondProof)
+	}),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, ExpectedSecondProof, _, _}},
+		get_chunk(B#block.weave_size)
+	),
+	?assertMatch(
+		{ok, {{<<"404">>, _}, _, _, _, _}},
+		get_chunk(B#block.weave_size + 1)
+	),
+	{ok, {{<<"200">>, _}, _, Data, _, _}} = get_tx_data(TX#tx.id),
+	?assertEqual(ar_util:encode(TX#tx.data), Data).
+
+accepts_unconfirmed_chunks_test_() ->
+	{timeout, 60, fun test_accepts_unconfirmed_chunks/0}.
+
+test_accepts_unconfirmed_chunks() ->
+	{Master, Wallet} = setup_node(),
+	{TX, Chunks} = tx(Wallet, #{ chunks => 3 }),
+	B = post_and_wait_until_confirmed(Master, TX#tx{ data = <<>> }, ?TRACK_CONFIRMATIONS - 1),
+	[FirstProof, SecondProof, ThirdProof] = build_proofs(B, TX, Chunks),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, _, _, _}},
+		post_chunk(jiffy:encode(FirstProof))
+	),
+	EndOffset = B#block.weave_size - B#block.block_size + binary_to_integer(maps:get(offset, FirstProof)),
+	%% Unconfirmed chunks are not served by GET /chunk/<offset>.
+	?assertMatch(
+		{ok, {{<<"404">>, _}, _, _, _, _}},
+		get_chunk(EndOffset)
+	),
+	?assertMatch(
+		{ok, {{<<"404">>, _}, _, _, _, _}},
+		get_chunk(EndOffset - 1)
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, <<>>, _, _}},
+		get_tx_data(TX#tx.id)
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, _, _, _}},
+		post_chunk(jiffy:encode(SecondProof))
+	),
+	?assertMatch(
+		{ok, {{<<"200">>, _}, _, _, _, _}},
+		post_chunk(jiffy:encode(ThirdProof))
+	),
+	{ok, {{<<"200">>, _}, _, Data, _, _}} = get_tx_data(TX#tx.id),
+	?assertEqual(ar_util:encode(TX#tx.data), Data).
+
+syncs_data_test_() ->
+	{timeout, 120, fun test_syncs_data/0}.
+
+test_syncs_data() ->
+	{Master, Slave, Wallet} = setup_nodes(),
+	Records = post_random_blocks(Master, Slave, Wallet),
+	RecordsWithProofs = lists:flatmap(
+		fun({B, TX, Chunks}) ->
+			[{B, TX, Proof} || Proof <- build_proofs(B, TX, Chunks)]
+		end,
+		Records
+	),
+	lists:foreach(
+		fun({_, _, Proof}) ->
+			?assertMatch(
+				{ok, {{<<"200">>, _}, _, _, _, _}},
+				post_chunk(jiffy:encode(Proof))
+			)
+		end,
+		RecordsWithProofs
+	),
+	lists:foreach(
+		fun({B, _, Proof}) ->
+			EndOffset = B#block.weave_size - B#block.block_size + binary_to_integer(maps:get(offset, Proof)),
+			ExpectedProof = jiiffy:encode(#{
+				data_path => maps:get(data_path, Proof),
+				tx_path => maps:get(tx_path, Proof),
+				chunk => maps:get(chunk, Proof)
+			}),
+			ar_util:do_until(
+				fun() ->
+					case get_chunk_from_slave(EndOffset) of
+						{ok, {{<<"200">>, _}, _, ExpectedProof, _, _}} ->
+							true;
+						_ ->
+							false
+					end
+				end,
+				100,
+				60 * 1000
+			)
+		end,
+		RecordsWithProofs
+	),
+	lists:foreach(
+		fun({#tx{ id = TXID, data = Data }, _, _}) ->
+			ExpectedData = ar_util:encode(Data),
+			ar_util:do_until(
+				fun() ->
+					get_tx_data_from_slave(TXID) == ExpectedData
+				end,
+				100,
+				60 * 1000
+			)
+		end,
+		RecordsWithProofs
+	).
+
+post_chunk(Body) ->
+	ar_http:req(#{
+		method => post,
+		peer => {127, 0, 0, 1, 1984},
+		path => "/chunk",
+		body => Body
+	}).
+
+setup_node() ->
+	Wallet = {_, Pub} = ar_wallet:new(),
+	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(20), <<>>}]),
+	{Master, _} = start(B0),
+	{Master, Wallet}.
+
+setup_nodes() ->
+	Wallet = {_, Pub} = ar_wallet:new(),
+	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(20), <<>>}]),
+	{Master, _} = start(B0),
+	{Slave, _} = slave_start(B0),
+	connect_to_slave(),
+	{Master, Slave, Wallet}.
+
+tx(Wallet, Params) ->
+	tx(Wallet, Params, v2).
+
+v1_tx(Wallet, Params) ->
+	tx(Wallet, Params, v1).
+
+tx(Wallet, #{ chunks := ChunkCount }, Format) ->
+	{Data, Chunks} = lists:foldl(
+		fun(_, {Data, Chunks}) ->
+			OneThird = ?DATA_CHUNK_SIZE div 3,
+			RandomSize = OneThird + rand:uniform(?DATA_CHUNK_SIZE - OneThird) - 1,
+			Chunk = crypto:strong_rand_bytes(RandomSize),
+			{<< Data/binary, Chunk/binary >>, [Chunk | Chunks]}
+		end,
+		{<<>>, []},
+		lists:seq(1, ChunkCount)
+	),
+	TX = case Format of
+		v1 ->
+			sign_v1_tx(Wallet, #{ data => Data });
+		v2 ->
+			sign_tx(Wallet, #{ data => Data })
+	end,
+	{TX, Chunks}.
+
+post_and_wait_until_confirmed(Master, TX, Confirmations) ->
+	assert_post_tx_to_master(Master, TX),
+	lists:foreach(
+		fun(Height) ->
+			ar_node:mine(Master),
+			wait_until_height(Master, Height)
+		end,
+		lists:seq(1, Confirmations)
+	),
+	[{H, _, _} | _] = ar_node:get_block_index(Master),
+	BShadow = ar_storage:read_block(H),
+	BShadow#block{ txs = ar_storage:read_tx(BShadow#block.txs) }.
+
+build_proofs(B, TX, Chunks) ->
+	SizeTaggedTXs = ar_block:generate_size_tagged_list_from_txs(B#block.txs),
+	{_, TXOffset} = lists:nth(index(TX#tx.id, lists:sort(B#block.txs)), SizeTaggedTXs),
+	{TXRoot, TXTree} = ar_merkle:generate_tree(SizeTaggedTXs),
+	TXPath = ar_merkle:generate_path(TXRoot, TXOffset, TXTree),
+	SizeTaggedChunks = ar_tx:chunks_to_size_tagged_chunks(Chunks),
+	{DataRoot, DataTree} = ar_merkle:generate_tree(SizeTaggedChunks),
+	lists:foldl(
+		fun({Chunk, ChunkOffset}, Proofs) ->
+			Proof = #{
+				tx_path => TXPath,
+				data_path => ar_merkle:generate_path(DataRoot, ChunkOffset, DataTree),
+				chunk => Chunk,
+				offset => integer_to_binary(TXOffset + ChunkOffset)
+			},
+			Proofs ++ Proof
+		end,
+		[],
+		SizeTaggedChunks
+	).
+
+index(TXID, TXs) ->
+	index(TXID, TXs, 1).
+
+index(TXID, [#tx{ id = TXID } | _], Index) ->
+	Index;
+index(TXID, [_ | TXs], Index) ->
+	index(TXID, TXs, Index + 1).
+
+get_chunk(Offset) ->
+	ar_http:req(#{
+		method => get,
+		peer => {127, 0, 0, 1, 1984},
+		path => "/chunk/" ++ integer_to_list(Offset)
+	}).
+
+get_chunk_from_slave(Offset) ->
+	ar_http:req(#{
+		method => get,
+		peer => {127, 0, 0, 1, 1983},
+		path => "/chunk/" ++ integer_to_list(Offset)
+	}).
+
+get_tx_data(TXID) ->
+	ar_http:req(#{
+		method => get,
+		peer => {127, 0, 0, 1, 1984},
+		path => "/tx/" ++ binary_to_list(ar_util:encode(TXID)) ++ "/data"
+	}).
+
+get_tx_data_from_slave(TXID) ->
+	ar_http:req(#{
+		method => get,
+		peer => {127, 0, 0, 1, 1983},
+		path => "/tx/" ++ binary_to_list(ar_util:encode(TXID)) ++ "/data"
+	}).
+
+post_random_blocks(Master, Slave, Wallet) ->
+	BlockMap = [
+		[v1],
+		empty,
+		[v2, v1],
+		[v2, v2, v2],
+		empty,
+		[v1, v2, v2, v2],
+		[v2],
+		empty,
+		empty,
+		[v1, v2, v1, v2],
+		empty,
+		empty,
+		empty,
+		empty
+	],
+	lists:foldl(
+		fun
+			({empty, Height}, Acc) ->
+				ar_node:mine(Master),
+				assert_slave_wait_until_height(Slave, Height),
+				Acc;
+			({TXMap, Height}, Acc) ->
+				TXsWithChunks = lists:map(
+					fun
+						(v1) ->
+							v1_tx(Wallet, #{ chunks => rand:uniform(10) });
+						(v2) ->
+							tx(Wallet, #{ chunks => rand:uniform(10) })
+					end,
+					TXMap
+				),
+				lists:foreach(
+					fun
+						({#tx{ format = 2 } = TX, _}) ->
+							assert_post_tx_to_master(Master, TX#tx{ data = <<>> });
+						(TX) ->
+							assert_post_tx_to_master(Master, TX)
+					end,
+					TXsWithChunks
+				),
+				ar_node:mine(Master),
+				assert_slave_wait_until_height(Slave, Height),
+				[{H, _, _} | _] = ar_node:get_block_index(Master),
+				BShadow = ar_storage:read_block(H),
+				B = BShadow#block{ txs = ar_storage:read_tx(BShadow#block.txs) },
+				[{B, TX, Chunks} || {TX, Chunks} <- TXsWithChunks] ++ Acc
+		end,
+		[],
+		lists:zip(BlockMap, lists:seq(1, length(BlockMap)))
+	).


### PR DESCRIPTION
This PR introduces the processing logic of the `ar_data_sync`.
The `ar_data_sync` is a gen-server process responsible for
tracking and synchronizing specific chunks on the weave as
desired (through specifying desire bytes on the weave range).
The data sync initialization and processing callbacks are
implemented as part of this PR.

Also included, is a pluggable KV store, `ar_kv` with a default
`ar_kv_rocksdb` backend engine. More backend engines could
be introduced in future, e.g. `ar_kv_mnesia`, etc