### PR TITLE
Introduce ar-rebar3 as a wrapper around rebar3

### DIFF
--- a/ar-rebar3
+++ b/ar-rebar3
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]; then
+	echo "ar-rebar3 <profile> <command>"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROFILE=$1
+COMMAND=$2
+
+echo Removing build artifacts...
+set -x
+rm -f "${SCRIPT_DIR}/bin/arweave-dev"
+rm -f "${SCRIPT_DIR}/lib"
+rm -f "${SCRIPT_DIR}/releases"
+{ set +x; } 2>/dev/null
+echo
+
+${SCRIPT_DIR}/rebar3 as ${PROFILE} ${COMMAND}
+
+if [ "${COMMAND}" = "release" ]; then
+	RELEASE_PATH=$(${SCRIPT_DIR}/rebar3 as ${ARWEAVE_BUILD_TARGET:-default} path --rel)
+    echo
+    echo Copying and linking build artifacts
+    set -x
+    cp ${RELEASE_PATH}/arweave/bin/arweave ${SCRIPT_DIR}/bin/arweave-dev
+    ln -s ${RELEASE_PATH}/arweave/releases ${SCRIPT_DIR}/releases
+    ln -s ${RELEASE_PATH}/arweave/lib ${SCRIPT_DIR}/lib
+    { set +x; } 2>/dev/null
+    echo
+fi

--- a/bin/arweave.env
+++ b/bin/arweave.env
@@ -17,24 +17,8 @@ else
     # the releases and lib directories in the parent directory. This allows the arweave
     # extended start script to run from our current directory (which is necessary for relative
     # paths to work correctly and not be relative to the rebar3 _build release directory)
-    echo Removing build artifacts...
-    set -x
-    rm -f "${SCRIPT_DIR}/arweave-dev"
-    rm -f "${PARENT_DIR}/lib"
-    rm -f "${PARENT_DIR}/releases"
-    { set +x; } 2>/dev/null
-    echo
     echo Building dependencies...
-    (cd ${PARENT_DIR} && ./rebar3 as ${ARWEAVE_BUILD_TARGET:-default} release)
-    RELEASE_PATH=$(cd ${PARENT_DIR} && ./rebar3 as ${ARWEAVE_BUILD_TARGET:-default} path --rel)
-    echo
-    echo Copying and linking build artifacts
-    set -x
-    cp ${RELEASE_PATH}/arweave/bin/arweave ${SCRIPT_DIR}/arweave-dev
-    ln -s ${RELEASE_PATH}/arweave/releases ${PARENT_DIR}/releases
-    ln -s ${RELEASE_PATH}/arweave/lib ${PARENT_DIR}/lib
-    { set +x; } 2>/dev/null
-    echo
+    (cd ${PARENT_DIR} && ./ar-rebar3 ${ARWEAVE_BUILD_TARGET:-default} release)
     export ARWEAVE="${SCRIPT_DIR}/arweave-dev"
     export ARWEAVE_COMMAND="console"
 fi

--- a/bin/shell
+++ b/bin/shell
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$0")"
 cd "$SCRIPT_DIR/.."
 
-./rebar3 as test compile
+./ar-rebar3 test compile
 
 if [ `uname -s` == "Darwin" ]; then
     RANDOMX_JIT="disable randomx_jit"

--- a/bin/test
+++ b/bin/test
@@ -4,7 +4,7 @@
 SCRIPT_DIR="$(dirname "$0")"
 cd "$SCRIPT_DIR/.."
 
-./rebar3 as test compile
+./ar-rebar3 test compile
 
 export ERL_EPMD_ADDRESS=127.0.0.1
 


### PR DESCRIPTION
it handles the rm and symlinking necessary to have the dev environment function similarly to the release environment.

This change was added in order to get ./bin/test and ./bin/shell to work again (the broke with the previous commit)