### PR TITLE
mention disk_space param in "out of space" message

### DIFF
--- a/apps/arweave/src/ar_header_sync.erl
+++ b/apps/arweave/src/ar_header_sync.erl
@@ -144,7 +144,8 @@ handle_cast(check_space_alarm, State) ->
 		false ->
 			Msg =
 				"The node has stopped syncing headers - the available disk space is"
-				" less than ~s. Add more disk space if you wish to store more headers.",
+				" less than ~s. Add more disk space or increase `disk_space` limit "
+				"if you wish to store more headers.",
 			ar:console(Msg, [ar_util:bytes_to_mb_string(?DISK_HEADERS_BUFFER_SIZE)]),
 			?LOG_INFO([
 				{event, ar_header_sync_stopped_syncing},


### PR DESCRIPTION
The current message is confusing when there is enough disk space in general, but the used space is below `disk_space` limit CLI parameter. 

This PR adds an explicit mention of `disk_space` param to prevent confusion for new users e.g. if that param is incorrectly set or if the parameter limit is the issue instead of overall available disk space.

Note: updated the log message text only - so haven't ran tests (made the change on github UI).