### PR TITLE
fix sub-query by block height

### DIFF
--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -1697,7 +1697,7 @@ search_in_block_index(H, BI) ->
 %% @doc Find a block, given a type and a specifier.
 find_block(<<"height">>, RawHeight) ->
 	BI = ar_node:get_block_index(whereis(http_entrypoint_node)),
-	ar_storage:read_block(binary_to_integer(RawHeight), BI);
+	ar_storage:read_block(RawHeight, BI);
 find_block(<<"hash">>, ID) ->
 	ar_storage:read_block(ID).
 


### PR DESCRIPTION
```
Error in process <0.12824.0> on node 'arweave@127.0.0.1' with exit value:
{badarg,
    [{erlang,binary_to_integer,[557419],[]},
     {ar_http_iface_middleware,find_block,2,
...
```