### PR TITLE
Process all VDF server updates - even multiple updates from

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 *.dat
 .vscode
-slave.out
+*.out
 *.code-workspace
 .arweave.plt
 testlog
@@ -13,8 +13,7 @@ _build
 .rebar3
 apps/arweave/c_src/**/*.o
 apps/arweave/c_src/tests/tests
-data_test_master
-data_test_slave
+data_test_*
 erl_crash.dump
 tags
 metrics
@@ -26,6 +25,5 @@ wallets
 logs
 !bin/logs
 ebin
-metrics_master
-metrics_slave
+metrics_*
 release/output

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -282,9 +282,12 @@ handle_info({'DOWN', Ref,  process, _, Reason},
 			{noreply, State}
 	end;
 
-handle_info({event, nonce_limiter, {computed_output, _}},
+handle_info({event, nonce_limiter, {computed_output, Args}},
 		#state{ session = #mining_session{ ref = undefined } } = State) ->
-	?LOG_DEBUG([{event, mining_debug_nonce_limiter_computed_output_session_undefined}]),
+	{{NextSeed, _StartIntervalNumber}, Session,
+		_PrevSessionKey, _PrevSession, _Output, _PartitionUpperBound} = Args,
+	?LOG_DEBUG([{event, mining_debug_nonce_limiter_computed_output_session_undefined},
+		{step_number, Session#vdf_session.step_number}, {session, ar_util:encode(NextSeed)}]),
 	{noreply, State};
 handle_info({event, nonce_limiter, {computed_output, Args}},
 		#state{ task_queue = Q } = State) ->
@@ -790,9 +793,12 @@ priority(mining_thread_computed_h0, StepNumber) ->
 priority(nonce_limiter_computed_output, StepNumber) ->
 	{6, -StepNumber}.
 
-handle_task({computed_output, _},
+handle_task({computed_output, Args},
 		#state{ session = #mining_session{ ref = undefined } } = State) ->
-	?LOG_DEBUG([{event, mining_debug_handle_task_computed_output_session_undefined}]),
+	{{NextSeed, _StartIntervalNumber}, Session,
+		_PrevSessionKey, _PrevSession, _Output, _PartitionUpperBound} = Args,
+	?LOG_DEBUG([{event, mining_debug_handle_task_computed_output_session_undefined},
+		{step_number, Session#vdf_session.step_number}, {session, ar_util:encode(NextSeed)}]),
 	{noreply, State};
 handle_task({computed_output, Args}, State) ->
 	#state{ session = Session, io_threads = IOThreads, hashing_threads = Threads } = State,

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -977,10 +977,15 @@ apply_external_update2(Update, State) ->
 					%% steps from the previous session to the new session. In this case we only
 					%% want to apply new steps - steps in Session that weren't already applied as
 					%% part of PrevSession.
+
+					%% Start after the last step of the previous session
 					RangeStart = case maps:get(PrevSessionKey, SessionByKey, undefined) of
 						undefined -> 0;
 						PrevSession -> PrevSession#vdf_session.step_number + 1
 					end,
+					%% But start no later than the beginning of the session 2 after PrevSession.
+					%% This is because the steps in that session - which may have been previously
+					%% computed - have now been invalidated.
 					NextSessionStart = (SessionInterval + 1) * ?NONCE_LIMITER_RESET_FREQUENCY,
 					{_, Steps} = get_step_range(
 						Session, min(RangeStart, NextSessionStart), StepNumber),					

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -1156,7 +1156,6 @@ trigger_computed_outputs(_SessionKey, _Session, _PrevSessionKey, _PrevSession,
 	ok;
 trigger_computed_outputs(SessionKey, Session, PrevSessionKey, PrevSession, UpperBound,
 		[Step | Steps]) ->
-	?LOG_ERROR([{event, trigger_computed_outputs}, {step, Step}]),
 	ar_events:send(nonce_limiter, {computed_output, {SessionKey, Session, PrevSessionKey,
 			PrevSession, Step, UpperBound}}),
 	#vdf_session{ step_number = StepNumber, steps = [_ | PrevSteps] } = Session,

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -968,7 +968,7 @@ apply_external_update2(Update, State) ->
 						{result, session_not_found},
 						{vdf_server, ar_util:format_peer(Peer)},
 						{is_partial, IsPartial},
-						{session_seed, SessionSeed},
+						{session_seed, ar_util:encode(SessionSeed)},
 						{session_interval, SessionInterval},
 						{server_step_number, StepNumber}]),
 					{reply, #nonce_limiter_update_response{ session_found = false }, State};

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -448,8 +448,13 @@ handle_call({get_steps, StartStepNumber, EndStepNumber, SessionKey}, _From, Stat
 			{reply, lists:sublist(Steps, TakeN), State}
 	end;
 
+%% @doc Get all the steps in the current session that fall between
+%% StartStepNumber+1 and EndStepNumber (inclusive)
 handle_call({get_session_steps, StartStepNumber, EndStepNumber, SessionKey}, _From, State) ->
-	{reply, get_session_steps(StartStepNumber, EndStepNumber, SessionKey, State), State};
+	#state{ session_by_key = SessionByKey } = State,
+	Session = maps:get(SessionKey, SessionByKey, not_found),
+	{_, Steps} = get_step_range(Session, StartStepNumber + 1, EndStepNumber),
+	{reply, Steps, State};
 
 handle_call(get_steps, _From, #state{ current_session_key = undefined } = State) ->
 	{reply, [], State};
@@ -530,11 +535,11 @@ handle_cast({validated_steps, Args}, State) ->
 						%% as well as the checkpoints associated with step StepNumber.
 						%% This branch occurs when a block is received that is ahead of us
 						%% in the VDF chain.
-						Steps2 = lists:sublist(Steps, StepNumber - CurrentStepNumber)
-								++ CurrentSteps,
+						{_, Steps2} =
+							get_step_range(Steps, StepNumber, CurrentStepNumber + 1, StepNumber),
 						Map2 = maps:put(StepNumber, LastStepCheckpoints, Map),
 						Session#vdf_session{
-							step_number = StepNumber, steps = Steps2,
+							step_number = StepNumber, steps = Steps2 ++ CurrentSteps,
 							step_checkpoints_map = Map2 };
 					false ->
 						Session
@@ -883,13 +888,12 @@ worker() ->
 get_steps(StartStepNumber, EndStepNumber, SessionKey, State) ->
 	#state{ session_by_key = SessionByKey } = State,
 	case maps:get(SessionKey, SessionByKey, not_found) of
-		#vdf_session{ step_number = StepNumber, steps = SessionSteps,
-				prev_session_key = PrevSessionKey }
+		#vdf_session{ step_number = StepNumber, prev_session_key = PrevSessionKey } = Session
 				when StepNumber >= EndStepNumber ->
-			%% Get the steps within the current session that fall within the StartStepNumber
-			%% and EndStepNumber range.
-			Steps = lists:nthtail(StepNumber - EndStepNumber, SessionSteps),
-			TotalCount = EndStepNumber - StartStepNumber,
+			%% Get the steps within the current session that fall within the StartStepNumber+1
+			%% and EndStepNumber (inclusive) range.
+			{_, Steps} = get_step_range(Session, StartStepNumber + 1, EndStepNumber),
+			TotalCount = EndStepNumber - StartStepNumber - 1,
 			Count = length(Steps),
 			%% If we haven't found all the steps, recurse into the previous session.
 			case TotalCount > Count of
@@ -902,24 +906,10 @@ get_steps(StartStepNumber, EndStepNumber, SessionKey, State) ->
 							Steps ++ PrevSteps
 					end;
 				false ->
-					lists:sublist(Steps, TotalCount)
+					Steps
 			end;
 		_ ->
 			not_found
-	end.
-
-%% @doc Get all the steps in the current session that fall between
-%% StartStepNumber and EndStepNumber
-get_session_steps(StartStepNumber, EndStepNumber, SessionKey, State) ->
-	#state{ session_by_key = SessionByKey } = State,
-	case maps:get(SessionKey, SessionByKey, not_found) of
-		#vdf_session{ step_number = StepNumber, steps = SessionSteps }
-				when StepNumber > StartStepNumber ->
-			End = min(StepNumber, EndStepNumber),
-			Steps = lists:nthtail(StepNumber - End, SessionSteps),
-			lists:sublist(Steps, End - StartStepNumber);
-		_ ->
-			[]
 	end.
 
 schedule_step(State) ->
@@ -978,36 +968,25 @@ apply_external_update2(Update, State) ->
 						{result, session_not_found},
 						{vdf_server, ar_util:format_peer(Peer)},
 						{is_partial, IsPartial},
-						{session_seed, ar_util:encode(SessionSeed)},
+						{session_seed, SessionSeed},
 						{session_interval, SessionInterval},
 						{server_step_number, StepNumber}]),
 					{reply, #nonce_limiter_update_response{ session_found = false }, State};
 				false ->
 					%% Handle the case where The VDF server has processed a block and re-allocated
-					%% steps across sessions. Between blocks The VDF server (and all nodes that 
-					%% compute their own VDF) will add all computed steps to the same session -
-					%% *even if* the new steps have crossed the entropy reset line and therefore 
-					%% could be added to a new session. Once a block is processed the server will
-					%% open a new session and re-allocate all the steps past the entropy reset line
-					%% to that new session. When the VDF client sees the new session it will request
-					%% the full session to be resent - which will contain steps it has already seen
-					%% and cached under the previous session key.
-					%% 
-					%% Note: This overlap in session caching is intentional. The intention is to
-					%% quickly access the steps when validating B1 -> reset line -> B2 given the
-					%% current fork of B1 -> B2' -> reset line -> B3 i.e. we can query all steps by
-					%% B1.next_seed even though on our fork the reset line determined a different
-					%% next_seed for the latest session.
-					%%
-					%% To avoid processing those steps twice, the client grabs PrevSessions's most
-					%% recently processed step and ignores it and any lower steps found in Session.
-					PrevStepNumber = case maps:get(PrevSessionKey, SessionByKey, undefined) of
+					%% steps from the previous session to the new session. In this case we only
+					%% want to apply new steps - steps in Session that weren't already applied as
+					%% part of PrevSession.
+					RangeStart = case maps:get(PrevSessionKey, SessionByKey, undefined) of
 						undefined -> 0;
-						PrevSession -> PrevSession#vdf_session.step_number
+						PrevSession -> PrevSession#vdf_session.step_number + 1
 					end,
+					NextSessionStart = (SessionInterval + 1) * ?NONCE_LIMITER_RESET_FREQUENCY,
+					{_, Steps} = get_step_range(
+						Session, min(RangeStart, NextSessionStart), StepNumber),					
 					State2 = apply_external_update3(State,
 						SessionKey, PrevSessionKey, CurrentSessionKey,
-						Session, StepNumber - PrevStepNumber, UpperBound),
+						Session, Steps, UpperBound),
 					{reply, ok, State2}
 			end;
 		#vdf_session{ step_number = CurrentStepNumber, steps = CurrentSteps,
@@ -1021,7 +1000,7 @@ apply_external_update2(Update, State) ->
 							steps = [Output | CurrentSteps] },
 					State2 = apply_external_update3(State,
 							SessionKey, PrevSessionKey, CurrentSessionKey, 
-							CurrentSession2, 1, UpperBound),
+							CurrentSession2, [Output], UpperBound),
 					{reply, ok, State2};
 				false ->
 					case CurrentStepNumber >= StepNumber of
@@ -1061,9 +1040,11 @@ apply_external_update2(Update, State) ->
 									%% To avoid processing those steps twice, the client grabs
 									%% CurrentStepNumber (our most recently processed step number)
 									%% and ignores it and any lower steps found in Session.
+									{_, Steps} = get_step_range(
+											Session, CurrentStepNumber + 1, StepNumber),
 									State2 = apply_external_update3(State,
 										SessionKey, PrevSessionKey, CurrentSessionKey, 
-										Session, StepNumber - CurrentStepNumber, UpperBound),
+										Session, Steps, UpperBound),
 									{reply, ok, State2}
 							end
 					end
@@ -1084,20 +1065,71 @@ apply_external_update2(Update, State) ->
 %% We truncate Session.steps such the previously procesed steps are not sent to
 %% trigger_computed_outputs.
 apply_external_update3(
-	State, SessionKey, PrevSessionKey, CurrentSessionKey, Session, NumSteps, UpperBound) ->
-	{SessionSeed, SessionInterval} = SessionKey,
+	State, SessionKey, PrevSessionKey, CurrentSessionKey, Session, Steps, UpperBound) ->
 	?LOG_DEBUG([{event, apply_external_vdf},
 		{result, ok},
-		{session_seed, ar_util:encode(SessionSeed)},
-		{session_interval, SessionInterval},
-		{num_steps, NumSteps},
-		{length, length(Session#vdf_session.steps)}]),
+		{session_seed, ar_util:encode(element(1, SessionKey))},
+		{session_interval, element(2, SessionKey)},
+		{length, length(Steps)}]),
 	#state{ session_by_key = SessionByKey } = State,
 	State2 = cache_session(State, SessionKey, CurrentSessionKey, Session),
 	PrevSession = maps:get(PrevSessionKey, SessionByKey, undefined),
-	Steps = lists:sublist(Session#vdf_session.steps, NumSteps),
 	trigger_computed_outputs(SessionKey, Session, PrevSessionKey, PrevSession, UpperBound, Steps),
 	State2.
+
+%% @doc Returns a sub-range of steps out of a larger list of steps. This is
+%% primarily used to manage "overflow" steps.
+%%
+%% Between blocks nodes will add all computed VDF steps to the same session -
+%% *even if* the new steps have crossed the entropy reset line and therefore 
+%% could be added to a new session (i.e. "overflow steps"). Once a block is 
+%% processed the node will open a new session and re-allocate all the steps past
+%% the entropy reset line to that new session. However, any steps that have crossed
+%% *TWO* entropy reset lines are no longer valid (the seed they were generated with
+%% has changed with the arrival of a new block)
+%% 
+%% Note: This overlap in session caching is intentional. The intention is to
+%% quickly access the steps when validating B1 -> reset line -> B2 given the
+%% current fork of B1 -> B2' -> reset line -> B3 i.e. we can query all steps by
+%% B1.next_seed even though on our fork the reset line determined a different
+%% next_seed for the latest session.
+get_step_range(Session, SessionInterval) ->
+	SessionStart = SessionInterval * ?NONCE_LIMITER_RESET_FREQUENCY,
+	SessionEnd = (SessionInterval + 1) * ?NONCE_LIMITER_RESET_FREQUENCY - 1,
+	get_step_range(Session, SessionStart, SessionEnd).
+
+get_step_range(not_found, _RangeStart, _RangeEnd) ->
+	{0, []};
+get_step_range(#vdf_session{steps = Steps, step_number = StepNumber}, RangeStart, RangeEnd) ->
+	get_step_range(Steps, StepNumber, RangeStart, RangeEnd).
+
+get_step_range([], _StepNumber, _RangeStart, _RangeEnd) ->
+	{0, []};
+get_step_range(_Steps, _StepNumber, RangeStart, RangeEnd)
+		when RangeStart > RangeEnd ->
+	{0, []};
+get_step_range(_Steps, StepNumber, RangeStart, _RangeEnd)
+		when StepNumber < RangeStart ->
+	{0, []};
+get_step_range(Steps, StepNumber, _RangeStart, RangeEnd)
+		when StepNumber - length(Steps) + 1 > RangeEnd ->
+	{0, []};
+get_step_range(Steps, StepNumber, RangeStart, RangeEnd) ->
+	%% Clip RangeStart to the earliest step number in Steps
+	RangeStart2 = max(RangeStart, StepNumber - length(Steps) + 1),
+	RangeSteps = 
+		case StepNumber > RangeEnd of
+			true ->
+				%% Exclude steps beyond the end of the session
+				lists:nthtail(StepNumber - RangeEnd, Steps);
+			false ->
+				Steps
+		end,
+	%% The highest step number in the range
+	RangeEnd2 = min(StepNumber, RangeEnd),
+	%% Exclude the steps before the start of the session
+	RangeSteps2 = lists:sublist(RangeSteps, RangeEnd2 - RangeStart2 + 1),
+	{RangeEnd2, RangeSteps2}.
 
 %% @doc Update the VDF session cache based on new info from a validated block.
 cache_block_session(State, SessionKey, PrevSessionKey, CurrentSessionKey, 
@@ -1107,22 +1139,11 @@ cache_block_session(State, SessionKey, PrevSessionKey, CurrentSessionKey,
 	Session =
 		case maps:get(SessionKey, SessionByKey, not_found) of
 			not_found ->
-				#vdf_session{ steps = PrevSteps, step_number = PrevStepNumber } = PrevSession,
 				{_, Interval} = SessionKey,
-				SessionStart = Interval * ?NONCE_LIMITER_RESET_FREQUENCY,
-				SessionEnd = (Interval + 1) * ?NONCE_LIMITER_RESET_FREQUENCY - 1,
-				Steps =
-					case PrevStepNumber > SessionEnd of
-						true ->
-							lists:nthtail(PrevStepNumber - SessionEnd, PrevSteps);
-						false ->
-							PrevSteps
-					end,
-				StepNumber = min(PrevStepNumber, SessionEnd),
-				Steps2 = lists:sublist(Steps, StepNumber - SessionStart + 1),
+				{StepNumber, Steps} = get_step_range(PrevSession, Interval),
 				#vdf_session{ step_number = StepNumber, seed = Seed,
 						step_checkpoints_map = StepCheckpointsMap,
-						steps = Steps2, upper_bound = UpperBound,
+						steps = Steps, upper_bound = UpperBound,
 						next_upper_bound = NextUpperBound, prev_session_key = PrevSessionKey,
 						vdf_difficulty = VDFDifficulty,
 						next_vdf_difficulty = NextVDFDifficulty };
@@ -1137,7 +1158,7 @@ cache_session(State, SessionKey, CurrentSessionKey, Session) ->
 	{NextSeed, Interval} = SessionKey,
 	may_be_set_vdf_step_metric(SessionKey, CurrentSessionKey, Session#vdf_session.step_number),
 	SessionByKey2 = maps:put(SessionKey, Session, SessionByKey),
-	%% If Session exists, then {Inerval, NextSeed} will already exist in the Sessions set and
+	%% If Session exists, then {Interval, NextSeed} will already exist in the Sessions set and
 	%% gb_sets:add_element will not cause a change.
 	Sessions2 = gb_sets:add_element({Interval, NextSeed}, Sessions),
 	State#state{ current_session_key = CurrentSessionKey, sessions = Sessions2,
@@ -1390,6 +1411,86 @@ test_reorg_after_join2() ->
 	ar_test_node:connect_to_slave(),
 	ar_test_node:slave_mine(),
 	ar_test_node:wait_until_height(3).
+
+get_step_range_test() ->
+	?assertEqual(
+		{0, []},
+		get_step_range(lists:seq(9, 5, -1), 9, 0, 4),
+		"Disjoint range A"
+	),
+	?assertEqual(
+		{0, []},
+		get_step_range(lists:seq(9, 5, -1), 9 , 10, 14),
+		"Disjoint range B"
+	),
+	?assertEqual(
+		{0, []},
+		get_step_range([], 9, 0, 4),
+		"Empty steps"
+	),
+	?assertEqual(
+		{0, []},
+		get_step_range(lists:seq(9, 5, -1), 9, 9, 5),
+		"Invalid range"
+	),
+	?assertEqual(
+		{9, [9, 8, 7, 6, 5]},
+		get_step_range(lists:seq(9, 5, -1), 9, 5, 9),
+		"Full intersection"
+	),
+	?assertEqual(
+		{9, [9, 8, 7, 6, 5]},
+		get_step_range(lists:seq(9, 5, -1), 9, 3, 9),
+		"Clipped RangeStart"
+	),
+	?assertEqual(
+		{9, [9, 8, 7, 6]},
+		get_step_range(lists:seq(9, 5, -1), 9, 6, 12),
+		"Clipped RangeEnd"
+	),
+	?assertEqual(
+		{8, [8, 7]},
+		get_step_range(lists:seq(20, 5, -1), 20, 7, 8),
+		"Clipped Steps above"
+	),
+	?assertEqual(
+		{9, [9, 8, 7, 6, 5]},
+		get_step_range(lists:seq(9, 0, -1), 9, 5, 9),
+		"Clipped Steps below"
+	),
+	?assertEqual(
+		{6, [6]},
+		get_step_range(lists:seq(9, 5, -1), 9, 6, 6),
+		"Range length 1"
+	),
+	?assertEqual(
+		{8, [8]},
+		get_step_range([8], 8, 8, 8),
+		"Steps length 1"
+	),
+	?assertEqual(
+		{9, [9, 8, 7, 6, 5]},
+		get_step_range(
+			#vdf_session{ steps = lists:seq(12, 0, -1), step_number = 12}, 1),
+		"Session and Interval"
+	),
+	?assertEqual(
+		{0, []},
+		get_step_range(not_found, 1),
+		"not_found and Interval"
+	),
+	?assertEqual(
+		{9, [9, 8, 7]},
+		get_step_range(
+			#vdf_session{ steps = lists:seq(12, 0, -1), step_number = 12}, 7, 9),
+		"Session and Range"
+	),
+	?assertEqual(
+		{0, []},
+		get_step_range(not_found, 7, 9),
+		"not_found and Range"
+	),
+	ok.
 
 assert_session(B, PrevB) ->
 	%% vdf_diffic ulty and next_vdf_difficulty in cached VDF sessions should be

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -380,9 +380,9 @@ external_update_test_() ->
 			{timeout, 120, fun test_session_overlap/0},
 			{timeout, 120, fun test_client_ahead/0},
 			{timeout, 120, fun test_skip_ahead/0},
-			{timeout, 120, fun test_2_servers_switching/0}
-			% {timeout, 120, fun test_backtrack/0},
-			% {timeout, 120, fun test_2_servers_backtrack/0}
+			{timeout, 120, fun test_2_servers_switching/0},
+			{timeout, 120, fun test_backtrack/0},
+			{timeout, 120, fun test_2_servers_backtrack/0}
 		]
     }.
 
@@ -497,7 +497,7 @@ test_session_overlap() ->
 		ok,
 		apply_external_update(<<"session2">>, 2, [11, 10], 12, false, <<"session1">>, 1),
 		"Full session2, some steps already seen"),
-	timer:sleep(5000),
+	timer:sleep(2000),
 	?assertEqual(
 		[<<"8">>, <<"7">>, <<"6">>, <<"5">>, <<"9">>, <<"10">>, <<"11">>, <<"12">>],
 		computed_steps()).
@@ -516,7 +516,7 @@ test_client_ahead() ->
 		#nonce_limiter_update_response{ step_number = 8 },
 		apply_external_update(<<"session1">>, 1, [6, 5], 7, false, <<"session0">>, 0),
 		"Full session, client ahead"),
-	timer:sleep(5000),
+	timer:sleep(2000),
 	?assertEqual(
 		[<<"8">>, <<"7">>, <<"6">>, <<"5">>],
 		computed_steps()).
@@ -554,7 +554,7 @@ test_skip_ahead() ->
 		ok,
 		apply_external_update(<<"session2">>, 2, [11, 10], 12, false, <<"session1">>, 1),
 		"Full session2, some steps already seen"),
-	timer:sleep(5000),
+	timer:sleep(2000),
 	?assertEqual(
 		[<<"6">>, <<"5">>, <<"8">>, <<"7">>, <<"9">>, <<"12">>, <<"11">>, <<"10">>],
 		computed_steps()).
@@ -597,7 +597,7 @@ test_2_servers_switching() ->
 		ok,
 		apply_external_update(<<"session2">>, 2, [], 14, true, <<"session1">>, 1, vdf_server_2()),
 		"Partial (new) session2 from vdf_server_2"),
-	timer:sleep(5000),
+	timer:sleep(2000),
 	?assertEqual([
 		<<"7">>, <<"6">>, <<"5">>, <<"8">>, <<"9">>,
 		<<"11">>, <<"10">>, <<"12">>, <<"13">>, <<"14">>
@@ -621,14 +621,21 @@ test_backtrack() ->
 		apply_external_update(<<"session2">>, 2, [], 15, true, <<"session1">>, 1),
 		"Partial session2"),
 	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 18 },
+		apply_external_update(
+			<<"session1">>, 1, [8, 7, 6, 5], 9, false, <<"session0">>, 0),
+		"Backtrack. Send full session1."),
+	?assertEqual(
 		ok,
 		apply_external_update(
 			<<"session2">>, 2, [14, 13, 12, 11, 10], 15, false, <<"session1">>, 1),
-		"Backtrack in session2"),
-	timer:sleep(5000),
-	?assertEqual(
-		[<<"TBD">>],
-		computed_steps()).
+		"Backtrack. Send full session2"),
+	timer:sleep(2000),
+	?assertEqual([
+		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
+        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
+        <<"5">>,<<"18">>,<<"15">>
+	], computed_steps()).
 
 test_2_servers_backtrack() ->
 	?assertEqual(
@@ -652,7 +659,9 @@ test_2_servers_backtrack() ->
 		apply_external_update(
 			<<"session2">>, 2, [14, 13, 12, 11, 10], 15, false, <<"session1">>, 1, vdf_server_2()),
 		"Backtrack in session2 from vdf_server_2"),
-	timer:sleep(5000),
-	?assertEqual(
-		[<<"TBD">>],
-		computed_steps()).
+	timer:sleep(2000),
+	?assertEqual([
+		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
+        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
+        <<"5">>,<<"18">>,<<"15">>
+	], computed_steps()).

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -379,9 +379,18 @@ external_update_test_() ->
 		[
 			{timeout, 120, fun test_session_overlap/0},
 			{timeout, 120, fun test_client_ahead/0},
-			{timeout, 120, fun test_skip_ahead/0}
+			{timeout, 120, fun test_skip_ahead/0},
+			{timeout, 120, fun test_2_servers_switching/0}
+			% {timeout, 120, fun test_backtrack/0},
+			% {timeout, 120, fun test_2_servers_backtrack/0}
 		]
     }.
+
+vdf_server_1() ->
+	{127,0,0,1,2001}.
+
+vdf_server_2() ->
+	{127,0,0,1,2002}.
 
 setup_external_update() ->
 	{ok, Config} = application:get_env(arweave, config),
@@ -391,7 +400,9 @@ setup_external_update() ->
 	%% auto-computed VDF steps getting in the way.
 	ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
-		Config#config{ nonce_limiter_server_trusted_peers = [ ar_util:format_peer(slave_peer()) ]}),
+		Config#config{ nonce_limiter_server_trusted_peers = [ 
+			ar_util:format_peer(vdf_server_1()),
+			ar_util:format_peer(vdf_server_2()) ]}),
 	ets:new(?MODULE, [named_table, ordered_set, public]),
 	Pid = spawn(
 		fun() ->
@@ -422,14 +433,14 @@ computed_output() ->
 
 apply_external_update(Seed, Interval, ExistingSteps, StepNumber, IsPartial,
 		PrevSeed, PrevInterval) ->
-	apply_external_update(Seed, Interval, ExistingSteps, StepNumber, StepNumber, IsPartial,
-		PrevSeed, PrevInterval).
-apply_external_update(Seed, Interval, ExistingSteps, StepNumber, Output, IsPartial,
-		PrevSeed, PrevInterval) ->
+	apply_external_update(Seed, Interval, ExistingSteps, StepNumber, IsPartial,
+		PrevSeed, PrevInterval, vdf_server_1()).
+apply_external_update(Seed, Interval, ExistingSteps, StepNumber, IsPartial,
+		PrevSeed, PrevInterval, Peer) ->
 	PrevSessionKey = {PrevSeed, PrevInterval},
 
 	SessionKey = {Seed, Interval},
-	Steps = [list_to_binary(integer_to_list(Step)) || Step <- [Output | ExistingSteps]],
+	Steps = [list_to_binary(integer_to_list(Step)) || Step <- [StepNumber | ExistingSteps]],
 	Session = #vdf_session{
 		upper_bound = 0,
 		prev_session_key = PrevSessionKey,
@@ -444,7 +455,7 @@ apply_external_update(Seed, Interval, ExistingSteps, StepNumber, Output, IsParti
 		checkpoints = [],
 		session = Session
 	},
-	ar_nonce_limiter:apply_external_update(Update, slave_peer()).
+	ar_nonce_limiter:apply_external_update(Update, Peer).
 
 %% @doc The VDF session key is only updated when a block is procesed by the VDF server. Until that
 %% happens the serve will push all VDF steps under the same session key - even if those steps
@@ -546,4 +557,102 @@ test_skip_ahead() ->
 	timer:sleep(5000),
 	?assertEqual(
 		[<<"6">>, <<"5">>, <<"8">>, <<"7">>, <<"9">>, <<"12">>, <<"11">>, <<"10">>],
+		computed_steps()).
+
+test_2_servers_switching() ->
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [6, 5], 7, false, <<"session0">>, 0, vdf_server_1()),
+		"Full session1 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [], 8, true, <<"session0">>, 0, vdf_server_2()),
+		"Partial session1 from vdf_server_2"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [], 9, true, <<"session0">>, 0, vdf_server_2()),
+		"Partial session1 from vdf_server_2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(<<"session2">>, 2, [], 11, true, <<"session1">>, 1, vdf_server_1()),
+		"Full session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session2">>, 2, [10], 11, false, <<"session1">>, 1, vdf_server_1()),
+		"Full session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			<<"session2">>, 2, [11, 10], 12, false, <<"session1">>, 1, vdf_server_2()),
+		"Full session2 from vdf_server_2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 12 },
+		apply_external_update(<<"session2">>, 2, [], 12, true, <<"session1">>, 1, vdf_server_1()),
+		"Partial (repeat) session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session2">>, 2, [], 13, true, <<"session1">>, 1, vdf_server_1()),
+		"Partial (new) session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session2">>, 2, [], 14, true, <<"session1">>, 1, vdf_server_2()),
+		"Partial (new) session2 from vdf_server_2"),
+	timer:sleep(5000),
+	?assertEqual([
+		<<"7">>, <<"6">>, <<"5">>, <<"8">>, <<"9">>,
+		<<"11">>, <<"10">>, <<"12">>, <<"13">>, <<"14">>
+	], computed_steps()).
+
+test_backtrack() ->
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [
+			16, 15,				%% interval 3
+			14, 13, 12, 11, 10, %% interval 2
+			9, 8, 7, 6, 5		%% interval 1
+		], 17, false, <<"session0">>, 0),
+		"Full session1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [], 18, true, <<"session0">>, 0),
+		"Partial session1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(<<"session2">>, 2, [], 15, true, <<"session1">>, 1),
+		"Partial session2"),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			<<"session2">>, 2, [14, 13, 12, 11, 10], 15, false, <<"session1">>, 1),
+		"Backtrack in session2"),
+	timer:sleep(5000),
+	?assertEqual(
+		[<<"TBD">>],
+		computed_steps()).
+
+test_2_servers_backtrack() ->
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [
+			16, 15,				%% interval 3
+			14, 13, 12, 11, 10, %% interval 2
+			9, 8, 7, 6, 5		%% interval 1
+		], 17, false, <<"session0">>, 0, vdf_server_1()),
+		"Full session1 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(<<"session1">>, 1, [], 18, true, <<"session0">>, 0, vdf_server_1()),
+		"Partial session1 from vdf_server_1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(<<"session2">>, 2, [], 15, true, <<"session1">>, 1, vdf_server_2()),
+		"Partial session2 from vdf_server_2"),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			<<"session2">>, 2, [14, 13, 12, 11, 10], 15, false, <<"session1">>, 1, vdf_server_2()),
+		"Backtrack in session2 from vdf_server_2"),
+	timer:sleep(5000),
+	?assertEqual(
+		[<<"TBD">>],
 		computed_steps()).


### PR DESCRIPTION
1. Process all VDF server updates - even multiple updates from different vdf servers arriving at close to the same time. This addresses a performance issue when a client used to sometimes get "stuck to" a slow VDF server
2. Avoid a crash that cold occur when a VDF server got 2 session ahead of the last Block session