### PR TITLE
Change `current` field in mining performance report to be a time window since last report

### DIFF
--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -191,7 +191,7 @@ handle_cast(report_performance, #state{ io_threads = IOThreads, session = Sessio
 					[{_, PartitionStart, PartitionTotal, CurrentStart, CurrentTotal}] ->
 						ets:update_counter(?MODULE,
 										   {performance, Partition},
-										   [{4, 0, -1, Now}, {5, 0, -1, 0}]),
+										   [{4, -1, Now, Now}, {5, 0, -1, 0}]),
 						PartitionTimeLapse = (Now - PartitionStart) / 1000,
 						PartitionAvg = PartitionTotal / PartitionTimeLapse / 4,
 						CurrentTimeLapse = (Now - CurrentStart) / 1000,


### PR DESCRIPTION
The core of the change here is on how the performance report is tracked and what it shows

The tracking has changed to keep track of 4 things
- Timestamp from when the partition "started" to be mined 
- Counter since partition "started"
- Timestamp of last report
- Counter since last report

Given this changes the `avg` displayed is the same as before, but now `current` refers to the values since last time it was reported. If the reports are paused this will cause the first one to come out to be a sort of average for that duration of the pause