### PR TITLE
Fix VDF retarget

### DIFF
--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -374,10 +374,12 @@
 
 	%% The fields added at the fork 2.7
 
-	%% The number of SHA2-256 iterations in a single 50-ms checkpoint.
+	%% The number of SHA2-256 iterations in a single VDF checkpoint. The protocol aims to keep the
+	%% checkoint calculation time to around 40ms by varying this paramter. Note: there are
+	%% 25 checkpoints in a single VDF step - so the protocol aims to keep the step calculation at
+	%% 1 second by varying this parameter.
 	vdf_difficulty = ?INITIAL_VDF_DIFFICULTY,
-	%% The number of SHA2-256 iterations in a single 50-ms checkpoint, scheduled for
-	%% applying after the closest approaching VDF reset line.
+	%% The VDF difficulty scheduled for to be applied after the next VDF reset line.
 	next_vdf_difficulty = ?INITIAL_VDF_DIFFICULTY
 }).
 
@@ -597,9 +599,6 @@
 	%% two-chunk) of the latest ?BLOCK_TIME_HISTORY_BLOCKS blocks.
 	%% Used internally, not gossiped.
 	block_time_history = [], % {block_interval, vdf_interval, chunk_count}
-	%% The current VDF difficulty. The protocol aims at keeping the step calculation
-	%% time around one second by varying this parameter.
-	vdf_difficulty = ?INITIAL_VDF_DIFFICULTY,
 
 	%% Used internally, not gossiped. Convenient for validating potentially non-unique
 	%% merkle proofs assigned to the different signatures of the same solution

--- a/apps/arweave/src/ar_block_pre_validator.erl
+++ b/apps/arweave/src/ar_block_pre_validator.erl
@@ -563,12 +563,11 @@ pre_validate_nonce_limiter_seed_data(B, PrevB, SolutionResigned, Peer) ->
 	#nonce_limiter_info{ global_step_number = StepNumber, seed = Seed,
 			next_seed = NextSeed, partition_upper_bound = PartitionUpperBound,
 			vdf_difficulty = VDFDifficulty,
-			next_vdf_difficulty = NextVDFDifficulty,
 			next_partition_upper_bound = NextPartitionUpperBound } = Info,
 	StepNumber = (B#block.nonce_limiter_info)#nonce_limiter_info.global_step_number,
 	ExpectedSeedData = ar_nonce_limiter:get_seed_data(StepNumber, PrevB),
 	case ExpectedSeedData == {Seed, NextSeed, PartitionUpperBound,
-			NextPartitionUpperBound, VDFDifficulty, NextVDFDifficulty} of
+			NextPartitionUpperBound, VDFDifficulty} of
 		true ->
 			pre_validate_partition_number(B, PrevB, PartitionUpperBound,
 					SolutionResigned, Peer);

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -797,8 +797,7 @@ handle_task({computed_output, _},
 handle_task({computed_output, Args}, State) ->
 	#state{ session = Session, io_threads = IOThreads, hashing_threads = Threads } = State,
 	{SessionKey,
-		#vdf_session{ seed = Seed, step_number = StepNumber,
-			vdf_difficulty = VDFDifficulty, next_vdf_difficulty = NextVDFDifficulty },
+		#vdf_session{ seed = Seed, step_number = StepNumber } = VDFSession,
 		Output, PartitionUpperBound} = Args,
 	{NextSeed, StartIntervalNumber} = SessionKey,
 	#mining_session{ next_seed = CurrentNextSeed,
