### PR TITLE
Remove 'get_block' message handling in ar_node

### DIFF
--- a/apps/arweave/src/ar_node.erl
+++ b/apps/arweave/src/ar_node.erl
@@ -672,10 +672,6 @@ handle(SPid, {get_blocks, From, Ref}) ->
 	{ok, BI} = ar_node_state:lookup(SPid, block_index),
 	From ! {Ref, blocks, self(), BI},
 	ok;
-handle(SPid, {get_block, From, Ref}) ->
-	{ok, BI} = ar_node_state:lookup(SPid, block_index),
-	From ! {Ref, block, self(), ar_node_utils:find_block(BI)},
-	ok;
 handle(SPid, {get_peers, From, Ref}) ->
 	{ok, GS} = ar_node_state:lookup(SPid, gossip),
 	From ! {Ref, peers, ar_gossip:peers(GS)},


### PR DESCRIPTION
This is no longer in use/exposed by the `ar_node` API.
Sending **{get_block, self(), Ref = make_ref()}** message
to `ar_node` process calls `ar_node_utils:find_block(BI)`,
which doesnt handle block index, resulting in a hidden
crash while `ar_node` server loop executes.

```
(master@127.0.0.1)1> [B0] = ar_weave:init().
[{block,<<58,92,17,196,106,79,25,177,135,103,57,148,88,15,
          67,177,252,20,95,226,171,151,233,157,54,246,...>>,
        <<>>,1588695511,1588695511,1,0,
        <<214,236,255,237,159,82,137,200,81,109,68,4,198,46,51,
          139,41,154,191,249,...>>,
        <<245,34,110,156,0,74,215,153,42,10,15,0,216,244,236,121,
          225,58,100,...>>,
        [],<<>>,[],[],<<>>,
        [{<<97,165,128,237,152,105,52,216,132,254,31,...>>,
          100000000000000000,<<>>},
         {<<121,149,23,223,31,143,84,212,45,135,...>>,
          100000000000000000,<<>>},
         {<<179,80,82,36,143,249,243,237,121,...>>,
          100000000000000000,<<>>},
         {<<20,3,182,147,52,111,136,165,...>>,
          100000000000000000,<<>>},
         {<<0,190,91,51,73,204,221,...>>,100000000000000000,<<>>},
         {<<"YVRî\v¥zPRÿEÕX"...>>,100000000000000000,<<>>},
         {<<"F¾3#ÐÞ"...>>,100000000000000000,<<>>},
         {<<132,116,65,64,...>>,100000000000000000,<<>>},
         {<<"Æåu§´¼"...>>,100000000000000000,<<>>},
         {<<"&¬\b"...>>,100000000000000000,<<>>},
         {<<"&"...>>,100000000000000000,...},
         {<<...>>,...},
         {...}|...],
        <<127,134,56,130,194,99,145,67,29,225,142,202,...>>,
        unclaimed,[],0,0,0,0,
        {poa,1,<<>>,<<>>,<<>>}}]
(master@127.0.0.1)2>
(master@127.0.0.1)2> Node = ar_node:start([], [B0]).
<0.861.0>
(master@127.0.0.1)3>
(master@127.0.0.1)3> BI = ar_node:get_block_index(Node).
[{<<245,34,110,156,0,74,215,153,42,10,15,0,216,244,236,
    121,225,58,100,62,82,175,49,134,5,43,94,...>>,
  0,<<>>}]
(master@127.0.0.1)4>
(master@127.0.0.1)4> ar_node_utils:find_block( BI ).
** exception error: no function clause matching ar_node_utils:find_block([{<<245,34,110,156,0,74,215,153,42,10,15,0,216,244,236,
                                                                             121,225,58,100,62,82,175,49,134,5,43,...>>,
....
```