### PR TITLE
Jp/20231031 mining stats

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
             ar_kv,
             ar_merkle,
             ar_mining_server,
+            ar_mining_stats,
             ar_node,
             ar_node_utils,
             ar_nonce_limiter,

--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -98,6 +98,10 @@
 %% Winstons per AR.
 -define(WINSTON_PER_AR, 1000000000000).
 
+%% The number of bytes in a gibibyte.
+-define(GiB, (1024 * 1024 * 1024)).
+-define(TiB, (1024 * ?GiB)).
+
 %% How far into the past or future the block can be in order to be accepted for
 %% processing. The maximum lag when fork recovery (chain reorganisation) is performed.
 -ifdef(DEBUG).

--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -108,7 +108,6 @@
 -endif.
 
 -define(DEFAULT_CM_POLL_INTERVAL, 60000).
--define(DEFAULT_CM_STAT_INTERVAL, 60000).
 
 %% @doc Startup options with default values.
 -record(config, {
@@ -200,8 +199,7 @@
 	cm_api_secret = not_set,
 	cm_exit_peer = not_set,
 	cm_peers = [],
-	cm_poll_interval = ?DEFAULT_CM_POLL_INTERVAL,
-	cm_stat_interval = ?DEFAULT_CM_STAT_INTERVAL
+	cm_poll_interval = ?DEFAULT_CM_POLL_INTERVAL
 }).
 
 -endif.

--- a/apps/arweave/include/ar_pricing.hrl
+++ b/apps/arweave/include/ar_pricing.hrl
@@ -1,8 +1,5 @@
 %% @doc Pricing macros.
 
-%% The number of bytes in a gibibyte.
--define(GiB, (1024 * 1024 * 1024)).
-
 %% For a new account, we charge the fee equal to the price of uploading
 %% this number of bytes. The fee is about 0.1$ at the time.
 -define(NEW_ACCOUNT_FEE_DATA_SIZE_EQUIVALENT, 20_000_000).

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -261,9 +261,6 @@ show_help() ->
 			{"cm_poll_interval", io_lib:format("The frequency in milliseconds of asking the "
 					"other nodes in the coordinated mining setup about their partition "
 					"tables. Default is ~B.", [?DEFAULT_CM_POLL_INTERVAL])},
