### PR TITLE
Update otp_release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
     - epmd -daemon
 otp_release:
     - 22.2
+    - 23.0
 # blocklist
 branches:
     except:

--- a/apps/arweave/c_src/Makefile
+++ b/apps/arweave/c_src/Makefile
@@ -34,7 +34,7 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I ../lib/RandomX/src
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I ../lib/RandomX/src
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei ../lib/RandomX/build/librandomx.a
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lei ../lib/RandomX/build/librandomx.a
 LDFLAGS += -shared
 
 # Verbosity.

--- a/apps/arweave/src/ar_http.erl
+++ b/apps/arweave/src/ar_http.erl
@@ -60,7 +60,7 @@ make_request(Pid, #{method := post, path := P} = Opts) ->
 		_ ->
 			maps:get(headers, Opts, [])
 	end,
-	gun:post(Pid, P, Headers, maps:get(body, Opts, <<>>));
+	gun:post(Pid, P, Headers, iolist_to_binary(maps:get(body, Opts, <<>>)));
 make_request(Pid, #{method := get, path := P} = Opts) ->
 	gun:get(Pid, P, merge_headers(?DEFAULT_REQUEST_HEADERS, maps:get(headers, Opts, []))).
 
@@ -135,7 +135,7 @@ upload_metric(#{method := post, path := Path, body := Body}) ->
 	prometheus_counter:inc(
 		http_client_uploaded_bytes_total,
 		[ar_metrics:label_http_path(list_to_binary(Path))],
-		byte_size(Body)
+		byte_size(iolist_to_binary(Body))
 	);
 upload_metric(_) ->
 	ok.

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -325,7 +325,7 @@ handle(<<"GET">>, [<<"tx">>, EncodedID, <<"offset">>], Req, _Pid) ->
 handle(<<"POST">>, [<<"chunk">>], Req, Pid) ->
 	case read_complete_body(Req, Pid, ?MAX_SERIALIZED_CHUNK_PROOF_SIZE) of
 		{ok, Body, Req2} ->
-			case ar_serialize:json_decode(Body, [{return_maps, true}]) of
+			case ar_serialize:json_decode(Body, [return_maps]) of
 				{ok, JSON} ->
 					case catch ar_serialize:json_map_to_chunk_proof(JSON) of
 						{'EXIT', _} ->

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -31,16 +31,10 @@ json_decode(JSON) ->
 	json_decode(JSON, []).
 
 json_decode(JSON, Opts) ->
-	ReturnMaps = proplists:get_bool(return_maps, Opts),
-	JiffyOpts =
-		case ReturnMaps of
-			true -> [return_maps];
-			false -> []
-		end,
-	try
-		{ok, jiffy:decode(JSON, JiffyOpts)}
-	catch
-		{error, Reason} -> {error, Reason}
+	case catch jiffy:decode(JSON, Opts) of
+		{{_, truncated_json}, _} -> {error, truncated_json};
+		{'EXIT', _} -> {error, invalid_json};
+		DecJSON -> {ok, DecJSON}
 	end.
 
 %% @doc Convert a block record into a JSON struct.

--- a/apps/arweave/test/ar_data_sync_tests.erl
+++ b/apps/arweave/test/ar_data_sync_tests.erl
@@ -354,7 +354,7 @@ test_accepts_chunks() ->
 	%% (EndOffset - ChunkSize, EndOffset], but not outside of it.
 	FirstChunk = ar_util:decode(maps:get(chunk, FirstProof)),
 	FirstChunkSize = byte_size(FirstChunk),
-	ExpectedProof = jiffy:encode(#{
+	ExpectedProof = ar_serialize:jsonify(#{
 		data_path => maps:get(data_path, FirstProof),
 		tx_path => maps:get(tx_path, FirstProof),
 		chunk => ar_util:encode(FirstChunk)
@@ -397,7 +397,7 @@ test_accepts_chunks() ->
 		{ok, {{<<"200">>, _}, _, _, _, _}},
 		post_chunk(jiffy:encode(SecondProof))
 	),
-	ExpectedSecondProof = jiffy:encode(#{
+	ExpectedSecondProof = ar_serialize:jsonify(#{
 		data_path => maps:get(data_path, SecondProof),
 		tx_path => maps:get(tx_path, SecondProof),
 		chunk => maps:get(chunk, SecondProof)
@@ -416,7 +416,7 @@ test_accepts_chunks() ->
 		500,
 		10 * 1000
 	),
-	ExpectedThirdProof = jiffy:encode(#{
+	ExpectedThirdProof = ar_serialize:jsonify(#{
 		data_path => maps:get(data_path, ThirdProof),
 		tx_path => maps:get(tx_path, ThirdProof),
 		chunk => maps:get(chunk, ThirdProof)

--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,13 @@
 {deps, [
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "a0ef55ec66ecf705848716c195bf45665f78818a"}}},
-	{jiffy, "0.15.2"},
+	{jiffy, "1.0.5"},
 	{gun, "1.3.2"},
 	{cowboy, "2.7.0"},
 	{graphql, {git, "https://github.com/shopgun/graphql-erlang.git", {branch, "master"}}},
 	{prometheus, "4.4.1"},
-	{prometheus_process_collector, "1.4.5"},
-	{prometheus_cowboy, {git, "https://github.com/ArweaveTeam/prometheus-cowboy.git", {ref, "3386d21191527831fd4480178633d1bb5aed253b"}}},
-	{rocksdb, {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {tag, "1.5.1"}}}
+	{prometheus_process_collector, "1.6.0"},
+	{prometheus_cowboy, "0.1.8"},
+	{rocksdb, {git, "https://gitlab.com/tonpa/erlang-rocksdb.git", {ref, "d45d326e"}}} %@TODO: back to barrel-db/erlang-rocksdb after merge: merge_requests/129, issue https://gitlab.com/barrel-db/erlang-rocksdb/-/issues/113
 ]}.
 
 {relx, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -11,20 +11,17 @@
        {ref,"fc76a2df7d1ddcf8bcc3bb46363e7ca8fca80939"}},
   0},
  {<<"gun">>,{pkg,<<"gun">>,<<"1.3.2">>},0},
- {<<"jiffy">>,{pkg,<<"jiffy">>,<<"0.15.2">>},0},
+ {<<"jiffy">>,{pkg,<<"jiffy">>,<<"1.0.5">>},0},
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.4.1">>},0},
- {<<"prometheus_cowboy">>,
-  {git,"https://github.com/ArweaveTeam/prometheus-cowboy.git",
-       {ref,"3386d21191527831fd4480178633d1bb5aed253b"}},
-  0},
+ {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.1.8">>},0},
  {<<"prometheus_httpd">>,{pkg,<<"prometheus_httpd">>,<<"2.1.11">>},1},
  {<<"prometheus_process_collector">>,
-  {pkg,<<"prometheus_process_collector">>,<<"1.4.5">>},
+  {pkg,<<"prometheus_process_collector">>,<<"1.6.0">>},
   0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},1},
  {<<"rocksdb">>,
-  {git,"https://gitlab.com/barrel-db/erlang-rocksdb.git",
-       {ref,"edabdc409ad729213deea25f5eb427bc5fada97d"}},
+  {git,"https://gitlab.com/tonpa/erlang-rocksdb.git",
+       {ref,"d45d326e7d3da4947153bc0179525408ce8afaf9"}},
   0}]}.
 [
 {pkg_hash,[
@@ -32,9 +29,10 @@
  {<<"cowboy">>, <<"91ED100138A764355F43316B1D23D7FF6BDB0DE4EA618CB5D8677C93A7A2F115">>},
  {<<"cowlib">>, <<"FD0FF1787DB84AC415B8211573E9A30A3EBE71B5CBFF7F720089972B2319C8A4">>},
  {<<"gun">>, <<"542064CBB9F613650B8A8100B3A927505F364FBE198B7A5A112868FF43F3E477">>},
- {<<"jiffy">>, <<"DE266C390111FD4EA28B9302F0BC3D7472468F3B8E0ACEABFBEFA26D08CD73B7">>},
+ {<<"jiffy">>, <<"A69B58FAF7123534C20E1B0B7AE97AC52079CA02ED4B6989B4B380179CD63A54">>},
  {<<"prometheus">>, <<"1E96073B3ED7788053768FEA779CBC896DDC3BDD9BA60687F2AD50B252AC87D6">>},
+ {<<"prometheus_cowboy">>, <<"CFCE0BC7B668C5096639084FCD873826E6220EA714BF60A716F5BD080EF2A99C">>},
  {<<"prometheus_httpd">>, <<"F616ED9B85B536B195D94104063025A91F904A4CFC20255363F49A197D96C896">>},
- {<<"prometheus_process_collector">>, <<"9BAEA93F5D8C2758DBAD0DE021EF74438D2F81A01D1F24F5EF0BB949A7B4191D">>},
+ {<<"prometheus_process_collector">>, <<"B169E224337497CD858DA16F9361EDABC5931B9D12201A97EE15D88EF5A6FCAA">>},
  {<<"ranch">>, <<"6B1FAB51B49196860B733A49C07604465A47BDB78AA10C1C16A3D199F7F8C881">>}]}
 ].


### PR DESCRIPTION
- Issue: https://github.com/ArweaveTeam/arweave/issues/249
- Issue of `erlang-rocksdb`: https://gitlab.com/barrel-db/erlang-rocksdb/-/issues/113
- Issue of `prometheus_process_collector`: https://github.com/deadtrickster/prometheus_process_collector/issues/21
- Issue of `jiffy`: https://github.com/davisp/jiffy/issues/197
**Notes:** (C) The old legacy `erl_interface` library is deprecated as of `OTP 22`, and will be removed in `OTP 23`. This does not apply to the ei library(https://www.erlang.org/downloads/22.0)