### PR TITLE
3 fixes related to the price transition

### DIFF
--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -92,7 +92,6 @@ start(B0, RewardAddr, Config, StorageModules) ->
 		mining_server_chunk_cache_size_limit = 4,
 		debug = true
 	}),
-	?LOG_ERROR("Config: ~p", [Config]),
 	{ok, _} = application:ensure_all_started(arweave, permanent),
 	wait_until_joined(),
 	wait_until_syncs_genesis_data(),


### PR DESCRIPTION
- use the new price after the transition period ends
- shift the transition period by 1 so that ?PRICE_2_6_8_TRANSITION_START is not interpolated
- remove a div in the new price calculation which could cause the price to go to 0 if there was an outage preventing miners from computing VDF for some period of time

Add comments explaining the replica count estimate

Add several unit tests for the price transition logic