@@ -839,7 +838,8 @@ handle_task({computed_output, Args}, State) ->
 			State),
 	?LOG_DEBUG([{event, mining_debug_processing_vdf_output}, {found_io_threads, N},
 		{step_number, StepNumber}, {start_interval_number, StartIntervalNumber},
-		{vdf_difficulty, VDFDifficulty}, {next_vdf_difficulty, NextVDFDifficulty}]),
+		{vdf_difficulty, VDFSession#vdf_session.vdf_difficulty},
+		{next_vdf_difficulty, VDFSession#vdf_session.next_vdf_difficulty}]),
 	{noreply, State2#state{ session = Session3 }};
 
 handle_task({io_thread_recall_range_chunk, {H0, PartitionNumber, Nonce, NonceLimiterOutput,

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -519,9 +519,8 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 					{step_number, StepNumber}]),
 			{noreply, State};
 		[NonceLimiterOutput | _] = Steps ->
-			{Seed, NextSeed, PartitionUpperBound, NextPartitionUpperBound,
-					VDFDifficulty, NextVDFDifficulty}
-						= ar_nonce_limiter:get_seed_data(StepNumber, PrevB),
+			{Seed, NextSeed, PartitionUpperBound, NextPartitionUpperBound, VDFDifficulty}
+				= ar_nonce_limiter:get_seed_data(StepNumber, PrevB),
 			LastStepCheckpoints2 =
 				case LastStepCheckpoints of
 					not_found ->
@@ -535,11 +534,12 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 						PrevOutput2 = ar_nonce_limiter:maybe_add_entropy(
 								PrevOutput, PrevStepNumber, StepNumber, PrevNextSeed),
 						{ok, NonceLimiterOutput, Checkpoints} = ar_nonce_limiter:compute(
-								StepNumber, PrevOutput2, NextVDFDifficulty),
+								StepNumber, PrevOutput2, VDFDifficulty),
 						Checkpoints;
 					_ ->
 						LastStepCheckpoints
 				end,
+			NextVDFDifficulty = ar_block:compute_next_vdf_difficulty(PrevB),
 			NonceLimiterInfo2 = NonceLimiterInfo#nonce_limiter_info{ seed = Seed,
 					next_seed = NextSeed, partition_upper_bound = PartitionUpperBound,
 					next_partition_upper_bound = NextPartitionUpperBound,
@@ -559,7 +559,6 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 					Denomination, Denomination2),
 			CDiff = ar_difficulty:next_cumulative_diff(PrevB#block.cumulative_diff, Diff,
 					Height),
-			BlockVDFDifficulty = ar_block:compute_vdf_difficulty(PrevB),
 			UnsignedB = pack_block_with_transactions(#block{
 				nonce = Nonce,
 				previous_block = PrevH,
@@ -599,8 +598,7 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 				double_signing_proof = may_be_get_double_signing_proof(PrevB, State),
 				merkle_rebase_support_threshold = MerkleRebaseThreshold,
 				chunk_hash = get_chunk_hash(PoA1, Height),
-				chunk2_hash = get_chunk_hash(PoA2, Height),
-				vdf_difficulty = BlockVDFDifficulty
+				chunk2_hash = get_chunk_hash(PoA2, Height)
 			}, PrevB),
 			UnsignedB2 =
 				case Height >= ar_fork:height_2_7() of
@@ -1069,14 +1067,10 @@ apply_block3(B, [PrevB | _] = PrevBlocks, Timestamp, State) ->
 					B3 =
 						case B#block.height >= ar_fork:height_2_7() of
 							true ->
-								BlockTimeHistory2 = ar_block:update_block_time_history(
-										B, PrevB),
-								Len2 = ?BLOCK_TIME_HISTORY_BLOCKS
-										+ ?STORE_BLOCKS_BEHIND_CURRENT,
+								BlockTimeHistory2 = ar_block:update_block_time_history(B, PrevB),
+								Len2 = ?BLOCK_TIME_HISTORY_BLOCKS + ?STORE_BLOCKS_BEHIND_CURRENT,
 								BlockTimeHistory3 = lists:sublist(BlockTimeHistory2, Len2),
-								B2#block{
-									block_time_history = BlockTimeHistory3
-								};
+								B2#block{ block_time_history = BlockTimeHistory3 };
 							false ->
 								B2
 						end,

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -894,7 +894,6 @@ start_worker(State) ->
 	State#state{ worker = Worker, worker_monitor_ref = Ref }.
 
 compute(StepNumber, PrevOutput, VDFDifficulty) ->
