### PR TITLE
Initialize ar_poller.in_sync_trusted_peers with the set of trusted peers

### DIFF
--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -1593,7 +1593,7 @@ record_fork_depth([], N) ->
 	prometheus_histogram:observe(fork_recovery_depth, N),
 	ok;
 record_fork_depth([H | Orphans], N) ->
-	?LOG_INFO([{event, orphaning_block}, {block, ar_util:encode(H)}]),
+	?LOG_INFO([{event, orphaning_block}, {block, ar_util:encode(H)}, {depth, N}]),
 	record_fork_depth(Orphans, N + 1).
 
 record_economic_metrics(B, PrevB) ->

--- a/apps/arweave/src/ar_poller_worker.erl
+++ b/apps/arweave/src/ar_poller_worker.erl
@@ -118,6 +118,7 @@ handle_cast({poll, Ref}, #state{ ref = Ref, peer = Peer,
 			ar_util:cast_after(FrequencyMs, self(), {poll, Ref}),
 			{noreply, State};
 		{error, not_found} ->
+			?LOG_DEBUG([{event, peer_out_of_sync}, {peer, ar_util:format_peer(Peer)}]),
 			gen_server:cast(ar_poller, {peer_out_of_sync, Peer}),
 			{noreply, State#state{ pause = true }};
 		{error, Reason} ->

--- a/rebar.config
+++ b/rebar.config
@@ -423,7 +423,7 @@
 		{deps, [{meck, "0.8.13"}]},
 		{erl_opts, [
 			{d, 'TESTNET', true},			
-			{d, 'NETWORK_NAME', "arweave.2.6.testnet"},
+			{d, 'NETWORK_NAME', "arweave.2.7.testnet"},
 			{d, 'TEST_WALLET_ADDRESS', "MXeFJwxb4y3vL4In3oJu60tQGXGCzFzWLwBUxnbutdQ"},
 			{d, 'TOP_UP_TEST_WALLET_AR', 1000000},
 

--- a/testnet/start_testnet_client.sh
+++ b/testnet/start_testnet_client.sh
@@ -20,7 +20,7 @@ screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh peer testnet_pilot)
 screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh vdf_server_trusted_peer testnet_pilot)
 
 screen_cmd+=" debug mine \
-max_vdf_validation_thread_count 2 \
+max_vdf_validation_thread_count 2 enable remove_orphaned_storage_module_data \
 data_dir /arweave-data"
 
 echo "$screen_cmd"

--- a/testnet/start_testnet_pilot.sh
+++ b/testnet/start_testnet_pilot.sh
@@ -21,7 +21,7 @@ screen_cmd="screen -dmsL arweave /arweave-build/testnet/bin/start"
 screen_cmd+=$($ARWEAVE_DIR/testnet/build_data_flags.sh)
 screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh vdf_client_peer testnet_client)
 
-screen_cmd+=" debug mine \
+screen_cmd+=" debug mine enable remove_orphaned_storage_module_data \
 data_dir /arweave-data"
 
 if [ -z "$block" ]; then

--- a/testnet/start_testnet_solo.sh
+++ b/testnet/start_testnet_solo.sh
@@ -18,7 +18,7 @@ screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh peer testnet_client)
 screen_cmd+=$($ARWEAVE_DIR/testnet/build_peer_flags.sh peer testnet_pilot)
 
 screen_cmd+=" debug mine \
-max_vdf_validation_thread_count 2 \
+max_vdf_validation_thread_count 2 enable remove_orphaned_storage_module_data \
 data_dir /arweave-data"
 
 echo "$screen_cmd"


### PR DESCRIPTION
 so that we only remove a peer when it is truly out of sync. Previously the set was initialized empty which meant a peer was only added if it went out of sync (due to the 5 minute timeout). This created a situation where a singl out of sync peer could cause the "Out of sync" console message to be printed.

By initializing the set with all trusted peers, the message is only printed when all peers go out of sync