### PR TITLE
Fetch new blocks' missing transactions earlier

### DIFF
--- a/apps/arweave/test/ar_multiple_txs_per_wallet_tests.erl
+++ b/apps/arweave/test/ar_multiple_txs_per_wallet_tests.erl
@@ -601,7 +601,6 @@ joins_network_successfully() ->
 		{ar_wallet:to_address(Pub), ?AR(20), <<>>}
 	]),
 	{Slave, _} = slave_start(B0),
-	disconnect_from_slave(),
 	{TXs, _} = lists:foldl(
 		fun(Height, {TXs, LastTX}) ->
 			{TX, AnchorType} = case rand:uniform(4) of

--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -195,7 +195,7 @@ wait_until_receives_txs(Node, TXs) ->
 			end
 		end,
 		100,
-		10 * 1000
+		60 * 1000
 	).
 
 assert_slave_wait_until_receives_txs(Node, TXs) ->


### PR DESCRIPTION
Before this change, the node would wait for another block to arrive before attempting
to download the missing transactions from the first block. This was an attempt to disincentivize
mining transactions into blocks without giving them reasonable time to spread across the network.

However, the disincentivization is there even without the change, because it takes time for
verifiers to download transactions, what increases the chance of a fork away from the block
in question. Therefore, the extra delay merely increases the forkiness in the network.