-			{"cm_stat_interval", io_lib:format("The frequency in milliseconds of printing the "
-					"coordinated mining statistics. Default is ~B.",
-					[?DEFAULT_CM_STAT_INTERVAL])},
 			{"cm_peer (IP:port)", "The peer(s) to mine in coordination with. You need to also "
 					"set coordinated_mining, cm_api_secret, and cm_exit_peer."},
 			{"cm_exit_peer (IP:port)", "The peer to send mining solutions to in the "
@@ -512,8 +509,6 @@ parse_cli_args(["cm_api_secret", _ | _], _) ->
 	erlang:halt();
 parse_cli_args(["cm_poll_interval", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config{ cm_poll_interval = list_to_integer(Num) });
-parse_cli_args(["cm_stat_interval", Num | Rest], C) ->
-	parse_cli_args(Rest, C#config{ cm_stat_interval = list_to_integer(Num) });
 parse_cli_args(["cm_peer", Peer | Rest], C = #config{ cm_peers = Ps }) ->
 	case ar_util:safe_parse_peer(Peer) of
 		{ok, ValidPeer} ->

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -544,11 +544,6 @@ parse_options([{<<"cm_poll_interval">>, CMPollInterval} | Rest], Config) when is
 parse_options([{<<"cm_poll_interval">>, CMPollInterval} | _], _) ->
 	{error, {bad_type, cm_poll_interval, number}, CMPollInterval};
 
-parse_options([{<<"cm_stat_interval">>, CMStatInterval} | Rest], Config) when is_integer(CMStatInterval) ->
-	parse_options(Rest, Config#config{ cm_stat_interval = CMStatInterval });
-parse_options([{<<"cm_stat_interval">>, CMStatInterval} | _], _) ->
-	{error, {bad_type, cm_stat_interval, number}, CMStatInterval};
-
 parse_options([{<<"cm_peers">>, Peers} | Rest], Config) when is_list(Peers) ->
 	case parse_peers(Peers, []) of
 		{ok, ParsedPeers} ->

--- a/apps/arweave/src/ar_coordination.erl
+++ b/apps/arweave/src/ar_coordination.erl
@@ -81,7 +81,7 @@ init([]) ->
 	process_flag(trap_exit, true),
 	{ok, Config} = application:get_env(arweave, config),
 	
-	%% using timer:apply_after so we can cacncel pending timers. This allows us to send the
+	%% using timer:apply_after so we can cancel pending timers. This allows us to send the
 	%% h1 batch as soon as it's full instead of waiting for the timeout to expire.
 	{ok, H1BatchTimerRef} = timer:apply_after(?BATCH_TIMEOUT_MS, ?MODULE, send_h1_batch_to_peer, []),
 	State = #state{

--- a/apps/arweave/src/ar_global_sync_record.erl
+++ b/apps/arweave/src/ar_global_sync_record.erl
@@ -118,7 +118,7 @@ handle_cast(update_serialized_sync_buckets, State) ->
 
 handle_cast(record_v2_index_data_size_metric, State) ->
 	#state{ sync_record = SyncRecord } = State,
-	prometheus_gauge:set(v2_index_data_size, ar_intervals:sum(SyncRecord)),
+	ar_mining_stats:set_total_data_size(ar_intervals:sum(SyncRecord)),
 	ar_util:cast_after(?UPDATE_SIZE_METRIC_FREQUENCY_MS, ?MODULE,
 			record_v2_index_data_size_metric),
 	{noreply, State};

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -3032,7 +3032,7 @@ handle_mining_h1(Req, Pid) ->
 			case ar_serialize:json_decode(Body, [{return_maps, true}]) of
 				{ok, JSON} ->
 					{Candidate, H1List} = ar_serialize:json_struct_to_h2_inputs(JSON),
-					ar_coordination:compute_h2(Peer, Candidate, H1List),
+					ar_coordination:compute_h2_for_peer(Peer, Candidate, H1List),
 					{200, #{}, <<>>, Req};
 				{error, _} ->
 					{400, #{}, jiffy:encode(#{ error => invalid_json }), Req2}
@@ -3049,7 +3049,7 @@ handle_mining_h2(Req, Pid) ->
 				{ok, JSON} ->
 					Candidate = ar_serialize:json_struct_to_candidate(JSON),
 					?LOG_INFO([{event, h2_received}, {peer, ar_util:format_peer(Peer)}]),
-					ar_coordination:post_solution(Candidate),
+					ar_coordination:post_solution(Peer, Candidate),
 					{200, #{}, <<>>, Req};
 				{error, _} ->
 					{400, #{}, jiffy:encode(#{ error => invalid_json }), Req2}

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -3011,7 +3011,7 @@ format_partition_table() ->
 
 format_partition_table([], UniquePartitions) ->
 	lists:sort(sets:to_list(UniquePartitions));
-format_partition_table([{PartitionId, MiningAddress, _StoreID} | Partitions], UniquePartitions) ->
+format_partition_table([{PartitionId, MiningAddress} | Partitions], UniquePartitions) ->
 	format_partition_table(
 		Partitions,
 		sets:add_element(

--- a/apps/arweave/src/ar_metrics.erl
+++ b/apps/arweave/src/ar_metrics.erl
@@ -153,9 +153,10 @@ register(MetricsDir) ->
 	]),
 	prometheus_gauge:new([
 		{name, v2_index_data_size_by_packing},
-		{labels, [store_id, packing, partition_size, partition_index]},
-		{help, "The size (in bytes) of the data stored and indexed. Groupped by the "
-				"store ID, packing, partition size, and partition index."}
+		{labels, [store_id, packing, partition_number, storage_module_size, storage_module_index]},
+		{help, "The size (in bytes) of the data stored and indexed. Grouped by the "
+				"store ID, packing, partition number, storage module size, "
+				"and storage module index."}
 	]),
 
 	%% Disk pool.

--- a/apps/arweave/src/ar_metrics.erl
+++ b/apps/arweave/src/ar_metrics.erl
@@ -241,9 +241,34 @@ register(MetricsDir) ->
 		}
 	]),
 	prometheus_gauge:new([
-		{name, mining_rate},
-		{help, "The number of solution candidates processed per second."}
+		{name, mining_read_rate},
+		{labels, [partition]},
+		{help, "The number of chunks read per second. Each chunk is 256KiB. The partition label "
+				"breaks the mining rate down by partition. The overall mining rate is inidcated by "
+				"'total'."}
 	]),
+	prometheus_gauge:new([
+		{name, mining_hash_rate},
+		{labels, [partition]},
+		{help, "The number of solutions candidates generated per second. The partition label "
+				"breaks the mining rate down by partition. The overall mining rate is inidcated by "
+				"'total'."}
+	]),
+	prometheus_gauge:new([
+		{name, cm_h1_rate},
+		{labels, [peer, direction]},
+		{help, "The number of H1 hashes exchanged with a coordinated mining peer per second. "
+				"The peer label indicates the peer that the value is exchanged with, and the "
+				"direction label can be 'to' or 'from'."}
+	]),
+	prometheus_gauge:new([
+		{name, cm_h2_count},
+		{labels, [peer, direction]},
+		{help, "The total number of H2 hashes exchanged with a coordinated mining peer. "
+				"The peer label indicates the peer that the value is exchanged with, and the "
+				"direction label can be 'to' or 'from'."}
+	]),
+
 	prometheus_gauge:new([
 		{name, mining_server_chunk_cache_size},
 		{help, "The number of chunks fetched during mining and not processed yet."}

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -82,15 +82,15 @@ handle_call(get_partitions, _From,
 	Max = ?MAX_PARTITION_NUMBER(PartitionUpperBound),
 	Partitions = lists:sort(sets:to_list(
 		maps:fold(
-			fun({Partition, MiningAddress, StoreID}, _, Acc) ->
+			fun({Partition, MiningAddress, _StoreID}, _, Acc) ->
 				case Partition > Max of
 					true ->
 						Acc;
 					_ ->
-						sets:add_element({Partition, MiningAddress, StoreID}, Acc)
+						sets:add_element({Partition, MiningAddress}, Acc)
 				end
 			end,
-			sets:new(), % A storage module may be smaller than a partition.
+			sets:new(), %% Ensure only one entry per partition (i.e. collapse storage modules)
 			IOThreads
 		))
 	),

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -135,7 +135,7 @@ handle_call(Request, _From, State) ->
 
 handle_cast(pause, State) ->
 	#state{ session = Session } = State,
-	prometheus_gauge:set(mining_rate, 0),
+	ar_mining_stats:mining_paused(),
 	%% Setting paused to true allows all pending tasks to complete, but prevents new output to be 
 	%% distributed. Setting diff to infnity ensures that no solutions are found.
 	{noreply, State#state{ diff = infinity, session = Session#mining_session{ paused = true } }};

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -2,8 +2,11 @@
 
 -behaviour(gen_server).
 
--export([start_link/0, pause_performance_reports/1, increment_partition_stats/1,
-		 increment_vdf_stats/0, reset_all_stats/0]).
+-export([start_link/0, pause_performance_reports/1,
+		set_total_data_size/1, set_storage_module_data_size/6,
+		vdf_computed/0, chunk_read/1, hash_computed/1,
+		h1_sent_to_peer/2, h1_received_from_peer/2, h2_sent_to_peer/1, h2_received_from_peer/1,
+		reset_all_stats/0]).
 
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
@@ -17,6 +20,54 @@
 	pause_performance_reports	= false,
 	pause_performance_reports_timeout
 }).
+
+-record(report, {
+	now,
+	vdf_speed,
+	total_data_size,
+	max_weave_read_mibps,
+	average_read_mibps,
+	current_read_mibps,
+	average_hash_hps,
+	current_hash_hps,
+	
+	partitions = #{},
+	peers = #{}
+}).
+
+-record(partition_report, {
+	data_size,
+	average_read_mibps,
+	current_read_mibps,
+	average_hash_hps,
+	current_hash_hps,
+	optimal_read_mibps
+}).
+
+-record(peer_report, {
+	average_h1_to_peer_hps,
+	current_h1_to_peer_hps,
+	average_h1_from_peer_hps,
+	current_h1_from_peer_hps,
+	total_h2_to_peer,
+	total_h2_from_peer
+}).
+
+%% ETS table structure:
+%%
+%% {vdf, 													StartTime, VDFStepCount}
+%% {{partition, PartitionNumber, read, total}, 				StartTime, TotalChunksRead}
+%% {{partition, PartitionNumber, read, current}, 			StartTime, CurrentChunksRead}
+%% {{partition, PartitionNumber, hash, total}, 				StartTime, TotalHashes}
+%% {{partition, PartitionNumber, hash, current}, 			StartTime, CurrentHashes}
+%% {total_data_size, 										TotalBytesPacked}
+%% {{partition, PartitionNumber, storage_module, StoreID}, 	BytesPacked}
+%% {{peer, Peer, h1_to_peer, total}, 						StartTime, TotalH1sSentToPeer}
+%% {{peer, Peer, h1_to_peer, current}, 						StartTime, CurrentH1sSentToPeer}
+%% {{peer, Peer, h1_from_peer, total}, 						StartTime, TotalH1sReceivedFromPeer}
+%% {{peer, Peer, h1_from_peer, current}, 					StartTime, CurrentH1sReceivedFromPeer}
+%% {{peer, Peer, h2_to_peer, total}, 						StartTime, TotalH2sSentToPeer}
+%% {{peer, Peer, h2_from_peer, total}, 						StartTime, TotalH2sReceivedFromPeer}
 
 -define(PERFORMANCE_REPORT_FREQUENCY_MS, 10000).
 
@@ -32,56 +83,44 @@ start_link() ->
 pause_performance_reports(Time) ->
 	gen_server:cast(?MODULE, {pause_performance_reports, Time}).
 
-increment_vdf_stats() ->
-	ets:update_counter(?MODULE, vdf,
-		[{3, 1}], 								     %% increment vdf count by 1
-		{vdf, erlang:monotonic_time(millisecond), 0} %% initialize timestamp and count
-	).
+vdf_computed() ->
+	increment_count(vdf).
 
-reset_vdf_stats(Now) ->
-	ets:insert(?MODULE, [{vdf, Now, 0}]).
+chunk_read(PartitionNumber) ->
+	increment_count({partition, PartitionNumber, read, total}),
+	increment_count({partition, PartitionNumber, read, current}).
 
-get_vdf_stats() ->
-	ets:lookup(?MODULE, vdf).
+hash_computed(PartitionNumber) ->
+	increment_count({partition, PartitionNumber, hash, total}),
+	increment_count({partition, PartitionNumber, hash, current}).
 
-increment_partition_stats(PartitionNumber) ->
-	ets:update_counter(?MODULE, {partition, PartitionNumber},
-		[
-			{3, 1}, %% increment total count chunks read for partition PartitionNumber
-			{5, 1}  %% increment current count chunks read for partition PartitionNumber
-		],
-		{
-			{partition, PartitionNumber},
-			erlang:monotonic_time(millisecond), 1, %% initialize total count and timestamp
-			erlang:monotonic_time(millisecond), 1  %% initialize current count and timestamp
-		}).
+h1_sent_to_peer(Peer, H1Count) ->
+	increment_count({peer, Peer, h1_to_peer, total}, H1Count),
+	increment_count({peer, Peer, h1_to_peer, current}, H1Count).
 
-reset_current_partition_stats(PartitionNumber, Now) ->
-	ets:update_counter(?MODULE, {partition, PartitionNumber},
-		[
-			{4, -1, Now, Now}, %% atomically reset the current count timestamp to Now
-			{5, 0, -1, 0}      %% atomically reset the current count to 0
-		]).
+h1_received_from_peer(Peer, H1Count) ->
+	increment_count({peer, Peer, h1_from_peer, total}, H1Count),
+	increment_count({peer, Peer, h1_from_peer, current}, H1Count).
 
-reset_partition_stats(PartitionNumber, Now) ->
-	ets:insert(?MODULE, [{partition, PartitionNumber, Now, 0, Now, 0}]).
+h2_sent_to_peer(Peer) ->
+	increment_count({peer, Peer, h2_to_peer, total}).
 
-get_partition_stats(PartitionNumber) ->
-	ets:lookup(?MODULE, {partition, PartitionNumber}).
+h2_received_from_peer(Peer) ->
+	increment_count({peer, Peer, h2_from_peer, total}).
+
+set_total_data_size(DataSize) ->
+	prometheus_gauge:set(v2_index_data_size, DataSize),
+	ets:insert(?MODULE, {total_data_size, DataSize}).
+
+set_storage_module_data_size(
+		StoreID, Packing, PartitionNumber, StorageModuleSize, StorageModuleIndex, DataSize) ->
+	prometheus_gauge:set(v2_index_data_size_by_packing,
+		[StoreID, Packing, PartitionNumber, StorageModuleSize, StorageModuleIndex],
+		DataSize),
+	ets:insert(?MODULE, {{partition, PartitionNumber, storage_module, StoreID}, DataSize}).
 
 reset_all_stats() ->
-	Now = erlang:monotonic_time(millisecond),
-
-	%% Reset partition stats
-	PartitionNumbers = ets:match(?MODULE, {{partition, '$1'}, '_', '_', '_', '_'}),
-    lists:foreach(
-		fun([PartitionNumber]) ->
-            reset_partition_stats(PartitionNumber, Now)
-        end,
-		PartitionNumbers),
-
-	%% Reset vdf stats
-	reset_vdf_stats(Now).
+	ets:delete_all_objects(?MODULE).
 
 %%%===================================================================
 %%% Generic server callbacks.
@@ -108,7 +147,7 @@ handle_cast(report_performance, #state{ pause_performance_reports = true,
 			{noreply, State}
 	end;
 handle_cast(report_performance, State) ->
-	report_performance(ar_mining_io:get_partitions()),
+	report_performance(),
 	ar_util:cast_after(?PERFORMANCE_REPORT_FREQUENCY_MS, ?MODULE, report_performance),
 	{noreply, State};
 
@@ -133,98 +172,425 @@ terminate(_Reason, _State) ->
 %%% Private functions.
 %%%===================================================================
 
-report_performance([]) ->
-	ok;
-report_performance(Partitions) ->
-	Now = erlang:monotonic_time(millisecond),
-	VdfSpeed = vdf_speed(Now),
-	{IOList, MaxPartitionTime, PartitionsSum, MaxCurrentTime, CurrentsSum} =
-		lists:foldr(
-			fun({Partition, _ReplicaID, StoreID}, {Acc1, Acc2, Acc3, Acc4, Acc5} = Acc) ->
-				case get_partition_stats(Partition) of
-					[] ->
-						Acc;
-					[{_, PartitionStart, _, CurrentStart, _}]
-							when Now - PartitionStart =:= 0
-								orelse Now - CurrentStart =:= 0 ->
-						Acc;
-					[{_, PartitionStart, PartitionTotal, CurrentStart, CurrentTotal}] ->
-						reset_current_partition_stats(Partition, Now),
-						PartitionTimeLapse = (Now - PartitionStart) / 1000,
-						PartitionAvg = PartitionTotal / PartitionTimeLapse / 4,
-						CurrentTimeLapse = (Now - CurrentStart) / 1000,
-						CurrentAvg = CurrentTotal / CurrentTimeLapse / 4,
-						Optimal = optimal_performance(StoreID, VdfSpeed),
-						?LOG_INFO([{event, mining_partition_performance_report},
-								{partition, Partition}, {avg, PartitionAvg},
-								{current, CurrentAvg}]),
-						case Optimal of
-							undefined ->
-								{[io_lib:format("Partition ~B avg: ~.2f MiB/s, "
-										"current: ~.2f MiB/s.~n",
-									[Partition, PartitionAvg, CurrentAvg]) | Acc1],
-									max(Acc2, PartitionTimeLapse), Acc3 + PartitionTotal,
-									max(Acc4, CurrentTimeLapse), Acc5 + CurrentTotal};
-							_ ->
-								{[io_lib:format("Partition ~B avg: ~.2f MiB/s, "
-										"current: ~.2f MiB/s, "
-										"optimum: ~.2f MiB/s, ~.2f MiB/s (full weave).~n",
-									[Partition, PartitionAvg, CurrentAvg, Optimal / 2,
-											Optimal]) | Acc1],
-									max(Acc2, PartitionTimeLapse), Acc3 + PartitionTotal,
-									max(Acc4, CurrentTimeLapse), Acc5 + CurrentTotal}
-						end
-				end
-			end,
-			{[], 0, 0, 0, 0},
-			Partitions
-		),
-	case MaxPartitionTime > 0 of
-		true ->
-			TotalAvg = PartitionsSum / MaxPartitionTime / 4,
-			TotalCurrent = CurrentsSum / MaxCurrentTime / 4,
-			?LOG_INFO([{event, mining_performance_report}, {total_avg_mibps, TotalAvg},
-					{total_avg_hps, TotalAvg * 4}, {total_current_mibps, TotalCurrent},
-					{total_current_hps, TotalCurrent * 4}]),
-			Str =
-				case VdfSpeed of
-					undefined ->
-						io_lib:format("~nMining performance report:~nTotal avg: ~.2f MiB/s, "
-								" ~.2f h/s; current: ~.2f MiB/s, ~.2f h/s.~n",
-						[TotalAvg, TotalAvg * 4, TotalCurrent, TotalCurrent * 4]);
-					_ ->
-						io_lib:format("~nMining performance report:~nTotal avg: ~.2f MiB/s, "
-								" ~.2f h/s; current: ~.2f MiB/s, ~.2f h/s; VDF: ~.2f s.~n",
-						[TotalAvg, TotalAvg * 4, TotalCurrent, TotalCurrent * 4, VdfSpeed])
-				end,
-			prometheus_gauge:set(mining_rate, TotalCurrent * 4),
-			IOList2 = [Str | [IOList | ["~n"]]],
-			ar:console(iolist_to_binary(IOList2));
-		false ->
-			ok
-	end.
-optimal_performance(_StoreID, undefined) ->
-	undefined;
-optimal_performance("default", _VdfSpeed) ->
-	undefined;
-optimal_performance(StoreID, VdfSpeed) ->
-	{PartitionSize, PartitionIndex, _Packing} = ar_storage_module:get_by_id(StoreID),
-	case prometheus_gauge:value(v2_index_data_size_by_packing, [StoreID, spora_2_6,
-			PartitionSize, PartitionIndex]) of
-		undefined -> 0.0;
-		StorageSize -> (200 / VdfSpeed) * (StorageSize / PartitionSize)
+%% @doc Atomically increments the count for ETS records stored in the format:
+%% {Key, StartTimestamp, Count}
+%% If the Key doesn't exist, it is initialized with the current timestamp and a count of Amount
+increment_count(Key) ->
+	increment_count(Key, 1).
+increment_count(Key, Amount) ->
+	ets:update_counter(?MODULE, Key,
+		[{3, Amount}], 									%% increment count by Amount
+		{Key, erlang:monotonic_time(millisecond), 0} 	%% initialize timestamp and count
+	).
+
+reset_count(Key, Now) ->
+	ets:insert(?MODULE, [{Key, Now, 0}]).
+
+get_average(Key, Now) ->
+	case ets:lookup(?MODULE, Key) of 
+		[] ->
+			0.0;
+		[{_, Start, _Count}] when Now - Start =:= 0 ->
+			0.0;
+		[{_, Start, Count}] ->
+			Elapsed = (Now - Start) / 1000,
+			Count / Elapsed
 	end.
 
-vdf_speed(Now) ->
-	case get_vdf_stats() of
+get_count(Key) ->
+	case ets:lookup(?MODULE, Key) of 
+		[] ->
+			0;
+		[{_, _Start, Count}] ->
+			Count
+	end.
+
+get_start(Key) ->
+	case ets:lookup(?MODULE, Key) of 
 		[] ->
 			undefined;
-		[{_, Now, _}] ->
-			undefined;
-		[{_, _Now, 0}] ->
-			undefined;
-		[{_, VdfStart, VdfCount}] ->
-			reset_vdf_stats(Now),
-			VdfLapse = (Now - VdfStart) / 1000,
-			VdfLapse / VdfCount
+		[{_, Start, _Count}] ->
+			Start
 	end.
+
+get_total_data_size() ->
+	case ets:lookup(?MODULE, total_data_size) of 
+		[] ->
+			0;
+		[{_, TotalDataSize}] ->
+			TotalDataSize
+	end.
+
+get_overall_average(ReadHash, TotalCurrent, Now) ->
+	Pattern = {{partition, '_', ReadHash, TotalCurrent}, '$1', '$2'},
+    Matches = ets:match(?MODULE, Pattern),
+    Starts = [Start || [Start, _] <- Matches],
+	Counts = [Count || [_, Count] <- Matches],
+
+	case Starts of
+		[] ->
+			0.0;
+		_ ->
+			TotalCount = lists:sum(Counts),
+			MinStart = lists:min(Starts),
+
+			case Now > MinStart of
+				true ->
+					Elapsed = (Now - MinStart) / 1000,
+					TotalCount / Elapsed;
+				false ->
+					0.0
+			end
+	end.
+
+get_partition_data_size(PartitionNumber) ->
+    Pattern = {{partition, PartitionNumber, storage_module, '_'}, '$1'},
+	Sizes = [Size || [Size] <- ets:match(?MODULE, Pattern)],
+    lists:sum(Sizes).
+
+%% @doc caculate the maximum hash rate (in MiB per second read from disk) for the given VDF speed
+%% at the current weave size.
+max_weave_read_mibps(VDFSpeed) ->
+	NumPartitions = ?MAX_PARTITION_NUMBER(ar_node:get_weave_size()) + 1,
+	NumPartitions * (200.0 / VDFSpeed).
+
+optimal_read_mibps(VDFSpeed, PartitionDataSize, TotalDataSize, WeaveSize) ->
+	(100.0 / VDFSpeed) * (PartitionDataSize / ?PARTITION_SIZE) * (1 + (TotalDataSize / WeaveSize)).
+
+generate_report() ->
+	generate_report(ar_mining_io:get_partitions(), erlang:monotonic_time(millisecond)).
+
+generate_report([], _Now) ->
+	ok;
+generate_report(Partitions, Now) ->
+	{ok, Config} = application:get_env(arweave, config),
+	VDFSpeed = vdf_speed(Now),
+	Report = #report{
+		now = Now,
+		vdf_speed = VDFSpeed,
+		total_data_size = get_total_data_size(),
+		max_weave_read_mibps = max_weave_read_mibps(VDFSpeed),
+		average_read_mibps = get_overall_average(read, total, Now) / 4,
+		current_read_mibps = get_overall_average(read, current, Now) / 4,
+		average_hash_hps = get_overall_average(hash, total, Now),
+		current_hash_hps = get_overall_average(hash, current, Now)
+	},
+
+	Report2 = generate_partition_reports(Partitions, Report),
+	Report3 = generate_peer_reports(Config#config.cm_peers, Report2),
+
+	ok.
+
+generate_partition_reports(Partitions, Report) ->
+	lists:foldr(
+		fun({PartitionNumber, _ReplicaID, _StoreID}, Acc) ->
+			generate_partition_report(PartitionNumber, Acc)
+		end,
+		Report,
+		Partitions
+	).
+
+generate_partition_report(PartitionNumber, Report) ->
+	#report{
+		now = Now,
+		vdf_speed = VDFSpeed,
+		total_data_size = TotalDataSize,
+		partitions = Partitions } = Report,
+	DataSize = get_partition_data_size(PartitionNumber),
+	PartitionReport = #partition_report{
+		data_size = DataSize,
+		average_read_mibps = get_average({partition, PartitionNumber, read, total}, Now) / 4,
+		current_read_mibps = get_average({partition, PartitionNumber, read, current}, Now) / 4,
+		average_hash_hps = get_average({partition, PartitionNumber, hash, total}, Now),
+		current_hash_hps = get_average({partition, PartitionNumber, hash, current}, Now),
+		optimal_read_mibps = optimal_read_mibps(
+			VDFSpeed, DataSize, TotalDataSize, ar_node:get_weave_size())
+	},
+
+	reset_count({partition, PartitionNumber, read, current}, Now),
+	reset_count({partition, PartitionNumber, hash, current}, Now),
+
+	Report#report{ partitions = maps:put(PartitionNumber, PartitionReport, Partitions) }.
+
+generate_peer_reports(Peers, Report) ->
+		lists:foldr(
+		fun(Peer, Acc) ->
+			generate_peer_report(Peer, Acc)
+		end,
+		Report,
+		Peers
+	).
+
+generate_peer_report(Peer, Report) ->
+	#report{
+		now = Now,
+		peers = Peers } = Report,
+	PeerReport = #peer_report{
+		average_h1_to_peer_hps = get_average({peer, Peer, h1_to_peer, total}, Now),
+		current_h1_to_peer_hps = get_average({peer, Peer, h1_to_peer, current}, Now),
+		average_h1_from_peer_hps = get_average({peer, Peer, h1_from_peer, total}, Now),
+		current_h1_from_peer_hps = get_average({peer, Peer, h1_from_peer, current}, Now),
+		total_h2_to_peer = get_count({peer, Peer, h2_to_peer, total}),
+		total_h2_from_peer = get_count({peer, Peer, h2_from_peer, total})
+	},
+
+	reset_count({peer, Peer, h1_to_peer, current}, Now),
+	reset_count({peer, Peer, h1_from_peer, current}, Now),
+
+	Report#report{ peers = maps:put(Peer, PeerReport, Peers) }.
+
+report_performance() ->
+	%% prometheus_gauge:set(mining_rate, TotalCurrent * 4),
+	ok.
+
+vdf_speed(Now) ->
+	case get_average(vdf, Now) of
+		0.0 ->
+			undefined;
+		VDFSpeed ->
+			reset_count(vdf, Now),
+			VDFSpeed
+	end.
+
+%%%===================================================================
+%%% Tests
+%%%===================================================================
+
+
+mining_stats_test_() ->
+	[
+		{timeout, 30, fun test_read_stats/0},
+		{timeout, 30, fun test_hash_stats/0},
+		{timeout, 30, fun test_vdf_stats/0},
+		{timeout, 30, fun test_data_size_stats/0},
+		{timeout, 30, fun test_h1_sent_to_peer_stats/0},
+		{timeout, 30, fun test_h1_received_from_peer_stats/0},
+		{timeout, 30, fun test_h2_peer_stats/0}
+	].
+
+test_read_stats() ->
+	test_local_stats(fun chunk_read/1, read).
+
+test_hash_stats() ->
+	test_local_stats(fun hash_computed/1, hash).
+
+test_local_stats(Fun, Stat) ->
+	ar_mining_stats:pause_performance_reports(120000),
+	ar_mining_stats:reset_all_stats(),
+	Fun(1),
+	TotalStart1 = get_start({partition, 1, Stat, total}),
+	CurrentStart1 = get_start({partition, 1, Stat, current}),
+	timer:sleep(1000),
+	Fun(1),
+	Fun(1),
+	
+	Fun(2),
+	TotalStart2 = get_start({partition, 2, Stat, total}),
+	CurrentStart2 = get_start({partition, 2, Stat, current}),
+	Fun(2),
+	
+	?assert(TotalStart1 /= TotalStart2),
+	?assert(CurrentStart1 /= CurrentStart2),
+	?assertEqual(0.0, get_average({partition, 1, Stat, total}, TotalStart1)),
+	?assertEqual(0.0, get_average({partition, 1, Stat, current}, CurrentStart1)),
+	?assertEqual(0.0, get_average({partition, 2, Stat, total}, TotalStart2)),
+	?assertEqual(0.0, get_average({partition, 2, Stat, current}, CurrentStart2)),
+
+	?assertEqual(6.0, get_average({partition, 1, Stat, total}, TotalStart1 + 500)),
+	?assertEqual(0.25, get_average({partition, 1, Stat, current}, CurrentStart1 + 12000)),
+	?assertEqual(0.5, get_average({partition, 2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(8.0, get_average({partition, 2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, current}, TotalStart1 + 250)),
+
+	?assertEqual(0.5, get_overall_average(Stat, total, TotalStart1 + 10000)),
+	?assertEqual(0.5, get_overall_average(Stat, current, TotalStart1 + 10000)),
+
+	Now = CurrentStart2 + 1000,
+	reset_count({partition, 1, Stat, current}, Now),
+	?assertEqual(Now, get_start({partition, 1, Stat, current})),
+	?assertEqual(6.0, get_average({partition, 1, Stat, total}, TotalStart1 + 500)),
+	?assertEqual(0.0, get_average({partition, 1, Stat, current}, Now + 12000)),
+	?assertEqual(0.5, get_average({partition, 2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(8.0, get_average({partition, 2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, current}, CurrentStart1 + 250)),
+
+	?assertEqual(0.5, get_overall_average(Stat, total, TotalStart1 + 10000)),
+	?assertEqual(0.2, get_overall_average(Stat, current, CurrentStart2 + 10000)),
+
+	ar_mining_stats:reset_all_stats(),
+	?assertEqual(0.0, get_average({partition, 1, Stat, total}, Now + 500)),
+	?assertEqual(0.0, get_average({partition, 1, Stat, current}, Now + 12000)),
+	?assertEqual(0.0, get_average({partition, 2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(0.0, get_average({partition, 2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({partition, 3, Stat, current}, TotalStart1 + 250)),
+
+	?assertEqual(0.0, get_overall_average(Stat, total, TotalStart1 + 10000)),
+	?assertEqual(0.0, get_overall_average(Stat, current, CurrentStart2 + 10000)).
+
+test_vdf_stats() ->
+	ar_mining_stats:pause_performance_reports(120000),
+	ar_mining_stats:reset_all_stats(),
+	ar_mining_stats:vdf_computed(),
+	Start = get_start(vdf),
+	ar_mining_stats:vdf_computed(),
+	ar_mining_stats:vdf_computed(),
+
+	?assertEqual(0.0, get_average(vdf, Start)),
+	?assertEqual(6.0, get_average(vdf, Start + 500)),
+
+	Now = Start + 1000,
+	?assertEqual(3.0, vdf_speed(Now)),
+	?assertEqual(Now, get_start(vdf)),
+	?assertEqual(undefined, vdf_speed(Now)),
+	?assertEqual(0.0, get_average(vdf, Now + 500)),
+	?assertEqual(undefined, vdf_speed(Now + 500)),
+
+	ar_mining_stats:vdf_computed(),
+	Start2 = get_start(vdf),
+	?assertEqual(2.0, vdf_speed(Start2 + 500)),
+
+	ar_mining_stats:vdf_computed(),
+	ar_mining_stats:reset_all_stats(),
+	?assertEqual(undefined, get_start(vdf)),
+	?assertEqual(0.0, get_average(vdf, 1000)),
+	?assertEqual(undefined, vdf_speed(1000)).
+
+test_data_size_stats() ->
+	ar_mining_stats:pause_performance_reports(120000),
+	ar_mining_stats:reset_all_stats(),
+	?assertEqual(0, get_total_data_size()),
+	?assertEqual(0, get_partition_data_size(1)),
+	?assertEqual(0, get_partition_data_size(2)),
+
+	ar_mining_stats:set_total_data_size(1000),
+	?assertEqual(1000, get_total_data_size()),
+	ar_mining_stats:set_total_data_size(500),
+	?assertEqual(500, get_total_data_size()),
+
+	ar_mining_stats:set_storage_module_data_size(store_id1, unpacked, 1, 100, 1, 100),
+	ar_mining_stats:set_storage_module_data_size(store_id2, unpacked, 1, 300, 2, 200),
+	ar_mining_stats:set_storage_module_data_size(store_id3, unpacked, 1, 200, 3, 50),
+	ar_mining_stats:set_storage_module_data_size(store_id4, unpacked, 2, 300, 1, 200),
+
+	?assertEqual(350, get_partition_data_size(1)),
+	?assertEqual(200, get_partition_data_size(2)),
+
+	ar_mining_stats:set_storage_module_data_size(store_id2, unpacked, 1, 300, 2, 100),
+	ar_mining_stats:set_storage_module_data_size(store_id5, unpacked, 2, 100, 2, 100),
+
+	?assertEqual(250, get_partition_data_size(1)),
+	?assertEqual(300, get_partition_data_size(2)),
+
+	ar_mining_stats:reset_all_stats(),
+	?assertEqual(0, get_total_data_size()),
+	?assertEqual(0, get_partition_data_size(1)),
+	?assertEqual(0, get_partition_data_size(2)).
+
+test_h1_sent_to_peer_stats() ->
+	test_peer_stats(fun h1_sent_to_peer/2, h1_to_peer).
+
+test_h1_received_from_peer_stats() ->
+	test_peer_stats(fun h1_received_from_peer/2, h1_from_peer).
+
+test_h2_peer_stats() ->
+	ar_mining_stats:pause_performance_reports(120000),
+	ar_mining_stats:reset_all_stats(),
+
+	Peer1 = ar_test_node:peer_ip(peer1),
+	Peer2 = ar_test_node:peer_ip(peer2),
+	Peer3 = ar_test_node:peer_ip(peer3),
+
+	ar_mining_stats:h2_sent_to_peer(Peer1),
+	ar_mining_stats:h2_sent_to_peer(Peer1),
+	ar_mining_stats:h2_sent_to_peer(Peer1),
+	ar_mining_stats:h2_sent_to_peer(Peer2),
+	ar_mining_stats:h2_sent_to_peer(Peer2),
+
+	?assertEqual(3, get_count({peer, Peer1, h2_to_peer, total})),
+	?assertEqual(2, get_count({peer, Peer2, h2_to_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_to_peer, total})),
+
+	ar_mining_stats:h2_received_from_peer(Peer1),
+	ar_mining_stats:h2_received_from_peer(Peer1),
+	ar_mining_stats:h2_received_from_peer(Peer1),
+	ar_mining_stats:h2_received_from_peer(Peer2),
+	ar_mining_stats:h2_received_from_peer(Peer2),
+
+	?assertEqual(3, get_count({peer, Peer1, h2_from_peer, total})),
+	?assertEqual(2, get_count({peer, Peer2, h2_from_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_from_peer, total})),
+
+	reset_count({peer, Peer1, h2_to_peer, total}, 1000),
+	reset_count({peer, Peer2, h2_from_peer, total}, 1000),
+
+	?assertEqual(0, get_count({peer, Peer1, h2_to_peer, total})),
+	?assertEqual(2, get_count({peer, Peer2, h2_to_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_to_peer, total})),
+	?assertEqual(3, get_count({peer, Peer1, h2_from_peer, total})),
+	?assertEqual(0, get_count({peer, Peer2, h2_from_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_from_peer, total})),
+
+	ar_mining_stats:reset_all_stats(),
+
+	?assertEqual(0, get_count({peer, Peer1, h2_to_peer, total})),
+	?assertEqual(0, get_count({peer, Peer2, h2_to_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_to_peer, total})),
+	?assertEqual(0, get_count({peer, Peer1, h2_from_peer, total})),
+	?assertEqual(0, get_count({peer, Peer2, h2_from_peer, total})),
+	?assertEqual(0, get_count({peer, Peer3, h2_from_peer, total})).
+
+test_peer_stats(Fun, Stat) ->
+	ar_mining_stats:pause_performance_reports(120000),
+	ar_mining_stats:reset_all_stats(),
+
+	Peer1 = ar_test_node:peer_ip(peer1),
+	Peer2 = ar_test_node:peer_ip(peer2),
+	Peer3 = ar_test_node:peer_ip(peer3),
+
+	Fun(Peer1, 10),
+	TotalStart1 = get_start({peer, Peer1, Stat, total}),
+	CurrentStart1 = get_start({peer, Peer1, Stat, current}),
+	timer:sleep(1000),
+	Fun(Peer1, 5),
+	Fun(Peer1, 15),
+	
+	Fun(Peer2, 1),
+	TotalStart2 = get_start({peer, Peer2, Stat, total}),
+	CurrentStart2 = get_start({peer, Peer2, Stat, current}),
+	Fun(Peer2, 19),
+	
+	?assert(TotalStart1 /= TotalStart2),
+	?assert(CurrentStart1 /= CurrentStart2),
+	?assertEqual(0.0, get_average({peer, Peer1, Stat, total}, TotalStart1)),
+	?assertEqual(0.0, get_average({peer, Peer1, Stat, current}, CurrentStart1)),
+	?assertEqual(0.0, get_average({peer, Peer2, Stat, total}, TotalStart2)),
+	?assertEqual(0.0, get_average({peer, Peer2, Stat, current}, CurrentStart2)),
+
+	?assertEqual(60.0, get_average({peer, Peer1, Stat, total}, TotalStart1 + 500)),
+	?assertEqual(2.5, get_average({peer, Peer1, Stat, current}, CurrentStart1 + 12000)),
+	?assertEqual(5.0, get_average({peer, Peer2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(80.0, get_average({peer, Peer2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, current}, TotalStart1 + 250)),
+
+	Now = CurrentStart2 + 1000,
+	reset_count({peer, Peer1, Stat, current}, Now),
+	?assertEqual(Now, get_start({peer, Peer1, Stat, current})),
+	?assertEqual(60.0, get_average({peer, Peer1, Stat, total}, TotalStart1 + 500)),
+	?assertEqual(0.0, get_average({peer, Peer1, Stat, current}, Now + 12000)),
+	?assertEqual(5.0, get_average({peer, Peer2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(80.0, get_average({peer, Peer2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, current}, CurrentStart1 + 250)),
+
+	ar_mining_stats:reset_all_stats(),
+	?assertEqual(0.0, get_average({peer, Peer1, Stat, total}, TotalStart1 + 500)),
+	?assertEqual(0.0, get_average({peer, Peer1, Stat, current}, Now + 12000)),
+	?assertEqual(0.0, get_average({peer, Peer2, Stat, total}, TotalStart2 + 4000)),
+	?assertEqual(0.0, get_average({peer, Peer2, Stat, current}, CurrentStart2 + 250)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, total}, TotalStart1 + 4000)),
+	?assertEqual(0.0, get_average({peer, Peer3, Stat, current}, CurrentStart1 + 250)).
+

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -275,7 +275,7 @@ vdf_speed(Now) ->
 			VDFSpeed
 	end.
 
-%% @doc caculate the maximum hash rate (in MiB per second read from disk) for the given VDF speed
+%% @doc calculate the maximum hash rate (in MiB per second read from disk) for the given VDF speed
 %% at the current weave size.
 optimal_overall_read_mibps(undefined, _TotalDataSize, _WeaveSize) ->
 	0.0;

--- a/apps/arweave/src/ar_node.erl
+++ b/apps/arweave/src/ar_node.erl
@@ -7,7 +7,7 @@
 
 -export([get_recent_block_hash_by_height/1, get_blocks/0, get_block_index/0,
 		get_current_block/0, is_in_block_index/1, get_block_index_and_height/0,
-		get_height/0, get_balance/1, get_last_tx/1, get_ready_for_mining_txs/0,
+		get_height/0, get_weave_size/0, get_balance/1, get_last_tx/1, get_ready_for_mining_txs/0,
 		get_current_usd_to_ar_rate/0, get_current_block_hash/0,
 		get_block_index_entry/1, get_2_0_hash_of_1_0_block/1, is_joined/0, get_block_anchors/0,
 		get_recent_txs_map/0, get_mempool_size/0,
@@ -142,6 +142,14 @@ get_height() ->
 	case ets:lookup(node_state, height) of
 		[{height, Height}] ->
 			Height;
+		[] ->
+			-1
+	end.
+
+get_weave_size() ->
+	case ets:lookup(node_state, weave_size) of
+		[{weave_size, WeaveSize}] ->
+			WeaveSize;
 		[] ->
 			-1
 	end.

--- a/apps/arweave/src/ar_sync_record.erl
+++ b/apps/arweave/src/ar_sync_record.erl
@@ -9,6 +9,7 @@
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
 -include_lib("arweave/include/ar.hrl").
+-include_lib("arweave/include/ar_consensus.hrl").
 -include_lib("arweave/include/ar_data_sync.hrl").
 -include_lib("arweave/include/ar_data_discovery.hrl").
 
@@ -43,10 +44,12 @@
 	state_db,
 	%% The identifier of the storage module.
 	store_id,
-	%% The size in bytes of the partition; undefined for the "default" storage.
-	partition_size,
-	%% The index of the partition; undefined for the "default" storage.
-	partition_index,
+	%% The partition covered by the storage module.
+	partition_number,
+	%% The size in bytes of the storage module; undefined for the "default" storage.
+	storage_module_size,
+	%% The index of the storage module; undefined for the "default" storage.
+	storage_module_index,
 	%% The number of entries in the write-ahead log.
 	wal
 }).
@@ -236,14 +239,15 @@ get_intersection_size(End, Start, ID, StoreID) ->
 
 init(StoreID) ->
 	process_flag(trap_exit, true),
-	{Dir, PartitionSize, PartitionIndex} =
+	{Dir, StorageModuleSize, StorageModuleIndex, PartitionNumber} =
 		case StoreID of
 			"default" ->
-				{filename:join(?ROCKS_DB_DIR, "ar_sync_record_db"), undefined, undefined};
+				{filename:join(?ROCKS_DB_DIR, "ar_sync_record_db"),
+					undefined, undefined, undefined};
 			_ ->
 				{Size, Index, _Packing} = ar_storage_module:get_by_id(StoreID),
 				{filename:join(["storage_modules", StoreID, ?ROCKS_DB_DIR,
-						"ar_sync_record_db"]), Size, Index}
+						"ar_sync_record_db"]), Size, Index, ?PARTITION_NUMBER(Size * Index)}
 		end,
 	StateDB = {sync_record, StoreID},
 	ok = ar_kv:open(Dir, StateDB),
@@ -254,8 +258,9 @@ init(StoreID) ->
 	{ok, #state{
 		state_db = StateDB,
 		store_id = StoreID,
-		partition_size = PartitionSize,
-		partition_index = PartitionIndex,
+		partition_number = PartitionNumber,
+		storage_module_size = StorageModuleSize,
+		storage_module_index = StorageModuleIndex,
 		sync_record_by_id = SyncRecordByID,
 		sync_record_by_id_type = SyncRecordByIDType,
 		wal = WAL
@@ -550,7 +555,9 @@ initialize_sync_record_by_id_type_ets2({{ID, Type}, SyncRecord, Iterator}, Store
 store_state(State) ->
 	#state{ state_db = StateDB, sync_record_by_id = SyncRecordByID,
 			sync_record_by_id_type = SyncRecordByIDType, store_id = StoreID,
-			partition_size = PartitionSize, partition_index = PartitionIndex } = State,
+			partition_number = PartitionNumber,
+			storage_module_size = StorageModuleSize,
+			storage_module_index = StorageModuleIndex } = State,
 	StoreSyncRecords =
 		ar_kv:put(
 			StateDB,
@@ -581,8 +588,9 @@ store_state(State) ->
 								_ ->
 									Type
 							end,
-						prometheus_gauge:set(v2_index_data_size_by_packing, [StoreID, Type2,
-								PartitionSize, PartitionIndex], ar_intervals:sum(TypeRecord));
+						ar_mining_stats:set_storage_module_data_size(
+							StoreID, Type2, PartitionNumber, StorageModuleSize, StorageModuleIndex,
+							ar_intervals:sum(TypeRecord));
 					(_, _) ->
 						ok
 				end,

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -105,7 +105,7 @@ handle([<<"vdf">>], Req, State) ->
 	end.
 
 test_vdf_server_push_fast_block() ->
-	VdfPort = ar_test_node:get_unused_port(),
+	VDFPort = ar_test_node:get_unused_port(),
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
@@ -117,13 +117,13 @@ test_vdf_server_push_fast_block() ->
 	{ok, Config} = application:get_env(arweave, config),
 	ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
-		Config#config{ nonce_limiter_client_peers = [ "127.0.0.1:" ++ integer_to_list(VdfPort) ]}),
+		Config#config{ nonce_limiter_client_peers = [ "127.0.0.1:" ++ integer_to_list(VDFPort) ]}),
 
 	%% Setup a server to listen for VDF pushes
 	Routes = [{"/[...]", ar_vdf_server_tests, []}],
 	{ok, _} = cowboy:start_clear(
 		ar_vdf_server_test_listener,
-		[{port, VdfPort}],
+		[{port, VDFPort}],
 		#{ env => #{ dispatch => cowboy_router:compile([{'_', Routes}]) } }
 	),
 


### PR DESCRIPTION
- Introduce ar_mining_stats to handle logging and reporting all mining stats.
- add the CM-related metrics to the report
- Add some metrics to better track mining performance via prometheus: `mining_read_rate`, `mining_hash_rate`, `cm_h1_rate`, `cm_h2_count`. All new metrics uses labels to get some more granularity
- Report on the amount of data synced
- update the report itself, it now looks like:
```
=========================================== Mining Performance Report ============================================

VDF Speed:  3.00 s

Local mining stats:
+-----------+-----------+----------+-------------+-------------+---------------+------------+--------------+------------+
| Partition | Data Size | % of Max |  Read (Cur) |  Read (Avg) |  Read (Ideal) | Hash (Cur) | Hash (Avg) | Hash (Ideal) |
+-----------+-----------+----------+-------------+-------------+---------------+------------+--------------+------------+
|     Total |   0.0 TiB |      5 % |   1.3 MiB/s |   1.3 MiB/s |    35.3 MiB/s |      5 h/s |      5 h/s |      141 h/s |
|         1 |   0.0 TiB |     34 % |   0.8 MiB/s |   0.8 MiB/s |    12.4 MiB/s |      3 h/s |      3 h/s |       49 h/s |
|         2 |   0.0 TiB |     25 % |   0.5 MiB/s |   0.5 MiB/s |     8.8 MiB/s |      2 h/s |      2 h/s |       35 h/s |
|         3 |   0.0 TiB |      0 % |   0.0 MiB/s |   0.0 MiB/s |     0.0 MiB/s |      0 h/s |      0 h/s |        0 h/s |
+-----------+-----------+----------+-----------+---------------+---------------+------------+------------+--------------+

Coordinated mining cluster stats:
+----------------------+-------------+-------------+---------------+---------------+---------+---------+
|                 Peer | H1 To (Cur) | H1 To (Avg) | H1 From (Cur) | H1 From (Avg) |   H2 To | H2 From |
+----------------------+-------------+-------------+---------------+---------------+---------+---------+
|                  All |      50 h/s |      50 h/s |        50 h/s |        50 h/s |       5 |       5 |
|      127.0.0.1:40195 |      30 h/s |      30 h/s |        20 h/s |        20 h/s |       3 |       2 |
|      127.0.0.1:53771 |      20 h/s |      20 h/s |        30 h/s |        30 h/s |       2 |       3 |
|      127.0.0.1:32793 |       0 h/s |       0 h/s |         0 h/s |         0 h/s |       0 |       0 |
+----------------------+-------------+-------------+---------------+---------------+---------+---------+
```

`Cur` values refer to the most recent value (e.g. the average over the last ~10seconds)
`Avg` values refer to the all-time running average
`Ideal` refers to the optimal rate given the VDF speed and amount of data currently packed
`% of Max` refers to how much of the given partition - or whole weave - is packed