### PR TITLE
Drop committed transactions from priority queue

### DIFF
--- a/apps/arweave/src/ar_fork_recovery.erl
+++ b/apps/arweave/src/ar_fork_recovery.erl
@@ -280,7 +280,8 @@ apply_next_block(State, NextB, B) ->
 			NewBlockTXPairs = ar_node_utils:update_block_txs_pairs(NextB, BlockTXPairs),
 			lists:foreach(
 				fun(TX) ->
-					ar_downloader:enqueue_random({tx_data, TX})
+					ar_downloader:enqueue_random({tx_data, TX}),
+					ar_tx_queue:drop_tx(TX)
 				end,
 				NextB#block.txs
 			),

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -325,7 +325,8 @@ integrate_new_block(
 	end,
 	lists:foreach(
 		fun(TX) ->
-			ar_downloader:enqueue_random({tx_data, TX})
+			ar_downloader:enqueue_random({tx_data, TX}),
+			ar_tx_queue:drop_tx(TX)
 		end,
 		BlockTXs
 	),

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -670,7 +670,8 @@ integrate_block_from_miner(StateIn, NewB, MinedTXs, BDS, _POA) ->
 	),
 	lists:foreach(
 		fun(TX) ->
-			ar_downloader:enqueue_random({tx_data, TX})
+			ar_downloader:enqueue_random({tx_data, TX}),
+			ar_tx_queue:drop_tx(TX)
 		end,
 		MinedTXs
 	),

--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -11,7 +11,7 @@
 -export([wait_until_receives_txs/2]).
 -export([assert_wait_until_receives_txs/2]).
 -export([assert_slave_wait_until_receives_txs/2]).
--export([post_tx_to_slave/2, post_tx_to_master/2]).
+-export([post_tx_to_slave/2, post_tx_to_master/2, post_tx_to_master/3]).
 -export([assert_post_tx_to_slave/2, assert_post_tx_to_master/2]).
 -export([sign_tx/1, sign_tx/2, sign_tx/3]).
 -export([sign_v1_tx/1, sign_v1_tx/2, sign_v1_tx/3]).
@@ -230,6 +230,9 @@ assert_post_tx_to_master(Master, TX) ->
 	{ok, {{<<"200">>, _}, _, <<"OK">>, _, _}} = post_tx_to_master(Master, TX).
 
 post_tx_to_master(Master, TX) ->
+	post_tx_to_master(Master, TX, true).
+
+post_tx_to_master(Master, TX, Wait) ->
 	Port = ar_meta_db:get(port),
 	MasterIP = {127, 0, 0, 1, Port},
 	Reply =
@@ -242,7 +245,12 @@ post_tx_to_master(Master, TX) ->
 		}),
 	case Reply of
 		{ok, {{<<"200">>, _}, _, <<"OK">>, _, _}} ->
-			assert_wait_until_receives_txs(Master, [TX]);
+			case Wait of
+				true ->
+					assert_wait_until_receives_txs(Master, [TX]);
+				false ->
+					ok
+			end;
 		_ ->
 			ar:console(
 				"Failed to post transaction. Error DB entries: ~p~n",


### PR DESCRIPTION
Normally, transactions are included in blocks only after they leave the priority queue. However, a TX may
be sent to multiple nodes and if the load distribution is not uniform, the node under a bigger pressure may
see the transaction included in a block while it still stays in its queue.