### PR TITLE
All chunks in interior subtrees must be aligned to chunk boundaries

### DIFF
--- a/apps/arweave/src/ar_pricing.erl
+++ b/apps/arweave/src/ar_pricing.erl
@@ -139,7 +139,7 @@ get_price_per_gib_minute2(Height, RewardHistory, BlockTimeHistory, Denomination2
 			PricePerGiBPerMinute = 
 				(max(1, RewardTotal) * (?GiB) * SolutionsPerPartitionPerSecond * 60)
 				div (max(1, HashRateTotal) * (?PARTITION_SIZE)),
-			?LOG_DEBUG([{event, get_price_per_gib_minute2},
+			?LOG_DEBUG([{event, get_price_per_gib_minute2}, {height, Height},
 				{hash_rate_total, HashRateTotal}, {reward_total, RewardTotal},
 				{interval_total, IntervalTotal}, {vdf_interval_total, VDFIntervalTotal},
 				{one_chunk_count, OneChunkCount}, {two_chunk_count, TwoChunkCount},
@@ -305,6 +305,9 @@ recalculate_price_per_gib_minute2(B) ->
 				false ->
 					{Price, ScheduledPrice};
 				true ->
+					%% price_per_gib_minute = scheduled_price_per_gib_minute
+					%% scheduled_price_per_gib_minute = get_price_per_gib_minute() capped to
+					%%                                  0.5x to 2x of old price_per_gib_minute
 					RewardHistory2 = lists:sublist(RewardHistory, ?REWARD_HISTORY_BLOCKS),
 					BlockTimeHistory2 = lists:sublist(BlockTimeHistory,
 							?BLOCK_TIME_HISTORY_BLOCKS),

--- a/testnet/ssh_restart_testnet.sh
+++ b/testnet/ssh_restart_testnet.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Function to display help
+display_help() {
+    echo "Usage: $0 <type: pilot|client|solo> <branch-name> [additional arguments...]"
+    echo "   type: Must be one of 'pilot', 'client', or 'solo'."
+    echo "   branch-name: Name of the git branch."
+    echo "   additional arguments: Optional arguments passed to the start_testnet_pilot.sh script."
+}
+
+# Check for required arguments
+if [ -z "$1" ] || [ -z "$2" ]; then
+    display_help
+    exit 1
+fi
+
+TYPE="$1"
+BRANCH="$2"
+shift 2 # Shift off the first two arguments
+OTHER_ARGS="$@"
+
+# Check if first argument is one of the required values
+if [[ "$TYPE" != "pilot" && "$TYPE" != "client" && "$TYPE" != "solo" ]]; then
+    echo "Error: Invalid type provided. Must be one of 'pilot', 'client', or 'solo'."
+    display_help
+    exit 1
+fi
+
+ARWEAVE_DIR="$(readlink -f "$(dirname "$0")")/.."
+source "$ARWEAVE_DIR/testnet/testnet_$TYPE.sh"
+
+
+for server in "${TESTNET_SERVERS[@]}"; do
+    echo "Stopping $server"
+
+    ssh -q -t "$server" 'bash --norc --noprofile' << 'ENDSSH'
+    END_TIME=$((SECONDS+30))
+    while (( SECONDS < END_TIME )); do
+        NO_SCREENS=$(screen -list | grep -c 'No Sockets found')
+
+        if (( NO_SCREENS > 0 )); then
+            echo "Arweave node no longer running"
+            break
+        else
+            echo "Found an Arweave node. Stopping..."
+            /arweave-build/testnet/bin/stop
+            sleep 5
+        fi
+    done
+
+    if (( SECONDS >= END_TIME )); then
+        echo "Timeout reached! Moving on."
+    fi
+    exit
+ENDSSH
+
+    echo "Rebuilding $server"
+    ssh -q -t "$server" 'bash --norc --noprofile' << ENDSSH
+    cd /opt/arweave/arweave
+    git fetch --all
+    git checkout $BRANCH
+    git pull origin $BRANCH
+    /opt/arweave/arweave/testnet/rebuild_testnet.sh
+    exit
+ENDSSH
+
+    echo "Starting $server: start_testnet_$TYPE.sh $OTHER_ARGS"
+    ssh -q -t "$server" 'bash --norc --noprofile' << ENDSSH
+    /opt/arweave/arweave/testnet/start_testnet_$TYPE.sh $OTHER_ARGS
+    exit
+ENDSSH
+
+    echo ""
+    echo "=============================================="
+    echo "Node is ready when the height is no longer -1:"
+    echo "curl http://$server:1984"
+done

--- a/testnet/start_testnet_pilot.sh
+++ b/testnet/start_testnet_pilot.sh
@@ -12,7 +12,7 @@ if [[ ! -f "/arweave-build/testnet/bin/start" ]]; then
 	exit 1
 fi
 
-# If an argument is provided, start from that block, otherwise start from latest state
+# If an argument is provided, start from that block in local state, otherwise start from peers
 if [ "$#" -gt 0 ]; then
     block=$1
 fi
@@ -22,13 +22,13 @@ screen_cmd+=$($ARWEAVE_DIR/testnet/build_data_flags.sh)
 screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh vdf_client_peer testnet_client)
 
 screen_cmd+=" debug mine \
-data_dir /arweave-data \
-header_sync_jobs 0"
+data_dir /arweave-data"
 
 if [ -z "$block" ]; then
-    screen_cmd+=" start_from_latest_state"
+    screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh peer testnet_client)
+    screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh peer testnet_solo)
 else
-    screen_cmd+=" start_from_block $block"
+    screen_cmd+=" header_sync_jobs 0 start_from_block $block"
 fi
 
 echo "$screen_cmd"


### PR DESCRIPTION
Previously the check to enforce that only considered the local, sub-tree offset which allowed each subtree to contain 1 or 2 unaligned chunks (rather than 1 or 2 unaligned chunks per transaction)