### PR TITLE
fix: mining stats incorrect after repack in place

### DIFF
--- a/apps/arweave/src/ar_storage_module.erl
+++ b/apps/arweave/src/ar_storage_module.erl
@@ -1,6 +1,6 @@
 -module(ar_storage_module).
 
--export([id/1, label/1, address_label/1, label_by_id/1,
+-export([id/1, label/1, address_label/1, packing_label/1, label_by_id/1,
 		get_by_id/1, get_range/1, get_packing/1, get_size/1, get/2, get_all/1, get_all/2]).
 
 -include_lib("arweave/include/ar.hrl").
@@ -68,6 +68,12 @@ address_label(Addr) ->
 		[{_, Label}] ->
 			integer_to_list(Label)
 	end.
+
+packing_label({spora_2_6, Addr}) ->
+	AddrLabel = ar_storage_module:address_label(Addr),
+	list_to_atom("spora_2_6_" ++ AddrLabel);
+packing_label(Packing) ->
+	Packing.
 
 %% @doc Return the obscure unique label for the given store ID.
 label_by_id("default") ->

--- a/apps/arweave/src/ar_sync_record.erl
+++ b/apps/arweave/src/ar_sync_record.erl
@@ -582,24 +582,8 @@ store_state(State) ->
 		ok ->
 			maps:map(
 				fun	({ar_data_sync, Type}, TypeRecord) ->
-						Type2 =
-							case Type of
-								{spora_2_6, Addr} ->
-									AddrLabel = ar_storage_module:address_label(Addr),
-									list_to_atom("spora_2_6_" ++ AddrLabel);
-								_ ->
-									Type
-							end,
-						StoreLabel =
-							case StoreID of
-								"default" ->
-									"default";
-								_ ->
-									StorageModule = ar_storage_module:get_by_id(StoreID),
-									ar_storage_module:label(StorageModule)
-							end,
 						ar_mining_stats:set_storage_module_data_size(
-							StoreLabel, Type2, PartitionNumber, StorageModuleSize,
+							StoreID, Type, PartitionNumber, StorageModuleSize,
 							StorageModuleIndex,
 							ar_intervals:sum(TypeRecord));
 					(_, _) ->


### PR DESCRIPTION
Mining stats now allow for two storage modules to have the same store id but different packing