### PR TITLE
Add estimated optimal performance of partition to mining report

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -188,6 +188,7 @@
 	debug = false,
 	run_defragmentation = false,
 	defragmentation_trigger_threshold = 1_500_000_000,
+	defragmentation_modules = [],
 	block_throttle_by_ip_interval = ?DEFAULT_BLOCK_THROTTLE_BY_IP_INTERVAL_MS,
 	block_throttle_by_solution_interval = ?DEFAULT_BLOCK_THROTTLE_BY_SOLUTION_INTERVAL_MS
 }).

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -308,7 +308,10 @@ show_help() ->
 			{"block_throttle_by_solution_interval (number)",
 					io_lib:format("The number of milliseconds that have to pass before "
 							"we accept another block with the same solution hash. "
-							"Default: ~B.", [?DEFAULT_BLOCK_THROTTLE_BY_SOLUTION_INTERVAL_MS])}
+							"Default: ~B.", [?DEFAULT_BLOCK_THROTTLE_BY_SOLUTION_INTERVAL_MS])},
+			{"defragment_module",
+				"Run defragmentation on the provided chunk storage files. "
+				"If this is provided it implies run_defragmentation option is true"}
 		]
 	),
 	erlang:halt().
@@ -519,6 +522,16 @@ parse_cli_args(["block_throttle_by_ip_interval", Num | Rest], C) ->
 parse_cli_args(["block_throttle_by_solution_interval", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config{
 			block_throttle_by_solution_interval = list_to_integer(Num) });
+parse_cli_args(["defragment_module", DefragModuleString | Rest], C) ->
+	DefragModules = C#config.defragmentation_modules,
+	try
+		DefragModule = ar_config:parse_storage_module(DefragModuleString),
+		DefragModules2 = [DefragModule | DefragModules],
+		parse_cli_args(Rest, C#config{ defragmentation_modules = DefragModules2 })
+	catch _:_ ->
+		io:format("~ndefragment_module value must be in the [number],[address] format.~n~n"),
+		erlang:halt()
+	end;
 parse_cli_args([Arg | _Rest], _O) ->
 	io:format("~nUnknown argument: ~s.~n", [Arg]),
 	show_help().

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -665,6 +665,7 @@ benchmark_vdf_command() ->
 benchmark_vdf() ->
 	Input = crypto:strong_rand_bytes(32),
 	{Time, _} = timer:tc(fun() -> ar_vdf:compute2(1, Input, ?VDF_DIFFICULTY) end),
+	persistent_term:put(vdf_speed_ms, Time / 1000),
 	io:format("~n~nVDF step computed in ~.2f seconds.~n~n", [Time / 1000000]),
 	case Time > 1250000 of
 		true ->

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -678,7 +678,6 @@ benchmark_vdf_command() ->
 benchmark_vdf() ->
 	Input = crypto:strong_rand_bytes(32),
 	{Time, _} = timer:tc(fun() -> ar_vdf:compute2(1, Input, ?VDF_DIFFICULTY) end),
-	persistent_term:put(vdf_speed_ms, Time / 1000),
 	io:format("~n~nVDF step computed in ~.2f seconds.~n~n", [Time / 1000000]),
 	case Time > 1250000 of
 		true ->

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -161,8 +161,9 @@ run_defragmentation() ->
 		true ->
 			ar:console("Defragmentation threshold: ~B bytes.~n",
 					   [Config#config.defragmentation_trigger_threshold]),
+			DefragModules = modules_to_defrag(Config),
 			Sizes = read_chunks_sizes(Config#config.data_dir),
-			Files = files_to_defrag(Config#config.storage_modules,
+			Files = files_to_defrag(DefragModules,
 									Config#config.data_dir,
 									Config#config.defragmentation_trigger_threshold,
 									Sizes),
@@ -570,6 +571,9 @@ read_chunks_sizes(DataDir) ->
 			]),
 			error
 	end.
+
+modules_to_defrag(#config{defragmentation_modules = [_ | _] = Modules}) -> Modules;
+modules_to_defrag(#config{storage_modules = Modules}) -> Modules.
 
 %%%===================================================================
 %%% Tests.

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -480,6 +480,16 @@ parse_options([{<<"block_throttle_by_solution_interval">>, D} | Rest], Config)
 		when is_integer(D) ->
 	parse_options(Rest, Config#config{ block_throttle_by_solution_interval = D });
 
+parse_options([{<<"defragment_modules">>, L} | Rest], Config) when is_list(L) ->
+	try
+		DefragModules = [parse_storage_module(Bin) || Bin <- L],
+		parse_options(Rest, Config#config{ defragmentation_modules = DefragModules })
+	catch _:_ ->
+		{error, {bad_format, defragment_modules, "an array of \"[number],[address]\""}, L}
+	end;
+parse_options([{<<"defragment_modules">>, Bin} | _], _) ->
+	{error, {bad_type, defragment_modules, array}, Bin};
+
 parse_options([Opt | _], _) ->
 	{error, unknown, Opt};
 parse_options([], Config) ->

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -188,6 +188,9 @@ handle_cast(report_performance, #state{ io_threads = IOThreads, session = Sessio
 				case ets:lookup(?MODULE, {performance, Partition}) of
 					[] ->
 						Acc;
+					[{_, PartitionStart, _, CurrentStart, _}] when Now - PartitionStart =:= 0
+															orelse Now - CurrentStart  =:= 0 ->
+						Acc;
 					[{_, PartitionStart, PartitionTotal, CurrentStart, CurrentTotal}] ->
 						ets:update_counter(?MODULE,
 										   {performance, Partition},

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -170,12 +170,12 @@ handle_cast(report_performance, #state{ io_threads = IOThreads, session = Sessio
 	Partitions =
 		lists:sort(sets:to_list(
 			maps:fold(
-				fun({Partition, _, _}, _, Acc) ->
+				fun({Partition, _, StoreID}, _, Acc) ->
 					case Partition > Max of
 						true ->
 							Acc;
 						_ ->
-							sets:add_element(Partition, Acc)
+							sets:add_element({Partition, StoreID}, Acc)
 					end
 				end,
 				sets:new(), % A storage module may be smaller than a partition.
@@ -184,7 +184,7 @@ handle_cast(report_performance, #state{ io_threads = IOThreads, session = Sessio
 	Now = erlang:monotonic_time(millisecond),
 	{IOList, MaxPartitionTime, PartitionsSum, MaxCurrentTime, CurrentsSum} =
 		lists:foldr(
-			fun(Partition, {Acc1, Acc2, Acc3, Acc4, Acc5} = Acc) ->
+			fun({Partition, StoreID}, {Acc1, Acc2, Acc3, Acc4, Acc5} = Acc) ->
 				case ets:lookup(?MODULE, {performance, Partition}) of
 					[] ->
 						Acc;
@@ -196,11 +196,13 @@ handle_cast(report_performance, #state{ io_threads = IOThreads, session = Sessio
 						PartitionAvg = PartitionTotal / PartitionTimeLapse / 4,
 						CurrentTimeLapse = (Now - CurrentStart) / 1000,
 						CurrentAvg = CurrentTotal / CurrentTimeLapse / 4,
+						Optimal = optimal_performance(StoreID),
 						?LOG_INFO([{event, mining_partition_performance_report},
 								{partition, Partition}, {avg, PartitionAvg},
 								{current, CurrentAvg}]),
-						{[io_lib:format("Partition ~B avg: ~.2f MiB/s, current: ~.2f MiB/s.~n",
-								[Partition, PartitionAvg, CurrentAvg]) | Acc1],
+						{[io_lib:format("Partition ~B avg: ~.2f MiB/s, current: ~.2f MiB/s, "
+										"estimated optimal: ~.2f MiB/s.~n",
+								[Partition, PartitionAvg, CurrentAvg, Optimal]) | Acc1],
 								max(Acc2, PartitionTimeLapse), Acc3 + PartitionTotal,
 								max(Acc4, CurrentTimeLapse), Acc5 + CurrentTotal}
 				end
@@ -1078,6 +1080,13 @@ get_recall_bytes(H0, PartitionNumber, Nonce, PartitionUpperBound) ->
 pick_hashing_thread(Threads) ->
 	{{value, Thread}, Threads2} = queue:out(Threads),
 	{Thread, queue:in(Thread, Threads2)}.
+
+optimal_performance(StoreID) ->
+	VdfSpeed = persistent_term:get(vdf_speed_ms) / 1000,
+	case prometheus_gauge:value(v2_index_data_size_by_packing, [StoreID, spora_2_6]) of
+		undefined -> 0;
+		StorageSize -> (100 / VdfSpeed) * (StorageSize / ?PARTITION_SIZE)
+	end.
 
 %%%===================================================================
 %%% Tests.

--- a/apps/arweave/src/ar_storage_module.erl
+++ b/apps/arweave/src/ar_storage_module.erl
@@ -1,6 +1,6 @@
 -module(ar_storage_module).
 
--export([id/1, get_range/1, get_packing/1, get/2, get_all/1, get_all/2]).
+-export([id/1, get_range/1, get_packing/1, get_size/1, get/2, get_all/1, get_all/2]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_consensus.hrl").
@@ -66,6 +66,20 @@ get_packing(ID, [Module | Modules]) ->
 			Packing;
 		false ->
 			get_packing(ID, Modules)
+	end.
+
+%% @doc Return the bucket size configured for the given module.
+get_size(ID) ->
+	{ok, Config} = application:get_env(arweave, config),
+	get_size(ID, Config#config.storage_modules).
+
+get_size(ID, [Module | Modules]) ->
+	case ar_storage_module:id(Module) == ID of
+		true ->
+			{BucketSize, _Bucket, _Packing} = Module,
+			BucketSize;
+		false ->
+			get_size(ID, Modules)
 	end.
 
 %% @doc Return a configured storage module covering the given Offset, preferably

--- a/apps/arweave/test/ar_config_tests.erl
+++ b/apps/arweave/test/ar_config_tests.erl
@@ -108,6 +108,13 @@ parse_config() ->
 				{3, 3, 3, 3, 1984}],
 		run_defragmentation = true,
 		defragmentation_trigger_threshold = 1_000,
+		defragmentation_modules = [
+			{?PARTITION_SIZE, 0, unpacked},
+			{?PARTITION_SIZE, 2, {spora_2_6, ExpectedMiningAddr}},
+			{?PARTITION_SIZE, 100, unpacked},
+			{1, 0, unpacked},
+			{1000000000000, 14, {spora_2_6, ExpectedMiningAddr}}
+		],
 		block_throttle_by_ip_interval = 5_000,
 		block_throttle_by_solution_interval = 12_000
 	}, ParsedConfig).

--- a/apps/arweave/test/ar_config_tests_config_fixture.json
+++ b/apps/arweave/test/ar_config_tests_config_fixture.json
@@ -113,6 +113,13 @@
   "vdf_client_peers": ["2.3.6.7:1984", "4.7.3.1:1983", "3.3.3.3"],
   "run_defragmentation": true,
   "defragmentation_trigger_threshold": 1000,
+  "defragment_modules": [
+    "0,unpacked",
+    "2,LKC84RnISouGUw4uMQGCpPS9yDC-tIoqM2UVbUIt-Sw",
+    "100,unpacked",
+    "0,1,unpacked",
+    "14,1000000000000,LKC84RnISouGUw4uMQGCpPS9yDC-tIoqM2UVbUIt-Sw"
+  ],
   "block_throttle_by_ip_interval": 5000,
   "block_throttle_by_solution_interval": 12000
 }


### PR DESCRIPTION
Should we use the VDF speed from startup or should is there a metric we can lookup each time?