### PR TITLE
Defragmentation of chunk files

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -171,7 +171,8 @@
 			= ?DEFAULT_MAX_NONCE_LIMITER_LAST_STEP_VALIDATION_THREAD_COUNT,
 	nonce_limiter_server_trusted_peer = not_set,
 	nonce_limiter_client_peers = [],
-	debug = false
+	debug = false,
+	run_defragmentation = false
 }).
 
 -endif.

--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -172,7 +172,8 @@
 	nonce_limiter_server_trusted_peer = not_set,
 	nonce_limiter_client_peers = [],
 	debug = false,
-	run_defragmentation = false
+	run_defragmentation = false,
+	defragmentation_trigger_threshold = 1_500_000_000
 }).
 
 -endif.

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -296,7 +296,9 @@ show_help() ->
 			{"debug",
 				"Enable extended logging."},
 			{"run_defragmentation",
-				"Run defragmentation of chunk storage files"}
+				"Run defragmentation of chunk storage files"},
+			{"defragmentation_trigger_threshold",
+				"File size threshold in bytes for it to be considered for defragmentation"}
 		]
 	),
 	erlang:halt().
@@ -498,6 +500,8 @@ parse_cli_args(["debug" | Rest], C) ->
 	parse_cli_args(Rest, C#config{ debug = true });
 parse_cli_args(["run_defragmentation" | Rest], C) ->
 	parse_cli_args(Rest, C#config{ run_defragmentation = true });
+parse_cli_args(["defragmentation_trigger_threshold", Num | Rest], C) ->
+	parse_cli_args(Rest, C#config{ defragmentation_trigger_threshold = list_to_integer(Num) });
 parse_cli_args([Arg | _Rest], _O) ->
 	io:format("~nUnknown argument: ~s.~n", [Arg]),
 	show_help().

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -294,8 +294,9 @@ show_help() ->
 			{"vdf_client_peer", "If the option is set, the node will push VDF updates "
 					"to this peer. You can specify several vdf_client_peer options."},
 			{"debug",
-				"Enable extended logging."
-			}
+				"Enable extended logging."},
+			{"run_defragmentation",
+				"Run defragmentation of chunk storage files"}
 		]
 	),
 	erlang:halt().
