### PR TITLE
Don't reset the mining session if the partition number decreases

### DIFF
--- a/apps/arweave/include/ar_mining.hrl
+++ b/apps/arweave/include/ar_mining.hrl
@@ -23,7 +23,7 @@
 	poa2 = not_set, %% serialized
 	preimage = not_set, %% serialized. this can be either the h1 or h2 preimage
 	seed = not_set, %% serialized
-	session_ref = not_set, %% not serialized
+	vdf_session_key = not_set, %% not serialized
 	start_interval_number = not_set, %% serialized
 	step_number = not_set %% serialized
 }).


### PR DESCRIPTION
Currently we reset the mining session if any of these values change:
- NextSeed
- StartInterval
- NextVDFDifficulty
- PartitionUpperBond

However since steps can be handled out of order - particularly for VDF clients - there are situations where the partition upper bounds that comes in flutter between two values. This causes the mining session to be repeatedly reset - each time the mining session is reset it invalidates all mining tasks created from earlier sessions.

However the only reason we store the partition upper bound in the mining session is to respawn the mining threads if the weave's maximum partition number increases. Because of this we don't need to reset the mining session if the partition number decreases