### PR TITLE
Update the release script to support pre-release builds

### DIFF
--- a/release/Dockerfile.ubuntu
+++ b/release/Dockerfile.ubuntu
@@ -31,4 +31,4 @@ RUN git fetch --all && \
     git checkout ${GIT_TAG} && \
     ./rebar3 as prod tar
     
-CMD cp _build/prod/rel/arweave/arweave-*.tar.gz /output/
+CMD cp _build/prod/rel/arweave/arweave-*.tar.gz /output/arweave.tar.gz

--- a/release/build.sh
+++ b/release/build.sh
@@ -1,16 +1,53 @@
 #!/bin/bash
 
+ECHO_ONLY=0
+PRE_RELEASE=0
+BRANCH=""
+
+# Parse flags
+while getopts 'eb:' flag; do
+  case "${flag}" in
+    e) ECHO_ONLY=1 ;;
+    b) PRE_RELEASE=1
+       BRANCH="${OPTARG}" ;;
+    *) echo "Usage: $0 [-e] [-b <pre-release branch>] version" 
+       exit 1 ;;
+  esac
+done
+shift $((OPTIND-1))
+
 # Check if version is supplied
 if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 version"
+    echo "Usage: $0 [-e] [-b <pre-release branch>] version"
     exit 1
 fi
 
 VERSION=$1
-GIT_TAG="N.$VERSION"
+if [ $PRE_RELEASE -eq 1 ]; then
+  GIT_TAG="$BRANCH"
+else
+  GIT_TAG="N.$VERSION"
+fi
+
 BASE_IMAGES=("arweave-base:18.04" "arweave-base:20.04" "arweave-base:22.04")
 LINUX_VERSIONS=("ubuntu18" "ubuntu20" "ubuntu22")
 BASE_DOCKERFILES=("Dockerfile.base.ubuntu18.04" "Dockerfile.base.ubuntu20.04" "Dockerfile.base.ubuntu22.04")
+
+# Limit the build to only ubuntu-22.04 for pre-release
+if [ $PRE_RELEASE -eq 1 ]; then
+  BASE_IMAGES=("arweave-base:22.04")
+  LINUX_VERSIONS=("ubuntu22")
+  BASE_DOCKERFILES=("Dockerfile.base.ubuntu22.04")
+fi
+
+# Function to execute a command, optionally just echoing it
+function run_cmd {
+  if [ $ECHO_ONLY -eq 1 ]; then
+    echo $1
+  else
+    eval $1
+  fi
+}
 
 # Build base images first
 for i in "${!BASE_DOCKERFILES[@]}"; do
@@ -20,7 +57,7 @@ for i in "${!BASE_DOCKERFILES[@]}"; do
     echo "Building base image $BASE_IMAGE..."
 
     # Build the base Docker image
-    docker build -f $BASE_DOCKERFILE -t $BASE_IMAGE .
+    run_cmd "docker build -f $BASE_DOCKERFILE -t $BASE_IMAGE ."
 done
 
 for i in "${!BASE_IMAGES[@]}"; do
@@ -37,17 +74,19 @@ for i in "${!BASE_IMAGES[@]}"; do
     echo "Building $IMAGE_NAME..."
 
     # Build the Docker image
-    docker build -f $DOCKERFILE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg GIT_TAG=$GIT_TAG -t $IMAGE_NAME .
+    run_cmd "docker build -f $DOCKERFILE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg GIT_TAG=$GIT_TAG -t $IMAGE_NAME ."
 
     echo "Running $IMAGE_NAME..."
 
     # Run the Docker container
-    docker run -v $(pwd)/output:/output $IMAGE_NAME
+    run_cmd "docker run --rm -v $(pwd)/output:/output $IMAGE_NAME"
 
     echo "Renaming output file..."
 
     # Rename the output file
-    mv "./output/arweave-$VERSION.tar.gz" "$OUTPUT_FILE"
+    run_cmd "mv './output/arweave.tar.gz' '$OUTPUT_FILE'"
 done
 
-cp "./output/arweave-$VERSION.ubuntu22-x86_64.tar.gz" "./output/arweave-$VERSION.linux-x86_64.tar.gz"
+if [ $PRE_RELEASE -eq 0 ]; then
+  run_cmd "cp './output/arweave-$VERSION.ubuntu22-x86_64.tar.gz' './output/arweave-$VERSION.linux-x86_64.tar.gz'"
+fi


### PR DESCRIPTION
New usage: `Usage: ./build.sh [-e] [-b <pre-release branch>] version`

- `-e` echo the commands only without running them
- `-b` pre-release branch to build. If this flag is omitted the `N.version` tag will be built.
- `version` the release version to build (e.g. `2.6.9`) or the name to use for the pre-release build

when `-b` is specified only ubuntu 22.04 is built. When `-b` is omitted 18.04, 20.04, and 22.04 are built.