-	?LOG_DEBUG([{event, compute_vdf}, {step_number, StepNumber}, {vdf_difficulty, VDFDifficulty}]),
 	{ok, Output, Checkpoints} = ar_vdf:compute2(StepNumber, PrevOutput, VDFDifficulty),
 	debug_double_check(
 		"compute",

--- a/apps/arweave/src/ar_nonce_limiter_server_worker.erl
+++ b/apps/arweave/src/ar_nonce_limiter_server_worker.erl
@@ -139,6 +139,11 @@ push_update(SessionKey, Session, PrevSessionKey, PrevSession, Output, PartitionU
 push_session(SessionKey, Session, Peer) ->
 	Update = ar_nonce_limiter_server:make_nonce_limiter_update(SessionKey, Session, false),
 	{SessionSeed, SessionInterval} = SessionKey,
+	?LOG_DEBUG([{event, push_session}, {peer, ar_util:format_peer(Peer)},
+			{session_seed, ar_util:encode(SessionSeed)},
+			{session_interval, SessionInterval},
+			{server_step_number, Session#vdf_session.step_number},
+			{num_steps, length(Session#vdf_session.steps)}]),
 	case ar_http_iface_client:push_nonce_limiter_update(Peer, Update) of
 		ok ->
 			ok;

--- a/apps/arweave/src/ar_nonce_limiter_server_worker.erl
+++ b/apps/arweave/src/ar_nonce_limiter_server_worker.erl
@@ -139,11 +139,6 @@ push_update(SessionKey, Session, PrevSessionKey, PrevSession, Output, PartitionU
 push_session(SessionKey, Session, Peer) ->
 	Update = ar_nonce_limiter_server:make_nonce_limiter_update(SessionKey, Session, false),
 	{SessionSeed, SessionInterval} = SessionKey,
-	?LOG_DEBUG([{event, push_session}, {peer, ar_util:format_peer(Peer)},
-			{session_seed, ar_util:encode(SessionSeed)},
-			{session_interval, SessionInterval},
-			{server_step_number, Session#vdf_session.step_number},
-			{num_steps, length(Session#vdf_session.steps)}]),
 	case ar_http_iface_client:push_nonce_limiter_update(Peer, Update) of
 		ok ->
 			ok;

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -343,6 +343,12 @@ binary_to_block_time_history(<<>>, BlockTimeHistory) ->
 binary_to_block_time_history(_Rest, _BlockTimeHistory) ->
 	{error, invalid_block_time_history}.
 
+%% Note: the #nonce_limiter_update and #vdf_session records are only serialized for communication
+%% between a VDF server and VDF client. Only fields that are required for this communication are
+%% serialized.
+%% 
+%% For example, the vdf_difficulty and next_vdf_difficulty fields are omitted as they are only used
+%% by nodes that compute their own VDF and never need to be shared from VDF server to VDF client.
 nonce_limiter_update_to_binary(#nonce_limiter_update{ session_key = {NextSeed, Interval},
 		session = Session, checkpoints = Checkpoints, is_partial = IsPartial }) ->
 	IsPartialBin = case IsPartial of true -> << 1:8 >>; _ -> << 0:8 >> end,

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -281,8 +281,7 @@ block_to_json_struct(
 						{merkle_rebase_support_threshold, integer_to_binary(RebaseThreshold)},
 						{chunk_hash, ar_util:encode(B#block.chunk_hash)},
 						{block_time_history_hash,
-							ar_util:encode(B#block.block_time_history_hash)},
-						{vdf_difficulty, integer_to_binary(B#block.vdf_difficulty)}
+							ar_util:encode(B#block.block_time_history_hash)}
 						| JSONElements5],
 				case B#block.chunk2_hash of
 					undefined ->
@@ -475,18 +474,17 @@ encode_post_2_6_fields(#block{ height = Height, hash_preimage = HashPreimage,
 
 encode_post_2_7_fields(#block{ height = Height,
 		merkle_rebase_support_threshold = Threshold, chunk_hash = ChunkHash,
-		chunk2_hash = Chunk2Hash, vdf_difficulty = VDFDifficulty,
+		chunk2_hash = Chunk2Hash,
 		block_time_history_hash = BlockTimeHistoryHash,
-		nonce_limiter_info = #nonce_limiter_info{ vdf_difficulty = VDFDifficulty2,
-				next_vdf_difficulty = VDFDifficulty3 } }) ->
+		nonce_limiter_info = #nonce_limiter_info{ vdf_difficulty = VDFDifficulty,
+				next_vdf_difficulty = NextVDFDifficulty } }) ->
 	case Height >= ar_fork:height_2_7() of
 		true ->
 			<< (encode_int(Threshold, 16))/binary, ChunkHash:32/binary,
 					(encode_bin(Chunk2Hash, 8))/binary,
-					(encode_int(VDFDifficulty, 8))/binary,
 					BlockTimeHistoryHash:32/binary,
-					(encode_int(VDFDifficulty2, 8))/binary,
-					(encode_int(VDFDifficulty3, 8))/binary >>;
+					(encode_int(VDFDifficulty, 8))/binary,
+					(encode_int(NextVDFDifficulty, 8))/binary >>;
 		false ->
 			<<>>
 	end.
@@ -706,18 +704,16 @@ parse_post_2_7_fields(Rest, #block{ height = Height } = B) ->
 			{ok, B};
 		{<< ThresholdSize:16, Threshold:(ThresholdSize*8), ChunkHash:32/binary,
 				Chunk2HashSize:8, Chunk2Hash:Chunk2HashSize/binary,
-				VDFDifficultySize:8, VDFDifficulty:(VDFDifficultySize * 8),
 				BlockTimeHistoryHash:32/binary,
-				VDFDifficulty2Size:8, VDFDifficulty2:(VDFDifficulty2Size * 8),
-				VDFDifficulty3Size:8, VDFDifficulty3:(VDFDifficulty3Size * 8) >>, true} ->
+				VDFDifficultySize:8, VDFDifficulty:(VDFDifficultySize * 8),
+				NextVDFDifficultySize:8, NextVDFDifficulty:(NextVDFDifficultySize * 8) >>, true} ->
 			Chunk2Hash2 = case Chunk2HashSize of 0 -> undefined; _ -> Chunk2Hash end,
 			{ok, B#block{ merkle_rebase_support_threshold = Threshold,
 					chunk_hash = ChunkHash, chunk2_hash = Chunk2Hash2,
-					vdf_difficulty = VDFDifficulty,
 					block_time_history_hash = BlockTimeHistoryHash,
 					nonce_limiter_info = (B#block.nonce_limiter_info)#nonce_limiter_info{
-							vdf_difficulty = VDFDifficulty2,
-							next_vdf_difficulty = VDFDifficulty3 } }};
+							vdf_difficulty = VDFDifficulty,
+							next_vdf_difficulty = NextVDFDifficulty } }};
 		_ ->
 			{error, invalid_merkle_rebase_support_threshold}
 	end.


### PR DESCRIPTION
1. When the entropy reset line is crossed: vdf_difficulty = next_vdf_difficulty
2. When publishing a new block if the block is at a VDF retarget height, compute a new next_vdf_difficulty value

Remove #block.vdf_difficulty and only use #block.nonce_limiter_info.vdf_difficulty and #block.nonce_limiter_info.next_vdf_difficulty