@@ -495,6 +496,8 @@ parse_cli_args(["vdf_client_peer", Peer | Rest],
 	end;
 parse_cli_args(["debug" | Rest], C) ->
 	parse_cli_args(Rest, C#config{ debug = true });
+parse_cli_args(["run_defragmentation" | Rest], C) ->
+	parse_cli_args(Rest, C#config{ run_defragmentation = true });
 parse_cli_args([Arg | _Rest], _O) ->
 	io:format("~nUnknown argument: ~s.~n", [Arg]),
 	show_help().
@@ -586,6 +589,7 @@ start(normal, _Args) ->
 		true  -> app_ipfs:start_pinning()
 	end,
 	set_mining_address(Config),
+	ar_chunk_storage:run_defragmentation(),
 	%% Start Arweave.
 	ar_sup:start_link().
 

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -512,11 +512,13 @@ files_to_defrag(StorageModules, DataDir, ByteSizeThreshold) ->
 defrag_files([]) ->
 	ok;
 defrag_files([Filepath | Rest]) ->
-	ar:console("Defragmenting file: ~ts~n", [Filepath]),
-	%% TODO: Actually defragment file, what you see here is an initial idea on
-	%% 		 how it can be done, but this should be validated first
-	%% DefragCmd = io_lib:format("rsync --sparse ~ts ~ts", [Filepath, Filepath]),
-	%% os:cmd(DefragCmd),
+	?LOG_DEBUG([{event, defragmenting_file}, {file, Filepath}]),
+	TmpFilepath = Filepath ++ ".tmp",
+	DefragCmd = io_lib:format("rsync --sparse --quiet ~ts ~ts", [Filepath, TmpFilepath]),
+	MoveDefragCmd = io_lib:format("mv ~ts ~ts", [TmpFilepath, Filepath]),
+	%% We expect nothing to be returned on successful calls
+	[] = os:cmd(DefragCmd),
+	[] = os:cmd(MoveDefragCmd),
 	defrag_files(Rest).
 
 %%%===================================================================

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -153,7 +153,15 @@ delete(Offset, StoreID) ->
 
 %% @doc Run defragmentation of chunk files if enabled
 run_defragmentation() ->
-	pending_implementation.
+	{ok, Config} = application:get_env(arweave, config),
+	case Config#config.run_defragmentation of
+		false ->
+			ok;
+		true ->
+			Files = files_to_defrag(Config#config.storage_modules,
+									Config#config.data_dir),
+			defrag_files(Files)
+	end.
 
 %%%===================================================================
 %%% Generic server callbacks.
@@ -464,6 +472,32 @@ sync_and_close_files([_ | Keys]) ->
 	sync_and_close_files(Keys);
 sync_and_close_files([]) ->
 	ok.
+
+files_to_defrag(StorageModules, DataDir) ->
+	%% TODO: This gets all files, but it is missing a filter based on file
+	%%       size so it is not included if it hasn't grown beyond a threshold
+	lists:flatmap(fun (StorageModule) ->
+		StorageId = ar_storage_module:id(StorageModule),
+		Dir =
+			case StorageId of
+				"default" ->
+					DataDir;
+				_ ->
+					filename:join([DataDir, "storage_modules", StorageId])
+			end,
+		StorageIndex = read_file_index(Dir),
+		maps:values(StorageIndex)
+	end, StorageModules).
+
+defrag_files([]) ->
+	ok;
+defrag_files([Filepath | Rest]) ->
+	ar:console("Defragmenting file: ~ts~n", [Filepath]),
+	%% TODO: Actually defragment file, what you see here is an initial idea on
+	%% 		 how it can be done, but this should be validated first
+	%% DefragCmd = io_lib:format("rsync --sparse ~ts ~ts", [Filepath, Filepath]),
+	%% os:cmd(DefragCmd),
+	defrag_files(Rest).
 
 %%%===================================================================
 %%% Tests.

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -4,7 +4,7 @@
 -behaviour(gen_server).
 
 -export([start_link/2, put/2, put/3, open_files/1, get/1, get/2, get_range/2, get_range/3,
-		close_file/2, close_files/1, cut/2, delete/1, delete/2]).
+		close_file/2, close_files/1, cut/2, delete/1, delete/2, run_defragmentation/0]).
 
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
@@ -150,6 +150,10 @@ delete(Offset) ->
 delete(Offset, StoreID) ->
 	GenServerID = list_to_atom("ar_chunk_storage_" ++ StoreID),
 	gen_server:call(GenServerID, {delete, Offset}, 10000).
+
+%% @doc Run defragmentation of chunk files if enabled
+run_defragmentation() ->
+	pending_implementation.
 
 %%%===================================================================
 %%% Generic server callbacks.

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -513,12 +513,8 @@ defrag_files([]) ->
 	ok;
 defrag_files([Filepath | Rest]) ->
 	?LOG_DEBUG([{event, defragmenting_file}, {file, Filepath}]),
-	TmpFilepath = Filepath ++ ".tmp",
-	DefragCmd = io_lib:format("rsync --sparse --quiet ~ts ~ts", [Filepath, TmpFilepath]),
-	MoveDefragCmd = io_lib:format("mv ~ts ~ts", [TmpFilepath, Filepath]),
-	%% We expect nothing to be returned on successful calls
-	[] = os:cmd(DefragCmd),
-	[] = os:cmd(MoveDefragCmd),
+	DefragCmd = io_lib:format("dd if=~ts of=~ts conv=notrunc bs=1048576", [Filepath, Filepath]),
+	os:cmd(DefragCmd),
 	defrag_files(Rest).
 
 %%%===================================================================

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -452,6 +452,9 @@ parse_options([{<<"vdf_client_peers">>, Peers} | _], _) ->
 parse_options([{<<"debug">>, B} | Rest], Config) when is_boolean(B) ->
 	parse_options(Rest, Config#config{ debug = B });
 
+parse_options([{<<"run_defragmentation">>, B} | Rest], Config) when is_boolean(B) ->
+	parse_options(Rest, Config#config{ run_defragmentation = B });
+
 parse_options([Opt | _], _) ->
 	{error, unknown, Opt};
 parse_options([], Config) ->

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -455,6 +455,9 @@ parse_options([{<<"debug">>, B} | Rest], Config) when is_boolean(B) ->
 parse_options([{<<"run_defragmentation">>, B} | Rest], Config) when is_boolean(B) ->
 	parse_options(Rest, Config#config{ run_defragmentation = B });
 
+parse_options([{<<"defragmentation_trigger_threshold">>, D} | Rest], Config) when is_integer(D) ->
+	parse_options(Rest, Config#config{ defragmentation_trigger_threshold = D });
+
 parse_options([Opt | _], _) ->
 	{error, unknown, Opt};
 parse_options([], Config) ->


### PR DESCRIPTION
- Add config `run_defragmentation` to enable running defragmentation
- Add config `defragmentation_trigger_threshold` to set minimum file size to do defragmentation on
- Get all chunk files and filter based on `defragmentation_trigger_threshold` and the growth of the files (currently hardcoded at 10%)
- Defragment file (`rsync --sparse ...`)
- Keep track of defragmented files size in a `chunks_sizes` file