### PR TITLE
Add metrics for assessing syncing and packing performance

### DIFF
--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -348,6 +348,7 @@ store_chunk2(Key, Offset, Chunk, Filepath, F) ->
 			]),
 			Error;
 		ok ->
+			prometheus_counter:inc(chunks_stored),
 			{ok, Filepath}
 	end.
 

--- a/apps/arweave/src/ar_metrics.erl
+++ b/apps/arweave/src/ar_metrics.erl
@@ -348,7 +348,10 @@ register(MetricsDir) ->
 	prometheus_gauge:new([{name, packing_buffer_size},
 			{help, "The number of chunks in the packing server queue."}]),
 	prometheus_gauge:new([{name, chunk_cache_size},
-			{help, "The number of chunks scheduled for downloading."}]).
+			{help, "The number of chunks scheduled for downloading."}]),
+
+	prometheus_counter:new([{name, process_functions},
+			{help, "Sampling active processes"}, {labels, [process]}]).
 
 %% @doc Store the given metric in a file.
 store(Name) ->

--- a/apps/arweave/src/ar_metrics.erl
+++ b/apps/arweave/src/ar_metrics.erl
@@ -325,30 +325,59 @@ register(MetricsDir) ->
 	%% Packing.
 	prometheus_histogram:new([
 		{name, packing_duration_milliseconds},
-		{labels, [type, trigger]},
-		{buckets, lists:seq(1, 200)},
-		{help, "The packing/unpacking time in milliseconds. The type label distinguishes"
-				"packing from unpacking. The trigger label shows whether packing was triggered"
-				"externally (an HTTP request) or internally (during syncing or repacking)."}
+		{labels, [type, packing, trigger]},
+		{buckets, lists:seq(1, 500)},
+		{help, "The packing/unpacking time in milliseconds. The type label can be 'pack' or "
+				"'unpack'. The packing label can be 'spora_2_5' or 'spora_2_6'. "
+				"The trigger label shows where the reqeust was triggered: "
+				"'external' (e.g. an HTTP request) or 'internal' (e.g. during syncing or "
+				"repacking)."}
+	]),
+	prometheus_counter:new([
+		{name, packing_requests},
+		{labels, [type, packing, from]},
+		{help, "The number of packing requests received. The type label can be 'pack' or "
+				"'unpack'. The packing label can be 'spora_2_5', 'spora_2_6', or 'unpacked'. "
+				"The from label show where the request was initiated (e.g. the "
+				"calling function, or message). "}
 	]),
 	prometheus_counter:new([
 		{name, validating_packed_spora},
-		{help, "The number of SPoRA solutions based on packed chunks entered validation."}
+		{labels, [packing]},
+		{help, "The number of SPoRA solutions based on packed chunks entered validation. "
+				"The packing label can be 'spora_2_5' or 'spora_2_6'."}
 	]),
