### PR TITLE
Two ways to build a storage module name (id vs. label).

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
             ar_retarget,
             ar_serialize,
             ar_storage,
+            ar_storage_module,
             ar_sync_buckets,
             ar_tx,
             ar_tx_db,

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -705,7 +705,7 @@ fetch_poa_from_peers(RecallByte) ->
 			spawn(
 				fun() ->
 					?LOG_INFO([{event, last_moment_proof_search},
-							{peer, ar_util:format_peer(Peer)}]),
+							{peer, ar_util:format_peer(Peer)}, {recall_byte, RecallByte}]),
 					case fetch_poa_from_peer(Peer, RecallByte) of
 						not_found ->
 							ok;


### PR DESCRIPTION
both use same code path now except swap out the last bit