### PR TITLE
during read_wallet_list call get_prev on H+1

### DIFF
--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -120,7 +120,7 @@ store_block_index(BI) ->
 			case binary_to_term(V) of
 				{H, WeaveSize, TXRoot, _PrevH} ->
 					BI2 = lists:reverse(lists:sublist(BI, Height2 - Height3)),
-					update_block_index(Height3 + 1, Height - Height3, BI2);
+					update_block_index(Height, Height - Height3, BI2);
 				{H2, _, _, _} ->
 					?LOG_ERROR([{event, failed_to_store_block_index},
 							{reason, no_intersection},

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -408,7 +408,7 @@ find_key_by_matching_longest_prefix(_Addr, [], {Key, Prefix}) ->
 			{Key, Prefix}
 	end;
 find_key_by_matching_longest_prefix(Addr, [{_, Prefix} | Keys], {Key, KeyPrefix})
-		when byte_size(Prefix) =< byte_size(KeyPrefix) ->
+		when Prefix == <<>> orelse byte_size(Prefix) =< byte_size(KeyPrefix) ->
 	find_key_by_matching_longest_prefix(Addr, Keys, {Key, KeyPrefix});
 find_key_by_matching_longest_prefix(Addr, [{H, Prefix} | Keys], {Key, KeyPrefix}) ->
 	case binary:match(Addr, Prefix) of

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -896,14 +896,18 @@ read_wallet_list({ok, << K:48/binary, _/binary >>, Bin}, Tree, Keys, RootHash, K
 			case Keys of
 				[] ->
 					{ok, Tree2};
-				[{H, Prefix} | Keys2] ->
-					Key2 = << H/binary, Prefix/binary >>,
-					read_wallet_list(ar_kv:get_next(account_tree_db, Key2), Tree2, Keys2,
+				[{H, _Prefix} | Keys2] ->
+					%% get_next(<<H>>) rather than get_next(<<H, Prefix>>) since the prefix 
+					%% associated with a hash depends on the order of insertions (and is only
+					%% needed to speed up the tree search when querying an address balance)
+					read_wallet_list(ar_kv:get_next(account_tree_db, H), Tree2, Keys2,
 							RootHash, H)
 			end;
-		[{H, Prefix} | Hs] ->
-			Key3 = << H/binary, Prefix/binary >>,
-			read_wallet_list(ar_kv:get_next(account_tree_db, Key3), Tree, Hs ++ Keys, RootHash,
+		[{H, _Prefix} | Hs] ->
+			%% get_next(<<H>>) rather than get_next(<<H, Prefix>>) since the prefix 
+			%% associated with a hash depends on the order of insertions (and is only
+			%% needed to speed up the tree search when querying an address balance)
+			read_wallet_list(ar_kv:get_next(account_tree_db, H), Tree, Hs ++ Keys, RootHash,
 					H)
 	end;
 read_wallet_list({ok, _, _}, _Tree, _Keys, RootHash, _K) ->

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -375,7 +375,9 @@ read_block(BH) ->
 %% to the tree. The balance may be also 0 when the address exists in the tree. Return
 %% not_found if some of the files with the account data are missing.
 read_account(Addr, Key) ->
-	case get_account_tree_value(Key) of
+	<< N:(48 * 8) >> = Key,
+	Key2 = << (N + 1):(48 * 8) >>,
+	case ar_kv:get_prev(account_tree_db, Key2) of
 		{ok, << Key:48/binary, _/binary >>, V} ->
 			case binary_to_term(V) of
 				{K, Val} when K == Addr ->
@@ -868,7 +870,9 @@ read_wallet_list(<<>>) ->
 	{ok, ar_patricia_tree:new()};
 read_wallet_list(WalletListHash) when is_binary(WalletListHash) ->
 	Key = WalletListHash,
-	read_wallet_list(get_account_tree_value(Key), ar_patricia_tree:new(), [],
+	<< N:(48 * 8) >> = Key,
+	Key2 = << (N + 1):(48 * 8) >>,
+	read_wallet_list(ar_kv:get_prev(account_tree_db, Key2), ar_patricia_tree:new(), [],
 			WalletListHash, WalletListHash).
 
 read_wallet_list({ok, << K:48/binary, _/binary >>, Bin}, Tree, Keys, RootHash, K) ->
@@ -879,11 +883,15 @@ read_wallet_list({ok, << K:48/binary, _/binary >>, Bin}, Tree, Keys, RootHash, K
 				[] ->
 					{ok, Tree2};
 				[{H, _Prefix} | Keys2] ->
-					read_wallet_list(get_account_tree_value(H), Tree2, Keys2,
+					<< N:(48 * 8) >> = H,
+					H2 = << (N + 1):(48 * 8) >>,
+					read_wallet_list(ar_kv:get_prev(account_tree_db, H2), Tree2, Keys2,
 							RootHash, H)
 			end;
-		[{H, _Prefix} | Hs] ->
-			read_wallet_list(get_account_tree_value(H), Tree, Hs ++ Keys, RootHash,
+		[{H, Prefix} | Hs] ->
+			<< N:(48 * 8) >> = H,
+			H2 = << (N + 1):(48 * 8) >>,
+			read_wallet_list(ar_kv:get_prev(account_tree_db, H2), Tree, Hs ++ Keys, RootHash,
 					H)
 	end;
 read_wallet_list({ok, _, _}, _Tree, _Keys, RootHash, _K) ->
@@ -1282,17 +1290,6 @@ store_account_tree_update(Height, RootHash, Map) ->
 	),
 	?LOG_INFO([{event, stored_account_tree}]).
 
-%% @doc Ignore the prefix when querying a key since the prefix might depend on the order of
-%% insertions and is only used to optimize certain lookups.
-get_account_tree_value(Key) ->
-	<< N:(48 * 8) >> = Key,
-	Key2 = << (N + 1):(48 * 8) >>,
-	ar_kv:get_prev(account_tree_db, Key2).
-
-%%%===================================================================
-%%% Tests
-%%%===================================================================
-
 %% @doc Test block storage.
 store_and_retrieve_block_test_() ->
 	{timeout, 60, fun test_store_and_retrieve_block/0}.
@@ -1332,10 +1329,7 @@ tx_id(TXID) ->
 	TXID.
 
 store_and_retrieve_wallet_list_test_() ->
-	[
-		{timeout, 20, fun test_store_and_retrieve_wallet_list/0},
-		{timeout, 240, fun test_store_and_retrieve_wallet_list_permutations/0}
-	].
+	{timeout, 20, fun test_store_and_retrieve_wallet_list/0}.
 
 test_store_and_retrieve_wallet_list() ->
 	[B0] = ar_weave:init(),
@@ -1368,73 +1362,6 @@ test_store_and_retrieve_wallet_list() ->
 	?assertEqual({0, TXID}, read_account(Addr, WalletListHash3)),
 	{ok, ActualWL6} = read_wallet_list(WalletListHash3),
 	assert_wallet_trees_equal(ActualWL5, ActualWL6).
-
-test_store_and_retrieve_wallet_list_permutations() ->
-	lists:foreach(
-		fun(Permutation) ->
-			store_and_retrieve_wallet_list(Permutation)
-		end,
-		permutations([ <<"a">>, <<"aa">>, <<"ab">>, <<"bb">>, <<"b">>, <<"aaa">> ])),
-	lists:foreach(
-		fun(Permutation) ->
-			store_and_retrieve_wallet_list(Permutation)
-		end,
-		permutations([ <<"a">>, <<"aa">>, <<"aaa">>, <<"aaaa">>, <<"aaaaa">> ])),
-	store_and_retrieve_wallet_list([ <<"a">>, <<"aa">>, <<"ab">>, <<"b">> ]),
-	store_and_retrieve_wallet_list([ <<"aa">>, <<"a">>, <<"ab">> ]),
-	store_and_retrieve_wallet_list([ <<"aaa">>, <<"bbb">>, <<"aab">>, <<"ab">>, <<"a">> ]),
-	store_and_retrieve_wallet_list([
-		<<"aaaa">>, <<"aaab">>, <<"aaac">>,
-		<<"aaa">>, <<"aab">>, <<"aac">>,
-		<<"aa">>, <<"ab">>, <<"ac">>,
-		<<"a">>, <<"b">>, <<"c">>
-	]),
-	store_and_retrieve_wallet_list([
-		<<"a">>, <<"b">>, <<"c">>,
-		<<"aa">>, <<"ab">>, <<"ac">>,
-		<<"aaa">>, <<"aab">>, <<"aac">>,
-		<<"aaaa">>, <<"aaab">>, <<"aaac">>,
-		<<"a">>, <<"b">>, <<"c">>,
-		<<"aa">>, <<"ab">>, <<"ac">>,
-		<<"aaa">>, <<"aab">>, <<"aac">>,
-		<<"aaaa">>, <<"aaab">>, <<"aaac">>
-	]),
-	store_and_retrieve_wallet_list([
-		<<"aaaa">>, <<"aaa">>, <<"aa">>, <<"a">>,
-		<<"aaab">>, <<"aab">>, <<"ab">>, <<"b">>,
-		<<"aaac">>, <<"aac">>, <<"ac">>, <<"c">>,
-		<<"aaaa">>, <<"aaa">>, <<"aa">>, <<"a">>,
-		<<"aaab">>, <<"aab">>, <<"ab">>, <<"b">>,
-		<<"aaac">>, <<"aac">>, <<"ac">>, <<"c">>
-	]),
-	store_and_retrieve_wallet_list([
-		<<"aaaa">>, <<"aaab">>, <<"aaac">>,
-		<<"a">>, <<"aa">>, <<"aaa">>,
-		<<"aaaa">>, <<"aaab">>, <<"aaac">>
-	]),
-	ok.
-
-store_and_retrieve_wallet_list(Keys) ->
-	MinBinary = <<>>,
-	MaxBinary = << <<1:1>> || _ <- lists:seq(1, 512) >>,
-	ar_kv:delete_range(account_tree_db, MinBinary, MaxBinary),
-	store_and_retrieve_wallet_list(Keys, ar_patricia_tree:new()).
-
-store_and_retrieve_wallet_list([], Tree) ->
-	Tree;
-store_and_retrieve_wallet_list([Key | Keys], Tree) ->
-	TXID = crypto:strong_rand_bytes(32),
-	Balance = rand:uniform(1000000000),
-	ExpectedTree = ar_patricia_tree:insert(Key, {Balance, TXID}, Tree),
-	WalletListHash = write_wallet_list(0, ExpectedTree),
-	{ok, ActualTree} = read_wallet_list(WalletListHash),
-	?assertEqual({Balance, TXID}, read_account(Key, WalletListHash)),
-	assert_wallet_trees_equal(ExpectedTree, ActualTree),
-	store_and_retrieve_wallet_list(Keys, ExpectedTree).
-
-%% From: https://www.erlang.org/doc/programming_examples/list_comprehensions.html#permutations
-permutations([]) -> [[]];
-permutations(L)  -> [[H|T] || H <- L, T <- permutations(L--[H])].
 
 assert_wallet_trees_equal(Expected, Actual) ->
 	?assertEqual(

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -896,18 +896,14 @@ read_wallet_list({ok, << K:48/binary, _/binary >>, Bin}, Tree, Keys, RootHash, K
 			case Keys of
 				[] ->
 					{ok, Tree2};
-				[{H, _Prefix} | Keys2] ->
-					%% get_next(<<H>>) rather than get_next(<<H, Prefix>>) since the prefix 
-					%% associated with a hash depends on the order of insertions (and is only
-					%% needed to speed up the tree search when querying an address balance)
-					read_wallet_list(ar_kv:get_next(account_tree_db, H), Tree2, Keys2,
+				[{H, Prefix} | Keys2] ->
+					Key2 = << H/binary, Prefix/binary >>,
+					read_wallet_list(ar_kv:get_next(account_tree_db, Key2), Tree2, Keys2,
 							RootHash, H)
 			end;
-		[{H, _Prefix} | Hs] ->
-			%% get_next(<<H>>) rather than get_next(<<H, Prefix>>) since the prefix 
-			%% associated with a hash depends on the order of insertions (and is only
-			%% needed to speed up the tree search when querying an address balance)
-			read_wallet_list(ar_kv:get_next(account_tree_db, H), Tree, Hs ++ Keys, RootHash,
+		[{H, Prefix} | Hs] ->
+			Key3 = << H/binary, Prefix/binary >>,
+			read_wallet_list(ar_kv:get_next(account_tree_db, Key3), Tree, Hs ++ Keys, RootHash,
 					H)
 	end;
 read_wallet_list({ok, _, _}, _Tree, _Keys, RootHash, _K) ->

--- a/rebar.config
+++ b/rebar.config
@@ -427,10 +427,10 @@
 			{d, 'TEST_WALLET_ADDRESS', "MXeFJwxb4y3vL4In3oJu60tQGXGCzFzWLwBUxnbutdQ"},
 			{d, 'TOP_UP_TEST_WALLET_AR', 1000000},
 
-			%% The following values all assume the testnet is restarted from height 1264619 using
+			%% The following values all assume the testnet is restarted from height 1265109 using
 			%% the flag:
-			%% start_from_block JMAqr9BXWseRcaUv_UeTqh4WXXt_uR1E1qc7Dy6XJfB9Mi1_dYWbewLuZNx16Rg_
-
+			%% start_from_block sepWUY7ZtNkIE9eaMb-lGOagaUd7YEnGXkXgeEMDEne7ek1Ife3t6cWaep5vO2Pt
+			
 			%% TOP_UP_TEST_WALLET_HEIGHT should always be set to either:
 			%% 1. a future height (i.e. a height which has not yet been mined on the testnet)
 			%% 2. an already mined height that was previously used to top up the test wallet
@@ -438,7 +438,7 @@
 			%% a TESTNET node will inject a deposit transaction a the specified height, if this is
 			%% done to an already mined block it will invalidate that block's wallet_list and cause
 			%% a crash.
-			{d, 'TOP_UP_TEST_WALLET_HEIGHT', 1264620},
+			{d, 'TOP_UP_TEST_WALLET_HEIGHT', 1265110},
 
 			%% TESTNET_DIFFICULTY_DROP_HEIGHT should meet the following requirements:
 			%% 1. It should be set to a difficulty retargeting height - i.e. a multiple of
@@ -446,19 +446,19 @@
 			%% 2. It should set to 1 more than the testnet initialization height.
 			%% 
 			%% For example, if the testnet was branched off mainnet at
-			%% height 1263279 (either through the use of start_from_latest_state or
-			%% start_from_block), then TESTNET_DIFFICULTY_DROP_HEIGHT should be set to 1263280.
-			{d, 'TESTNET_DIFFICULTY_DROP_HEIGHT', 1264620},
+			%% height 1265219 (either through the use of start_from_latest_state or
+			%% start_from_block), then TESTNET_DIFFICULTY_DROP_HEIGHT should be set to 1265220.
+			{d, 'TESTNET_DIFFICULTY_DROP_HEIGHT', 1265110},
 
 			%% The following variables were used to do pre-launch testing on the 2.7 fork. They
 			%% should be changed or removed once the 2.7 fork is live.
-			{d, 'FORK_2_7_HEIGHT', 1264630},
+			{d, 'FORK_2_7_HEIGHT', 1265120},
 			{d, 'BLOCK_TIME_HISTORY_BLOCKS', 10},
 			{d, 'VDF_DIFFICULTY_RETARGET', 10},
 			%% VDF_HISTORY_CUT must be lower than BLOCK_TIME_HISTORY_BLOCKS
 			{d, 'VDF_HISTORY_CUT', 5},
-			{d, 'PRICE_2_6_8_TRANSITION_START', 75080}, %% height 1264640
-			{d, 'PRICE_2_6_8_TRANSITION_BLOCKS', 50}, %% height 1264690
+			{d, 'PRICE_2_6_8_TRANSITION_START', 75570}, %% height 1265130
+			{d, 'PRICE_2_6_8_TRANSITION_BLOCKS', 50}, %% height 1265180
 			{d, 'PRICE_ADJUSTMENT_FREQUENCY', 10}
 		]},
 		{relx, [

--- a/rebar.config
+++ b/rebar.config
@@ -427,9 +427,9 @@
 			{d, 'TEST_WALLET_ADDRESS', "MXeFJwxb4y3vL4In3oJu60tQGXGCzFzWLwBUxnbutdQ"},
 			{d, 'TOP_UP_TEST_WALLET_AR', 1000000},
 
-			%% The following values all assume the testnet is restarted from height 1262709 using
+			%% The following values all assume the testnet is restarted from height 1264619 using
 			%% the flag:
-			%% start_from_block IkwYrOpByk7PT0pZmHKxOmml6AQ4MPH6aNDsa-OpaFCPE8ie2gdXfhruOFj5TZPA
+			%% start_from_block JMAqr9BXWseRcaUv_UeTqh4WXXt_uR1E1qc7Dy6XJfB9Mi1_dYWbewLuZNx16Rg_
 
 			%% TOP_UP_TEST_WALLET_HEIGHT should always be set to either:
 			%% 1. a future height (i.e. a height which has not yet been mined on the testnet)
@@ -438,7 +438,7 @@
 			%% a TESTNET node will inject a deposit transaction a the specified height, if this is
 			%% done to an already mined block it will invalidate that block's wallet_list and cause
 			%% a crash.
-			{d, 'TOP_UP_TEST_WALLET_HEIGHT', 1262710},
+			{d, 'TOP_UP_TEST_WALLET_HEIGHT', 1264620},
 
 			%% TESTNET_DIFFICULTY_DROP_HEIGHT should meet the following requirements:
 			%% 1. It should be set to a difficulty retargeting height - i.e. a multiple of
@@ -446,19 +446,19 @@
 			%% 2. It should set to 1 more than the testnet initialization height.
 			%% 
 			%% For example, if the testnet was branched off mainnet at
-			%% height 1262709 (either through the use of start_from_latest_state or
-			%% start_from_block), then TESTNET_DIFFICULTY_DROP_HEIGHT should be set to 1262710.
-			{d, 'TESTNET_DIFFICULTY_DROP_HEIGHT', 1262710},
+			%% height 1263279 (either through the use of start_from_latest_state or
+			%% start_from_block), then TESTNET_DIFFICULTY_DROP_HEIGHT should be set to 1263280.
+			{d, 'TESTNET_DIFFICULTY_DROP_HEIGHT', 1264620},
 
 			%% The following variables were used to do pre-launch testing on the 2.7 fork. They
 			%% should be changed or removed once the 2.7 fork is live.
-			{d, 'FORK_2_7_HEIGHT', 1262720},
+			{d, 'FORK_2_7_HEIGHT', 1264630},
 			{d, 'BLOCK_TIME_HISTORY_BLOCKS', 10},
 			{d, 'VDF_DIFFICULTY_RETARGET', 10},
 			%% VDF_HISTORY_CUT must be lower than BLOCK_TIME_HISTORY_BLOCKS
 			{d, 'VDF_HISTORY_CUT', 5},
-			{d, 'PRICE_2_6_8_TRANSITION_START', 73170}, %% height 1262730
-			{d, 'PRICE_2_6_8_TRANSITION_BLOCKS', 50}, %% height 1262780
+			{d, 'PRICE_2_6_8_TRANSITION_START', 75080}, %% height 1264640
+			{d, 'PRICE_2_6_8_TRANSITION_BLOCKS', 50}, %% height 1264690
 			{d, 'PRICE_ADJUSTMENT_FREQUENCY', 10}
 		]},
 		{relx, [


### PR DESCRIPTION
Fix by @ldmberman 
during read_wallet_list call get_prev  since the prefixes might depend
on the order of insertions and we only need them in
GET /block/height/{height}/wallet/{addr}/balance, to search the tree faster

Also fix a regression in update_block_index introduced earlier.