### PR TITLE
Improve the help for data-doctor bench

### DIFF
--- a/apps/arweave/src/ar_doctor_bench.erl
+++ b/apps/arweave/src/ar_doctor_bench.erl
@@ -17,10 +17,23 @@ main(Args) ->
 	bench_read(Args).
 
 help() ->
-	ar:console("data-doctor bench duration data_dir storage_module [storage_module] [...]~n"),
+	ar:console("data-doctor bench <duration> <data_dir> <storage_module> [<storage_module> ...]~n"),
 	ar:console("  duration: How long, in seconds, to run the benchmark for.~n"), 
-	ar:console("            During the run data will be logged to ~p in the format:~n", [?OUTPUT_FILENAME]),
-	ar:console("            '~s'~n", [?FILE_FORMAT]).
+	ar:console("  data_dir: Full path to your data_dir.~n"), 
+	ar:console("  storage_module: List of storage modules in same format used for Arweave ~n"),
+	ar:console("                  configuration (e.g. 0,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI).~n"), 
+	ar:console("                  It's recommended that you specify all configured storage_modules ~n"),
+	ar:console("                  in order to benchmark the overall system performance including  ~n"),
+	ar:console("                  any data busses that are shared across disks.~n"), 
+	ar:console("~n"), 
+	ar:console("Example:~n"), 
+	ar:console("data-doctor bench 60 /mnt/arweave-data 0,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \\~n"),
+	ar:console("    1,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \\~n"),
+	ar:console("    2,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \\~n"),
+	ar:console("    3,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI~n"),
+	ar:console("~n"), 
+	ar:console("Note: During the run data will be logged to ~p in the format:~n", [?OUTPUT_FILENAME]),
+	ar:console("      '~s'~n", [?FILE_FORMAT]).
 
 bench_read(Args) when length(Args) < 3 ->
 	false;


### PR DESCRIPTION
data-doctor bench <duration> <data_dir> <storage_module> [<storage_module> ...]
  duration: How long, in seconds, to run the benchmark for.
  data_dir: Full path to your data_dir.
  storage_module: List of storage modules in same format used for Arweave
                  configuration (e.g. 0,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI).
                  It's recommended that you specify all configured storage_modules
                  in order to benchmark the overall system performance including
                  any data busses that are shared across disks.

Example:
data-doctor bench 60 /mnt/arweave-data 0,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \
    1,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \
    2,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI \
    3,En2eqsVJARnTVOSh723PBXAKGmKgrGSjQ2YIGwE_ZRI

Note: During the run data will be logged to "<storage_module>.benchmark.csv" in the format:
      'timestamp,bytes_read,elapsed_time_ms,throughput_bps'