### PR TITLE
Provide partitions with every pool CM job fetch

### DIFF
--- a/apps/arweave/include/ar_pool.hrl
+++ b/apps/arweave/include/ar_pool.hrl
@@ -41,7 +41,12 @@
 }).
 
 %% @doc A set of coordinated mining jobs provided by the pool.
+%%
+%% Miners fetch and submit pool CM jobs via the same POST /pool_cm_jobs endpoint.
+%% When miners fetch jobs, they specify the partitions and leave the job fields empty.
+%% When miners submit jobs, they leave the partitions field empty.
 -record(pool_cm_jobs, {
 	h1_to_h2_jobs = [], % [#mining_candidate{}]
-	h1_read_jobs = [] % [#mining_candidate{}]
+	h1_read_jobs = [], % [#mining_candidate{}]
+	partitions = [] % a list of {[{bucket, ...}, {bucketsize, ...}, {addr, ...}]} JSON structs
 }).

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -16,7 +16,7 @@
 		push_nonce_limiter_update/3, get_vdf_update/1, get_vdf_session/1,
 		get_previous_vdf_session/1, get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
 		cm_publish_send/2, get_jobs/2, post_partial_solution/2,
-		get_pool_cm_jobs/1, post_pool_cm_jobs/2, post_cm_partition_table_to_pool/2]).
+		get_pool_cm_jobs/2, post_pool_cm_jobs/2, post_cm_partition_table_to_pool/2]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_pricing.hrl").
@@ -721,7 +721,7 @@ post_partial_solution(Peer, Solution) ->
 		is_peer_request => IsPeerRequest
 	})).
 
-get_pool_cm_jobs(Peer) ->
+get_pool_cm_jobs(Peer, Jobs) ->
 	{Peer3, Headers, BasePath, IsPeerRequest} =
 		case Peer of
 			{pool, URL} ->
@@ -730,13 +730,16 @@ get_pool_cm_jobs(Peer) ->
 			_ ->
 				{Peer, cm_p2p_headers(), "", true}
 		end,
+	Struct = ar_serialize:pool_cm_jobs_to_json_struct(Jobs),
+	Payload = ar_serialize:jsonify(Struct),
 	handle_get_pool_cm_jobs_response(ar_http:req(#{
 		peer => Peer3,
-		method => get,
+		method => post,
 		path => BasePath ++ "/pool_cm_jobs",
 		timeout => 5 * 1000,
 		connect_timeout => 1000,
 		headers => Headers,
+		body => Payload,
 		is_peer_request => IsPeerRequest
 	})).
 

--- a/apps/arweave/src/ar_pool_cm_job_poller.erl
+++ b/apps/arweave/src/ar_pool_cm_job_poller.erl
@@ -43,7 +43,9 @@ handle_call(Request, _From, State) ->
 
 handle_cast(fetch_cm_jobs, State) ->
 	Peer = ar_pool:pool_peer(),
-	case ar_http_iface_client:get_pool_cm_jobs(Peer) of
+	Partitions = ar_coordination:get_unique_partitions_list(),
+	PartitionJobs = #pool_cm_jobs{ partitions = Partitions },
+	case ar_http_iface_client:get_pool_cm_jobs(Peer, PartitionJobs) of
 		{ok, Jobs} ->
 			push_cm_jobs_to_cm_peers(Jobs),
 			ar_pool:process_cm_jobs(Jobs, Peer),

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -1925,10 +1925,12 @@ partial_solution_response_to_json_struct(Response) ->
 	{[{<<"indep_hash">>, ar_util:encode(H)}, {<<"status">>, S}]}.
 
 pool_cm_jobs_to_json_struct(Jobs) ->
-	#pool_cm_jobs{ h1_to_h2_jobs = H1ToH2Jobs, h1_read_jobs = H1ReadJobs } = Jobs,
+	#pool_cm_jobs{ h1_to_h2_jobs = H1ToH2Jobs, h1_read_jobs = H1ReadJobs,
+			partitions = Partitions } = Jobs,
 	{[
 		{h1_to_h2_jobs, [pool_cm_h1_to_h2_job_to_json_struct(Job) || Job <- H1ToH2Jobs]},
-		{h1_read_jobs, [pool_cm_h1_read_job_to_json_struct(Job) || Job <- H1ReadJobs]}
+		{h1_read_jobs, [pool_cm_h1_read_job_to_json_struct(Job) || Job <- H1ReadJobs]},
+		{partitions, Partitions}
 	]}.
 
 pool_cm_h1_to_h2_job_to_json_struct(Job) ->


### PR DESCRIPTION
To support the same miner having multiple exit nodes in the coordinated mining through pool setup.