### PR TITLE
Better handling of build directories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,5 +200,5 @@ jobs:
           find /home/runner -type d -name "_build_${{ github.run_id }}" -exec rm -rf {} +
       - name: Cleanup old build artifacts
         run: |
-          find /tmp -name "arweave_build_*" -type f -mtime +7 -exec rm -f {} +
+          find /tmp -maxdepth 1 -name "arweave_build_*" -type f -mtime +7 -exec rm -f {} +
           find /home/runner -name "_build_*" -type d -mtime +7 -exec rm -rf {} +

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,9 +192,13 @@ jobs:
   cleanup:
     needs: eunit-tests
     runs-on: self-hosted
-    if: ${{ always() }}
+    if: ${{ success() && needs.eunit-tests.result == 'success' }}
     steps:
       - name: Cleanup build directories
         run: |
           rm -rf /tmp/arweave_build_${{ github.run_id }}.tar.gz
           find /home/runner -type d -name "_build_${{ github.run_id }}" -exec rm -rf {} +
+      - name: Cleanup old build artifacts
+        run: |
+          find /tmp -name "arweave_build_*" -type f -mtime +7 -exec rm -f {} +
+          find /home/runner -name "_build_*" -type d -mtime +7 -exec rm -rf {} +


### PR DESCRIPTION
1. Only delete the build directory on success to make re-running failed tasks quicker
2. Delete build directories order than 1 week