### PR TITLE
CMake requirements supplement to compile the upgrade "Upgrade erlang-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, refer to the [mining guide](https://docs.arweave.org/info/
 - Erlang OTP v23+, with OpenSSL support
 - GCC or Clang
 - GNU Make
-- CMake
+- CMake (CMake version > 3.10.0)
 - SQLite3 headers (libsqlite3-dev on Ubuntu)
 - GNU MP (libgmp-dev on Ubuntu)
 


### PR DESCRIPTION
…rocksdb to 1.7.0; RocksDB 6.25.3"

If the CMake version is below v3.10.0, we could still build a rocksDB binary lib but meetting the error at bin/start of arweave issued #349