-	prometheus_counter:new([
-		{name, validating_unpacked_spora},
-		{help, "The number of SPoRA solutions based on unpacked chunks entered validation."}
+	prometheus_gauge:new([
+		{name, packing_latency_benchmark},
+		{labels, [benchmark, type, packing]},
+		{help, "The benchmark packing latency. The benchmark label indicates which "
+				"benchmark is being recorded - 'protocol' records the ?PACKING_LATENCY "
+				"value, and 'init' records the latency sampled at node startup. "
+				"The type label can be 'pack' or 'unpack'. The packing label can be "
+				"'spora_2_5' or 'spora_2_6'. The 'packing_duration_milliseconds' metric "
+				"records the actual latency observed during node operation."}
 	]),
-	prometheus_counter:new([
-		{name, validating_packed_2_6_spora},
-		{help, "The number of SPoRA solutions based on chunks packed for 2.6 entered "
-				"validation."}
+	prometheus_gauge:new([
+		{name, packing_rate_benchmark},
+		{labels, [benchmark]},
+		{help, "The benchmark packing rate. The benchmark label indicates which "
+				"benchmark is being recorded - 'protocol' records the maximum rate allowed by "
+				"the protocol, 'configured' records the packing rate configured by the user. "
+				"The 'packing_duration_milliseconds' metric records the actual rate observed "
+				"during node operation."}
+	]),
+	prometheus_gauge:new([
+		{name, packing_schedulers},
+		{help, "The number of schedulers available for packing."}
 	]),
 
 	prometheus_gauge:new([{name, packing_buffer_size},
 			{help, "The number of chunks in the packing server queue."}]),
 	prometheus_gauge:new([{name, chunk_cache_size},
 			{help, "The number of chunks scheduled for downloading."}]),
+	prometheus_counter:new([{name, chunks_stored},
+			{help, "The counter is incremented every time a chunk is written to "
+					"chunk_storage."}]),
 
 	prometheus_counter:new([{name, process_functions},
 			{help, "Sampling active processes"}, {labels, [process]}]).
@@ -372,8 +401,20 @@ get_status_class({error, connect_timeout}) ->
 	"connect_timeout";
 get_status_class({error, timeout}) ->
 	"timeout";
+get_status_class({error,{shutdown,timeout}}) ->
+	"shutdown_timeout";
 get_status_class({error, econnrefused}) ->
 	"econnrefused";
+get_status_class({error, {shutdown,econnrefused}}) ->
+	"shutdown_econnrefused";
+get_status_class({error, {shutdown,ehostunreach}}) ->
+	"shutdown_ehostunreach";
+get_status_class({error, {shutdown,normal}}) ->
+	"shutdown_normal";
+get_status_class({error, {closed,_}}) ->
+	"closed";
+get_status_class({error, noproc}) ->
+	"noproc";
 get_status_class(208) ->
 	"already_processed";
 get_status_class(418) ->

--- a/apps/arweave/src/ar_packing_server.erl
+++ b/apps/arweave/src/ar_packing_server.erl
@@ -429,11 +429,7 @@ record_buffer_size_metric() ->
 
 record_packing_benchmarks(PackingStateRef, MaxRate, PackingRate, Schedulers) ->
 	prometheus_gauge:set(packing_latency_benchmark,
-		[protocol, pack, spora_2_5], ?PACKING_LATENCY_MS),
-	prometheus_gauge:set(packing_latency_benchmark,
 		[protocol, pack, spora_2_6], ?PACKING_LATENCY_MS),
-	prometheus_gauge:set(packing_latency_benchmark,
-		[protocol, unpack, spora_2_5], ?PACKING_LATENCY_MS),
 	prometheus_gauge:set(packing_latency_benchmark,
 		[protocol, unpack, spora_2_6], ?PACKING_LATENCY_MS),
 	prometheus_gauge:set(packing_rate_benchmark,

--- a/apps/arweave/src/ar_packing_server.erl
+++ b/apps/arweave/src/ar_packing_server.erl
@@ -30,6 +30,7 @@
 %% unique and cannot be easily inferred during mining from any metadata stored in RAM.
 pack(Packing, ChunkOffset, TXRoot, Chunk) ->
 	[{_, RandomXStateRef}] = ets:lookup(?MODULE, randomx_packing_state),
+	record_packing_request(pack, Packing, get_caller()),
 	case pack(Packing, ChunkOffset, TXRoot, Chunk, RandomXStateRef, external) of
 		{ok, Packed, _} ->
 			{ok, Packed};
@@ -41,6 +42,7 @@ pack(Packing, ChunkOffset, TXRoot, Chunk) ->
 %% {error, invalid_packed_size}, {error, invalid_chunk_size}, or {error, invalid_padding}.
 unpack(Packing, ChunkOffset, TXRoot, Chunk, ChunkSize) ->
 	[{_, RandomXStateRef}] = ets:lookup(?MODULE, randomx_packing_state),
+	record_packing_request(unpack, Packing, get_caller()),
 	case unpack(Packing, ChunkOffset, TXRoot, Chunk, ChunkSize, RandomXStateRef, external) of
 		{ok, Unpacked, _} ->
 			{ok, Unpacked};
@@ -97,6 +99,9 @@ init([]) ->
 			"The process may take several minutes.~n", [ar_util:encode(?RANDOMX_PACKING_KEY)]),
 	PackingStateRef = ar_mine_randomx:init_fast(?RANDOMX_PACKING_KEY, Schedulers),
 	ets:insert(?MODULE, {randomx_packing_state, PackingStateRef}),
+
+	record_packing_benchmarks(PackingStateRef, MaxRate, PackingRate, Schedulers),
+
 	ar:console("RandomX dataset initialisation complete.~n", []),
 	SpawnSchedulers = min(SchedulersRequired, Schedulers),
 	%% Since the total rate of spawned processes might exceed the desired rate,
@@ -134,9 +139,11 @@ handle_cast(Cast, State) ->
 
 handle_info({event, chunk, {unpack_request, Ref, Args}}, State) ->
 	#state{ workers = Workers } = State,
+	{Packing, _Chunk, _AbsoluteOffset, _TXRoot, _ChunkSize} = Args,
 	{{value, Worker}, Workers2} = queue:out(Workers),
 	?LOG_DEBUG([{event, got_unpack_request}, {ref, Ref}]),
 	increment_buffer_size(),
+	record_packing_request(unpack, Packing, unpack_request),
 	Worker ! {unpack, Ref, self(), Args},
 	{noreply, State#state{ workers = queue:in(Worker, Workers2) }};
 
@@ -154,12 +161,14 @@ handle_info({event, chunk, {repack_request, Ref, Args}}, State) ->
 		{unpacked, _} ->
 			?LOG_DEBUG([{event, sending_for_packing}, {ref, Ref}]),
 			increment_buffer_size(),
+			record_packing_request(pack, RequestedPacking, repack_request),
 			Worker ! {pack, Ref, self(), {RequestedPacking, Chunk, AbsoluteOffset, TXRoot,
 					ChunkSize}},
 			{noreply, State#state{ workers = queue:in(Worker, Workers2) }};
 		_ ->
 			?LOG_DEBUG([{event, got_pack_request_need_unpacking_first}, {ref, Ref}]),
 			increment_buffer_size(),
+			record_packing_request(unpack, Packing, repack_request),
 			Worker ! {unpack, Ref, self(), {Packing, Chunk, AbsoluteOffset, TXRoot, ChunkSize}},
 			%% At first we have to unpack so we have to remember the
 			%% reference for now, to not forget to pack later.
@@ -182,6 +191,7 @@ handle_info({worker, {unpacked, Ref, Args}}, State) ->
 			?LOG_DEBUG([{event, worker_unpacked_chunk_for_packing}, {ref, Ref}]),
 			{_Packing, Chunk, AbsoluteOffset, TXRoot, ChunkSize} = Args,
 			increment_buffer_size(),
+			record_packing_request(pack, RequestedPacking, unpacked),
 			Worker ! {pack, Ref, self(),
 				{RequestedPacking, Chunk, AbsoluteOffset, TXRoot, ChunkSize}},
 			{noreply, State#state{ workers = queue:in(Worker, Workers2),
@@ -292,7 +302,7 @@ pack(spora_2_5, ChunkOffset, TXRoot, Chunk, RandomXStateRef, External) ->
 			%% packing.
 			Key = crypto:hash(sha256, << ChunkOffset:256, TXRoot/binary >>),
 			{ok, prometheus_histogram:observe_duration(packing_duration_milliseconds,
-					[pack, External], fun() ->
+					[pack, spora_2_5, External], fun() ->
 							ar_mine_randomx:randomx_encrypt_chunk(RandomXStateRef, Key,
 									pad_chunk(Chunk)) end), was_not_already_packed}
 	end;
@@ -313,7 +323,7 @@ pack({spora_2_6, RewardAddr}, ChunkOffset, TXRoot, Chunk, RandomXStateRef, Exter
 			Key = crypto:hash(sha256, << ChunkOffset:256, TXRoot:32/binary,
 					RewardAddr/binary >>),
 			case prometheus_histogram:observe_duration(packing_duration_milliseconds,
-					[pack, External], fun() ->
+					[pack, spora_2_6, External], fun() ->
 							ar_mine_randomx:randomx_encrypt_chunk_2_6(RandomXStateRef, Key,
 									pad_chunk(Chunk)) end) of
 				{ok, Packed} ->
@@ -352,7 +362,7 @@ unpack(spora_2_5, ChunkOffset, TXRoot, Chunk, ChunkSize, RandomXStateRef, Extern
 		true ->
 			Key = crypto:hash(sha256, << ChunkOffset:256, TXRoot/binary >>),
 			Unpacked = prometheus_histogram:observe_duration(packing_duration_milliseconds,
-					[unpack, External], fun() ->
+					[unpack, spora_2_5, External], fun() ->
 							ar_mine_randomx:randomx_decrypt_chunk(RandomXStateRef, Key, Chunk,
 									ChunkSize) end),
 			{ok, binary:part(Unpacked, 0, ChunkSize), was_not_already_unpacked}
@@ -371,7 +381,7 @@ unpack({spora_2_6, RewardAddr}, ChunkOffset, TXRoot, Chunk, ChunkSize,
 			Key = crypto:hash(sha256, << ChunkOffset:256, TXRoot:32/binary,
 					RewardAddr/binary >>),
 			case prometheus_histogram:observe_duration(packing_duration_milliseconds,
-					[unpack, External], fun() ->
+					[unpack, spora_2_6, External], fun() ->
 							ar_mine_randomx:randomx_decrypt_chunk_2_6(RandomXStateRef, Key,
 									Chunk, ?DATA_CHUNK_SIZE) end) of
 			{ok, Unpacked} ->
@@ -406,6 +416,9 @@ increment_buffer_size() ->
 decrement_buffer_size() ->
 	ets:update_counter(?MODULE, buffer_size, {2, -1}, {buffer_size, 0}).
 
+%%%===================================================================
+%%% Prometheus metrics
+%%%===================================================================
 record_buffer_size_metric() ->
 	case ets:lookup(?MODULE, buffer_size) of
 		[{_, Size}] ->
@@ -413,6 +426,85 @@ record_buffer_size_metric() ->
 		_ ->
 			ok
 	end.
+
+record_packing_benchmarks(PackingStateRef, MaxRate, PackingRate, Schedulers) ->
+	prometheus_gauge:set(packing_latency_benchmark,
+		[protocol, pack, spora_2_5], ?PACKING_LATENCY_MS),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[protocol, pack, spora_2_6], ?PACKING_LATENCY_MS),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[protocol, unpack, spora_2_5], ?PACKING_LATENCY_MS),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[protocol, unpack, spora_2_6], ?PACKING_LATENCY_MS),
+	prometheus_gauge:set(packing_rate_benchmark,
+		[protocol], MaxRate),
+	prometheus_gauge:set(packing_rate_benchmark,
+		[configured], PackingRate),
+	prometheus_gauge:set(packing_schedulers,
+		Schedulers),
+
+	Chunk = crypto:strong_rand_bytes(?DATA_CHUNK_SIZE),
+	Key = crypto:hash(sha256, crypto:strong_rand_bytes(256)),
+	Pack = [PackingStateRef, Key, Chunk],
+	Unpack = [PackingStateRef, Key, Chunk, ?DATA_CHUNK_SIZE],
+	%% Run each randomx routine Repetitions times and return the minimum runtime. We use
+	%% minimum rather than average since it more closely approximates the fastest that this
+	%% machine can do the calculation.
+	Repetitions = 5,
+	prometheus_gauge:set(packing_latency_benchmark,
+		[init, pack, spora_2_5],
+		minimum_run_time(ar_mine_randomx, randomx_encrypt_chunk, Pack, Repetitions)),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[init, pack, spora_2_6],
+		minimum_run_time(ar_mine_randomx, randomx_encrypt_chunk_2_6, Pack, Repetitions)),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[init, unpack, spora_2_5],
+		minimum_run_time(ar_mine_randomx, randomx_decrypt_chunk, Unpack, Repetitions)),
+	prometheus_gauge:set(packing_latency_benchmark,
+		[init, unpack, spora_2_6],
+		minimum_run_time(ar_mine_randomx, randomx_decrypt_chunk_2_6, Unpack, Repetitions)).
+
+
+minimum_run_time(Module, Function, Args, Repetitions) ->
+	minimum_run_time(Module, Function, Args, Repetitions, infinity).
+minimum_run_time(_Module, _Function, _Args, 0, MinTime) ->
+	%% round microseconds to the nearest millisecond
+	(MinTime + 500) div 1000;
+minimum_run_time(Module, Function, Args, Repetitions, MinTime) ->
+	{RunTime, _} = timer:tc(Module, Function, Args),
+	minimum_run_time(Module, Function, Args, Repetitions-1, erlang:min(MinTime, RunTime)).
+
+%% @doc Walk up the stack trace to the parent of the current function. E.g.
+%% example() ->
+%%     get_caller().
+%%
+%% Will return the caller of example/0.
+get_caller() ->
+    {current_stacktrace, CallStack} = process_info(self(), current_stacktrace),
+    calling_function(CallStack).
+calling_function([_, {_, _, _, _}|[{Module, Function, Arity, _}|_]]) ->
+	atom_to_list(Module) ++ ":" ++ atom_to_list(Function) ++ "/" ++ integer_to_list(Arity);
+calling_function(_) ->
+    "unknown".
+
+record_packing_request(Type, Packing, From) when
+	is_atom(Type), is_atom(Packing), is_list(From) ->
+	prometheus_counter:inc(
+		packing_requests,
+		[atom_to_list(Type), atom_to_list(Packing), From]);
+record_packing_request(Type, Packing, From) when
+	is_atom(From) ->
+	record_packing_request(Type, Packing, atom_to_list(From));
+record_packing_request(Type, Packing, From) when
+	not is_atom(Packing) ->
+	PackingAtom = case Packing of
+		{Atom, _} ->
+			Atom;
+		Atom when is_atom(Atom) ->
+			Atom
+	end,
+	record_packing_request(Type, PackingAtom, From).
+
 
 %%%===================================================================
 %%% Tests.

--- a/apps/arweave/src/ar_poa.erl
+++ b/apps/arweave/src/ar_poa.erl
@@ -47,9 +47,9 @@ validate(Args) ->
 					AbsoluteEndOffset = BlockStartOffset + TXStartOffset + ChunkEndOffset,
 					case Packing of
 						{spora_2_6, _} ->
-							prometheus_counter:inc(validating_packed_2_6_spora);
+							prometheus_counter:inc(validating_packed_spora, [spora_2_6]);
 						spora_2_5 ->
-							prometheus_counter:inc(validating_packed_spora)
+							prometheus_counter:inc(validating_packed_spora, [spora_2_5])
 					end,
 					case ar_packing_server:unpack(Packing, AbsoluteEndOffset, TXRoot, Chunk,
 							ChunkSize) of

--- a/apps/arweave/src/ar_process_sampler.erl
+++ b/apps/arweave/src/ar_process_sampler.erl
@@ -10,43 +10,43 @@
 
 %% API
 start_link() ->
-  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% gen_server callbacks
 init([]) ->
-  timer:send_interval(?SAMPLE_INTERVAL, sample),
-  {ok, #{}}.
+	timer:send_interval(?SAMPLE_INTERVAL, sample),
+	{ok, #{}}.
 
 handle_call(_Request, _From, State) ->
-  {reply, ok, State}.
+	{reply, ok, State}.
 
 handle_cast(_Msg, State) ->
-  {noreply, State}.
+	{noreply, State}.
 
 handle_info(sample, State) ->
-  Processes = erlang:processes(),
-  ProcessNames = lists:filtermap(fun(Pid) -> process_function(Pid) end, Processes),
-  lists:foreach(fun(Name) -> prometheus_counter:inc(process_functions, [Name]) end, ProcessNames),
-  {noreply, State};
+	Processes = erlang:processes(),
+	ProcessNames = lists:filtermap(fun(Pid) -> process_function(Pid) end, Processes),
+	lists:foreach(fun(Name) -> prometheus_counter:inc(process_functions, [Name]) end, ProcessNames),
+	{noreply, State};
 
 handle_info(_Info, State) ->
-  {noreply, State}.
+	{noreply, State}.
 
 terminate(_Reason, _State) ->
-  ok.
+	ok.
 
 code_change(_OldVsn, State, _Extra) ->
-  {ok, State}.
+	{ok, State}.
 
 %% Internal functions
 process_function(Pid) ->
-  case process_info(Pid, [current_function, status]) of
-    [{current_function, {?MODULE, process_function, _A}}, _] ->
-      false;
-    [{current_function, {erlang, process_info, _A}}, _] ->
-      false;
-    [{current_function, {M, F, A}}, {status, running}] ->
-      {true, atom_to_list(M) ++ ":" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A)};
-    _ ->
-      false
-  end.
+	case process_info(Pid, [current_function, status]) of
+	[{current_function, {?MODULE, process_function, _A}}, _] ->
+		false;
+	[{current_function, {erlang, process_info, _A}}, _] ->
+		false;
+	[{current_function, {M, F, A}}, {status, running}] ->
+		{true, atom_to_list(M) ++ ":" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A)};
+	_ ->
+		false
+	end.

--- a/apps/arweave/src/ar_process_sampler.erl
+++ b/apps/arweave/src/ar_process_sampler.erl
@@ -1,0 +1,52 @@
+-module(ar_process_sampler).
+-behaviour(gen_server).
+
+-include_lib("arweave/include/ar.hrl").
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+
+-define(SAMPLE_INTERVAL, 500).
+
+%% API
+start_link() ->
+  gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% gen_server callbacks
+init([]) ->
+  timer:send_interval(?SAMPLE_INTERVAL, sample),
+  {ok, #{}}.
+
+handle_call(_Request, _From, State) ->
+  {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+  {noreply, State}.
+
+handle_info(sample, State) ->
+  Processes = erlang:processes(),
+  ProcessNames = lists:filtermap(fun(Pid) -> process_function(Pid) end, Processes),
+  lists:foreach(fun(Name) -> prometheus_counter:inc(process_functions, [Name]) end, ProcessNames),
+  {noreply, State};
+
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+terminate(_Reason, _State) ->
+  ok.
+
+code_change(_OldVsn, State, _Extra) ->
+  {ok, State}.
+
+%% Internal functions
+process_function(Pid) ->
+  case process_info(Pid, [current_function, status]) of
+    [{current_function, {?MODULE, process_function, _A}}, _] ->
+      false;
+    [{current_function, {erlang, process_info, _A}}, _] ->
+      false;
+    [{current_function, {M, F, A}}, {status, running}] ->
+      {true, atom_to_list(M) ++ ":" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A)};
+    _ ->
+      false
+  end.

--- a/apps/arweave/src/ar_sup.erl
+++ b/apps/arweave/src/ar_sup.erl
@@ -99,6 +99,7 @@ init([]) ->
 		?CHILD_SUP(ar_nonce_limiter_server_sup, supervisor),
 		?CHILD(ar_nonce_limiter, worker),
 		?CHILD(ar_mining_server, worker),
+		?CHILD(ar_process_sampler, worker),
 		?CHILD_SUP(ar_tx_emitter_sup, supervisor),
 		?CHILD_SUP(ar_block_pre_validator_sup, supervisor),
 		?CHILD_SUP(ar_poller_sup, supervisor),


### PR DESCRIPTION
Metrics are used in this Grafana dashboard: https://arweave.grafana.net/d/cvSjnX-Vk/sync-and-pack?orgId=1&var-node=gateway-3-temp.arweave.net&from=now-3h&to=now

- Top panels track high-level metrics. They chart Packing Rate, Packing Latency, and Chunk Write Throughput against a collection of benchmarks.
- All the bottom (collapsed) panels provide more details that can be useful in investigating performance issues.

This PR also adds a lightweight process sampler. Every 500 ms it wakes up, checks the active processes, and increments a prometheus counter for each one. This provides a (rough) view into what processes might be dominating the CPU. 