### PR TITLE
Fix for validating steps between two blocks crossing an entropy reset line

### DIFF
--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -492,7 +492,8 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 	CorrectRebaseThreshold =
 		case PassesSeedCheck of
 			false ->
-				?LOG_INFO([{event, ignore_mining_solution}, {reason, accepted_another_block}]),
+				?LOG_INFO([{event, ignore_mining_solution}, {reason, accepted_another_block},
+					{check, seed_check}, {solution, ar_util:encode(SolutionH)}]),
 				false;
 			true ->
 				case get_merkle_rebase_threshold(PrevB) of
@@ -505,7 +506,8 @@ handle_info({event, miner, {found_solution, Args}}, State) ->
 	HaveSteps =
 		case CorrectRebaseThreshold of
 			false ->
-				?LOG_INFO([{event, ignore_mining_solution}, {reason, accepted_another_block}]),
+				?LOG_INFO([{event, ignore_mining_solution}, {reason, accepted_another_block},
+					{check, rebase_threshold_check}, {solution, ar_util:encode(SolutionH)}]),
 				false;
 			true ->
 				ar_nonce_limiter:get_steps(PrevStepNumber, StepNumber, PrevNextSeed)


### PR DESCRIPTION
When validating steps between two blocks that cross an entropy reset line, use the VDF difficulty from the previous block to validate the steps up to the reset line, and the difficulty from the current block to validate the steps after the reset line