### PR TITLE
dev: add erlang-ls config and nix-dev-shell

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,0 +1,16 @@
+apps_dirs:
+  - "apps/*"
+  - "_build/default/lib/*"
+deps_dirs:
+  - "_build/default/lib/*"
+diagnostics:
+  enabled:
+    - crossref
+include_dirs:
+  - "apps"
+  - "apps/*/include"
+  - "_build/default/lib"
+  - "_build/default/lib/*/include"
+providers:
+  enabled:
+    - signature-help

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,34 @@
 
       defaultPackage = self.packages."${system}".arweave;
 
+      devShells = {
+        # for arweave development, made to work with rebar3 builds (not nix)
+        default = with pkgs; mkShellNoCC {
+          name = "arweave-dev";
+          buildInputs = [
+            bashInteractive
+            cmake
+            elvis-erlang
+            erlang
+            erlang-ls
+            gmp
+            openssl
+            pkg-config
+            rebar3
+            rsync
+          ];
+
+          PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig";
+
+          shellHook = ''
+            ${pkgs.fish}/bin/fish --interactive -C \
+              '${pkgs.any-nix-shell}/bin/any-nix-shell fish --info-right | source'
+            exit $?
+          '';
+
+        };
+      };
+
     });
 
 }


### PR DESCRIPTION
This PR adds a development shell command, if a developer has nix installed it is possible to run

``` 
$ nix develop
```

and all the erlang tools are imported into a shell, making rebar3 commands ready to be used, it may work well with dotenv later on.

The other change is erlang_ls (language server) config, giving value to developers that are using text editors which support erlang_ls.