### PR TITLE
Handle off-by-one error in update_block_index()

### DIFF
--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -1497,7 +1497,7 @@ apply_validated_block2(State, B, PrevBlocks, Orphans, RecentBI, BlockTXPairs) ->
 		end,
 		tl(lists:reverse(PrevBlocks))
 	),
-	ar_storage:update_block_index(B#block.height - OrphanCount, OrphanCount, AddedBIElements),
+	ar_storage:update_block_index(B#block.height, OrphanCount, AddedBIElements),
 	ar_storage:store_reward_history_part(AddedBlocks),
 	ar_storage:store_block_time_history_part(AddedBlocks, lists:last(PrevBlocks)),
 	ets:insert(node_state, [


### PR DESCRIPTION
Handle off-by-one error in update_block_index() that was causing a valid index to be deleted when OrphanCount was 1