### PR TITLE
Solution Tracking

### DIFF
--- a/apps/arweave/include/ar_mining.hrl
+++ b/apps/arweave/include/ar_mining.hrl
@@ -54,4 +54,10 @@
 	steps = []
 }).
 
+%% @doc Solution validation response.
+-record(solution_response, {
+	indep_hash = <<>>,
+	status = <<>>
+}).
+
 -endif.

--- a/apps/arweave/include/ar_mining.hrl
+++ b/apps/arweave/include/ar_mining.hrl
@@ -28,6 +28,7 @@
 	preimage = not_set, %% serialized. this can be either the h1 or h2 preimage
 	seed = not_set, %% serialized
 	session_key = not_set, %% serialized
+	solution_peer = not_set, %% serialized. if set, the winning hash came from another peer
 	start_interval_number = not_set, %% serialized
 	step_number = not_set, %% serialized
 	label = <<"not_set">> %% not atom, in order to prevent atom table pollution DoS
@@ -49,6 +50,7 @@
 	recall_byte2 = undefined,
 	seed = << 0:(8 * 48) >>,
 	solution_hash = << 0:256 >>,
+	solution_peer = not_set, %% serialized. if set, the solution hash came from another peer
 	start_interval_number = 0,
 	step_number = 0,
 	steps = []

--- a/apps/arweave/include/ar_mining.hrl
+++ b/apps/arweave/include/ar_mining.hrl
@@ -9,7 +9,8 @@
 	cache_ref = not_set, %% not serialized
 	chunk1 = not_set, %% not serialized
 	chunk2 = not_set, %% not serialized
-	cm_diff = not_set, %% serialized. set to the difficulty used by the H1 miner
+	diff_pair = not_set, %% serialized. set to the difficulty associated with this candidate.
+						 %% diff_pair can be set by CM peers or a pool server.
 	cm_h1_list = [], %% serialized. list of {h1, nonce} pairs
 	cm_lead_peer = not_set, %% not serialized. if set, this candidate came from another peer
 	h0 = not_set, %% serialized

--- a/apps/arweave/include/ar_mining.hrl
+++ b/apps/arweave/include/ar_mining.hrl
@@ -29,29 +29,28 @@
 	session_key = not_set, %% serialized
 	start_interval_number = not_set, %% serialized
 	step_number = not_set, %% serialized
-	label = <<"not_set">> %% not atom, for prevent atom table pollution DoS
+	label = <<"not_set">> %% not atom, in order to prevent atom table pollution DoS
 }).
 
 -record(mining_solution, {
-	last_step_checkpoints = [],
-	merkle_rebase_threshold = 0,
+	last_step_checkpoints = [], 
+	mining_address = << 0:256 >>,
 	next_seed = << 0:(8 * 48) >>,
 	next_vdf_difficulty = 0,
 	nonce = 0,
 	nonce_limiter_output = << 0:256 >>,
 	partition_number = 0,
+	partition_upper_bound = 0,
 	poa1 = #poa{},
 	poa2 = #poa{},
 	preimage = << 0:256 >>,
 	recall_byte1 = 0,
 	recall_byte2 = undefined,
+	seed = << 0:(8 * 48) >>,
 	solution_hash = << 0:256 >>,
 	start_interval_number = 0,
 	step_number = 0,
-	steps = [],
-	seed = << 0:(8 * 48) >>,
-	mining_address = << 0:256 >>,
-	partition_upper_bound = 0
+	steps = []
 }).
 
 -endif.

--- a/apps/arweave/include/ar_pool.hrl
+++ b/apps/arweave/include/ar_pool.hrl
@@ -34,12 +34,6 @@
 	partition_upper_bound = 0
 }).
 
-%% @doc Partial solution validation response.
--record(partial_solution_response, {
-	indep_hash = <<>>,
-	status = <<>>
-}).
-
 %% @doc A set of coordinated mining jobs provided by the pool.
 %%
 %% Miners fetch and submit pool CM jobs via the same POST /pool_cm_jobs endpoint.

--- a/apps/arweave/src/ar_chain_stats.erl
+++ b/apps/arweave/src/ar_chain_stats.erl
@@ -3,6 +3,7 @@
 -behaviour(gen_server).
 
 -include_lib("arweave/include/ar.hrl").
+-include_lib("arweave/include/ar_config.hrl").
 -include_lib("arweave/include/ar_chain_stats.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
@@ -38,7 +39,9 @@ get_forks(StartTime) ->
 init([]) ->
     %% Trap exit to avoid corrupting any open files on quit..
     process_flag(trap_exit, true),
-	ok = ar_kv:open(filename:join(?ROCKS_DB_DIR, "forks_db"), forks_db),
+    {ok, Config} = application:get_env(arweave, config),
+    RocksDBDir = filename:join(Config#config.data_dir, ?ROCKS_DB_DIR),
+	ok = ar_kv:open(filename:join(RocksDBDir, "forks_db"), forks_db),
     {ok, #{}}.
 
 handle_call({get_forks, StartTime}, _From, State) ->

--- a/apps/arweave/src/ar_events_sup.erl
+++ b/apps/arweave/src/ar_events_sup.erl
@@ -55,8 +55,6 @@ init([]) ->
 		?CHILD(ar_events, chunk_storage, worker),
 		%% Events: add_range, remove_range, global_remove_range, cut, global_cut.
 		?CHILD(ar_events, sync_record, worker),
-		%% Events: rejected, stale, partial, accepted.
-		?CHILD(ar_events, solution, worker),
 		%% Used for the testing purposes.
 		?CHILD(ar_events, testing, worker)
 	]}}.

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -619,7 +619,7 @@ post_partial_solution(Peer, Solution) ->
 				ar_serialize:jsonify(ar_serialize:solution_to_json_struct(Solution))
 		end,
 	Req = build_cm_or_pool_request(post, Peer, "/partial_solution", Payload),
-	handle_post_partial_solution_response(ar_http:req(Req#{
+	handle_post_solution_response(ar_http:req(Req#{
 		timeout => 20 * 1000,
 		connect_timeout => 5 * 1000
 	})).
@@ -704,14 +704,14 @@ handle_post_pool_cm_jobs_response({ok, {{<<"200">>, _}, _, _, _, _}}) ->
 handle_post_pool_cm_jobs_response(Reply) ->
 	{error, Reply}.
 
-handle_post_partial_solution_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
+handle_post_solution_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
 	case catch jiffy:decode(Body, [return_maps]) of
 		{'EXIT', _} ->
 			{error, invalid_json};
 		Response ->
 			{ok, Response}
 	end;
-handle_post_partial_solution_response(Reply) ->
+handle_post_solution_response(Reply) ->
 	{error, Reply}.
 
 handle_get_jobs_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -591,7 +591,10 @@ cm_h1_send(Peer, Candidate) ->
 cm_h2_send(Peer, Candidate) ->
 	JSON = ar_serialize:jsonify(ar_serialize:candidate_to_json_struct(Candidate)),
 	Req = build_cm_or_pool_request(post, Peer, "/coordinated_mining/h2", JSON),
-	handle_cm_noop_response(ar_http:req(Req)).
+	handle_solution_response(ar_http:req(Req#{
+		timeout => 20 * 1000,
+		connect_timeout => 5 * 1000
+	})).
 
 cm_publish_send(Peer, Solution) ->
 	?LOG_DEBUG([{event, cm_publish_send}, {peer, ar_util:format_peer(Peer)},
@@ -619,7 +622,7 @@ post_partial_solution(Peer, Solution) ->
 				ar_serialize:jsonify(ar_serialize:solution_to_json_struct(Solution))
 		end,
 	Req = build_cm_or_pool_request(post, Peer, "/partial_solution", Payload),
-	handle_post_solution_response(ar_http:req(Req#{
+	handle_solution_response(ar_http:req(Req#{
 		timeout => 20 * 1000,
 		connect_timeout => 5 * 1000
 	})).
@@ -704,14 +707,14 @@ handle_post_pool_cm_jobs_response({ok, {{<<"200">>, _}, _, _, _, _}}) ->
 handle_post_pool_cm_jobs_response(Reply) ->
 	{error, Reply}.
 
-handle_post_solution_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
+handle_solution_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
 	case catch jiffy:decode(Body, [return_maps]) of
 		{'EXIT', _} ->
 			{error, invalid_json};
 		Response ->
 			{ok, Response}
 	end;
-handle_post_solution_response(Reply) ->
+handle_solution_response(Reply) ->
 	{error, Reply}.
 
 handle_get_jobs_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -15,7 +15,7 @@
 		get_block_time_history/3,
 		push_nonce_limiter_update/3, get_vdf_update/1, get_vdf_session/1,
 		get_previous_vdf_session/1, get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
-		cm_publish_send/2, get_jobs/2, post_partial_solution/2,
+		get_jobs/2, post_partial_solution/2,
 		get_pool_cm_jobs/2, post_pool_cm_jobs/2, post_cm_partition_table_to_pool/2]).
 
 -include_lib("arweave/include/ar.hrl").
@@ -595,16 +595,6 @@ cm_h2_send(Peer, Candidate) ->
 		timeout => 20 * 1000,
 		connect_timeout => 5 * 1000
 	})).
-
-cm_publish_send(Peer, Solution) ->
-	?LOG_DEBUG([{event, cm_publish_send}, {peer, ar_util:format_peer(Peer)},
-		{solution, ar_util:encode(Solution#mining_solution.solution_hash)},
-		{step_number, Solution#mining_solution.step_number},
-		{start_interval_number, Solution#mining_solution.start_interval_number},
-		{seed, ar_util:encode(Solution#mining_solution.seed)}]),
-	JSON = ar_serialize:jsonify(ar_serialize:solution_to_json_struct(Solution)),
-	Req = build_cm_or_pool_request(post, Peer, "/coordinated_mining/publish", JSON),
-	handle_cm_noop_response(ar_http:req(Req)).
 
 %% @doc Fetch the jobs from the pool or coordinated mining exit peer.
 get_jobs(Peer, PrevOutput) ->

--- a/apps/arweave/src/ar_http_iface_cm_pool.erl
+++ b/apps/arweave/src/ar_http_iface_cm_pool.erl
@@ -1,0 +1,113 @@
+-module(ar_http_iface_cm_pool).
+
+-export([handle_post_solution/2, handle_get_jobs/3]).
+
+-include_lib("arweave/include/ar_config.hrl").
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+handle_post_solution(Req, Pid) ->
+    case ar_node:is_joined() of
+		false ->
+			not_joined(Req);
+		true ->
+            APISecret = case {ar_pool:is_server(), ar_coordination:is_exit_peer()} of
+                {true, _} ->
+                    pool;
+                {_, true} ->
+                    cm;
+                _ ->
+                    error
+            end,
+            case validate_request(APISecret, Req) of
+                true ->
+                    handle_post_solution2(Req, Pid);
+                FailureResponse ->
+                    FailureResponse
+            end
+    end.
+
+handle_get_jobs(EncodedPrevOutput, Req, Pid) ->
+    case ar_node:is_joined() of
+		false ->
+			not_joined(Req);
+		true ->
+			case ar_util:safe_decode(EncodedPrevOutput) of
+				{ok, PrevOutput} ->
+					handle_get_jobs2(PrevOutput, Req);
+				{error, invalid} ->
+					{400, #{}, jiffy:encode(#{ error => invalid_prev_output }), Req}
+			end
+	end;
+
+
+%%%===================================================================
+%%% Internal functions.
+%%%===================================================================
+
+handle_post_solution2(Req, Pid) ->
+    Peer = ar_http_util:arweave_peer(Req),
+	case read_complete_body(Req, Pid) of
+		{ok, Body, Req2} ->
+			case catch ar_serialize:json_map_to_solution(
+					jiffy:decode(Body, [return_maps])) of
+				{'EXIT', _} ->
+					{400, #{}, jiffy:encode(#{ error => invalid_json }), Req2};
+				Solution ->
+					ar_mining_router:received_solution(Solution,
+						[{peer, ar_util:format_peer(Peer)}]),
+					Response = ar_mining_router:route_solution(Solution),
+					JSON = ar_serialize:solution_response_to_json_struct(Response),
+					{200, #{}, ar_serialize:jsonify(JSON), Req2}
+			end;
+		{error, body_size_too_large} ->
+			{413, #{}, <<"Payload too large">>, Req};
+		{error, timeout} ->
+			{500, #{}, <<"Handler timeout">>, Req}
+	end.
+
+handle_get_jobs2(PrevOutput, Req) ->
+    {ok, Config} = application:get_env(arweave, config),
+	CMExitNode = ar_coordination:is_exit_peer() andalso ar_pool:is_client(),
+	case {Config#config.is_pool_server, CMExitNode} of
+		{false, false} ->
+			{501, #{}, jiffy:encode(#{ error => configuration }), Req};
+		{true, _} ->
+			case check_internal_api_secret(Req) of
+				{reject, {Status, Headers, Body}} ->
+					{Status, Headers, Body, Req};
+				pass ->
+					Jobs = ar_pool:generate_jobs(PrevOutput),
+					JSON = ar_serialize:jsonify(ar_serialize:jobs_to_json_struct(Jobs)),
+					{200, #{}, JSON, Req}
+			end;
+		{_, true} ->
+			case check_cm_api_secret(Req) of
+				{reject, {Status, Headers, Body}} ->
+					{Status, Headers, Body, Req};
+				pass ->
+					Jobs = ar_pool:get_cached_jobs(PrevOutput),
+					JSON = ar_serialize:jsonify(ar_serialize:jobs_to_json_struct(Jobs)),
+					{200, #{}, JSON, Req}
+			end
+	end.
+
+validate_request(APISecret, Req) ->
+    SecretCheck = case APISecret of
+        pool ->
+            check_internal_api_secret(Req);
+        cm ->
+            check_cm_api_secret(Req);
+        _ ->
+            {501, #{}, jiffy:encode(#{ error => configuration }), Req}
+    end,
+    case SecretCheck of
+        pass ->
+            true;
+        {reject, {Status, Headers, Body}} ->
+            {Status, Headers, Body, Req};
+        _ ->
+            SecretCheck
+    end.

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -3260,8 +3260,8 @@ handle_mining_h2(Req, Pid) ->
 												Payload) end),
 									{200, #{}, <<>>, Req2};
 								_ ->
-									ar_mining_server:prepare_and_post_solution(Candidate),
 									ar_mining_stats:h2_received_from_peer(Peer),
+									ar_mining_router:prepare_solution(Candidate),
 									{200, #{}, <<>>, Req}
 							end
 					end;
@@ -3288,7 +3288,7 @@ handle_mining_cm_publish(Req, Pid) ->
 							?LOG_INFO("Block candidate ~p from ~p ~n", [
 								ar_util:encode(Solution#mining_solution.solution_hash),
 								ar_util:format_peer(Peer)]),
-							ar_mining_server:post_solution(Solution),
+							ar_mining_router:post_solution(Solution),
 							{200, #{}, <<>>, Req}
 					end;
 				{error, _} ->

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -3209,7 +3209,10 @@ handle_mining_h2(Req, Pid) ->
 									{200, #{}, <<>>, Req2};
 								_ ->
 									ar_mining_stats:h2_received_from_peer(Peer),
-									ar_mining_router:received_solution(Candidate, h2),
+									ar_mining_router:received_solution(Candidate, [
+										{peer, ar_util:format_peer(Peer)}
+									]),
+									%% xxx: prepare_solution, need response
 									ar_mining_router:prepare_solution(Candidate),
 									{200, #{}, <<>>, Req}
 							end

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -3288,7 +3288,7 @@ handle_mining_cm_publish(Req, Pid) ->
 							?LOG_INFO("Block candidate ~p from ~p ~n", [
 								ar_util:encode(Solution#mining_solution.solution_hash),
 								ar_util:format_peer(Peer)]),
-							ar_mining_router:post_solution(Solution),
+							ar_mining_router:route_solution(Solution),
 							{200, #{}, <<>>, Req}
 					end;
 				{error, _} ->

--- a/apps/arweave/src/ar_mining_router.erl
+++ b/apps/arweave/src/ar_mining_router.erl
@@ -233,24 +233,14 @@ route_solution(#config{ cm_exit_peer = not_set, is_pool_client = true }, Solutio
 	ar_pool:post_partial_solution(Solution);
 route_solution(#config{ cm_exit_peer = not_set, is_pool_client = false }, Solution, Ref) ->
 	ar_mining_server:validate_solution(Solution);
-route_solution(#config{ cm_exit_peer = ExitPeer, is_pool_client = true }, Solution, Ref) ->
+route_solution(#config{ cm_exit_peer = ExitPeer }, Solution, Ref) ->
 	case ar_http_iface_client:post_partial_solution(ExitPeer, Solution) of
 		{ok, _} ->
 			ok;
 		{error, Reason} ->
-			?LOG_WARNING([{event, found_partial_solution_but_failed_to_reach_exit_node},
-					{reason, io_lib:format("~p", [Reason])}]),
-			ar:console("We found a partial solution but failed to reach the exit node, "
-					"error: ~p.", [io_lib:format("~p", [Reason])])
-	end;
-route_solution(#config{ cm_exit_peer = ExitPeer, is_pool_client = false }, Solution, Ref) ->
-	case ar_http_iface_client:cm_publish_send(ExitPeer, Solution) of
-		{ok, _} ->
-			ok;
-		{error, Reason} ->
 			?LOG_WARNING([{event, solution_rejected},
-					{reason, failed_to_reach_exit_node},
-					{message, io_lib:format("~p", [Reason])}]),
+				{reason, failed_to_reach_exit_node},
+				{message, io_lib:format("~p", [Reason])}]),
 			ar:console("We found a solution but failed to reach the exit node, "
 					"error: ~p.", [io_lib:format("~p", [Reason])]),
 			ar_mining_stats:solution(rejected)

--- a/apps/arweave/src/ar_mining_router.erl
+++ b/apps/arweave/src/ar_mining_router.erl
@@ -2,7 +2,12 @@
 
 -behaviour(gen_server).
 
--export([start_link/0, prepare_solution/1, route_solution/1, route_h1/2, route_h2/1]).
+-export([start_link/0,
+	prepare_solution/1, route_solution/1,
+	found_solution/3, received_solution/2, received_solution/3,
+	reject_solution/3, reject_solution/4,
+	accept_solution/1, accept_solution/2, accept_block_solution/2, accept_block_solution/3,
+	route_h1/2, route_h2/1]).
 
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
@@ -13,6 +18,7 @@
 -include_lib("stdlib/include/ms_transform.hrl").
 
 -record(state, {
+	request_pid_by_ref = maps:new()
 }).
 
 %%%===================================================================
@@ -30,7 +36,116 @@ prepare_solution(Candidate) ->
 
 route_solution(Solution) ->
 	{ok, Config} = application:get_env(arweave, config),
-	route_solution(Config#config.cm_exit_peer, Config#config.is_pool_client, Solution).
+	gen_server:call(?MODULE, {route_solution, Config, Solution}).
+
+found_solution(#mining_candidate{} = Candidate, WhichHash, ExtraLogs) ->
+	#mining_candidate{
+		mining_address = MiningAddress,
+		nonce_limiter_output = NonceLimiterOutput,
+		seed = Seed, next_seed = NextSeed, 
+		start_interval_number = StartIntervalNumber, step_number = StepNumber } = Candidate,
+
+	{Hash, PartitionNumber} = case WhichHash of 
+		h1 ->
+			{Candidate#mining_candidate.h1, Candidate#mining_candidate.partition_number};
+		h2 ->
+			{Candidate#mining_candidate.h2, Candidate#mining_candidate.partition_number2}
+	end,
+	?LOG_INFO([
+		{event, solution_lifecycle},
+		{status, found},
+		{hash, ar_util:safe_encode(Hash)},
+		{mining_address, ar_util:safe_encode(MiningAddress)},
+		{partition, PartitionNumber},
+		{seed, Seed},
+		{next_seed, NextSeed},
+		{start_interval_number, StartIntervalNumber},
+		{step_number, StepNumber},
+		{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}] ++
+		ExtraLogs),		
+	ar_mining_stats:solution(found).
+
+received_solution(#mining_candidate{} = Candidate, WhichHash, ExtraLogs) ->
+	#mining_candidate{
+		mining_address = MiningAddress,
+		nonce_limiter_output = NonceLimiterOutput,
+		seed = Seed, next_seed = NextSeed, 
+		start_interval_number = StartIntervalNumber, step_number = StepNumber } = Candidate,
+
+	{Hash, PartitionNumber} = case WhichHash of 
+		h1 ->
+			{Candidate#mining_candidate.h1, Candidate#mining_candidate.partition_number};
+		h2 ->
+			{Candidate#mining_candidate.h2, Candidate#mining_candidate.partition_number2}
+	end,
+	received_solution(Hash, MiningAddress, PartitionNumber, Seed, NextSeed,
+		StartIntervalNumber, StepNumber, NonceLimiterOutput, ExtraLogs).
+
+received_solution(Solution, ExtraLogs) ->
+	#mining_solution{
+		mining_address = MiningAddress,
+		nonce_limiter_output = NonceLimiterOutput, partition_number = PartitionNumber,
+		solution_hash = H, seed = Seed, next_seed = NextSeed, 
+		start_interval_number = StartIntervalNumber, step_number = StepNumber } = Solution,
+	received_solution(H, MiningAddress, PartitionNumber, Seed, NextSeed, StartIntervalNumber,
+		StepNumber, NonceLimiterOutput, ExtraLogs).
+	
+reject_solution(Solution, Reason, ExtraLogs) ->
+	#mining_solution{
+		mining_address = MiningAddress,
+		nonce_limiter_output = NonceLimiterOutput, partition_number = PartitionNumber,
+		recall_byte1 = RecallByte1, recall_byte2 = RecallByte2,
+		solution_hash = H, seed = Seed, next_seed = NextSeed, 
+		start_interval_number = StartIntervalNumber, step_number = StepNumber } = Solution,
+	ar:console("WARNING: solution was rejected. Check logs for more details~n"),
+	?LOG_WARNING([
+		{event, solution_lifecycle},
+		{status, rejected},
+		{reason, Reason},
+		{hash, ar_util:safe_encode(H)},
+		{mining_address, ar_util:safe_encode(MiningAddress)},
+		{partition, PartitionNumber},
+		{recall_byte1, RecallByte1},
+		{recall_byte2, RecallByte2},
+		{seed, Seed},
+		{next_seed, NextSeed},
+		{start_interval_number, StartIntervalNumber},
+		{step_number, StepNumber},
+		{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}] ++
+		ExtraLogs),		
+	ar_mining_stats:solution(rejected).
+
+reject_solution(Solution, Reason, ExtraLogs, Ref) ->
+	reject_solution(Solution, Reason, ExtraLogs),
+	Status = iolist_to_binary([<<"rejected_">>, atom_to_binary(Reason)]),
+	gen_server:cast(?MODULE, {solution_response, Status, <<>>, Ref}).
+
+accept_solution(Solution) ->
+	#mining_solution{ mining_address = MiningAddress, solution_hash = H } = Solution,
+	?LOG_WARNING([
+		{event, solution_lifecycle},
+		{status, accepted},
+		{hash, ar_util:safe_encode(H)},
+		{mining_address, ar_util:safe_encode(MiningAddress)}]),		
+	ar_mining_stats:solution(accepted).
+
+accept_solution(Solution, Ref) ->
+	accept_solution(Solution),
+	gen_server:cast(?MODULE, {solution_response, <<"accepted">>, <<>>, Ref}).
+
+accept_block_solution(Solution, BlockH) ->
+	#mining_solution{ mining_address = MiningAddress, solution_hash = H } = Solution,
+	?LOG_WARNING([
+		{event, solution_lifecycle},
+		{status, accepted},
+		{hash, ar_util:safe_encode(H)},
+		{mining_address, ar_util:safe_encode(MiningAddress)},
+		{block_hash, ar_util:safe_encode(BlockH)}]),		
+	ar_mining_stats:solution(accepted).
+
+accept_block_solution(Solution, BlockH, Ref) ->
+	accept_block_solution(Solution, BlockH),
+	gen_server:cast(?MODULE, {solution_response, <<"accepted_block">>, BlockH, Ref}).
 
 route_h1(Candidate, DiffPair) ->
 	{ok, Config} = application:get_env(arweave, config),
@@ -53,10 +168,27 @@ route_h2(Candidate) ->
 init([]) ->
 	{ok, #state{}}.
 
+handle_call({route_solution, Config, Solution}, From, State) ->
+	#state{ request_pid_by_ref = Map } = State,
+	Ref = make_ref(),
+	case route_solution(Config, Solution, Ref) of
+		noreply ->
+			{noreply, State#state{ request_pid_by_ref = maps:put(Ref, From, Map) }};
+		Reply ->
+			{reply, Reply, State}
+	end;
+
 handle_call(Request, _From, State) ->
 	?LOG_WARNING([{event, unhandled_call}, {module, ?MODULE}, {request, Request}]),
 	{reply, ok, State}.
 
+handle_cast({solution_response, Status, BlockH, {pool, Ref}}, State) ->
+	#state{ request_pid_by_ref = Map } = State,
+	PID = maps:get(Ref, Map),
+	gen_server:reply(PID,
+			#solution_response{ indep_hash = BlockH, status = Status }),
+	{noreply, State#state{ request_pid_by_ref = maps:remove(Ref, Map) }};
+	
 handle_cast(Cast, State) ->
 	?LOG_WARNING([{event, unhandled_cast}, {module, ?MODULE}, {cast, Cast}]),
 	{noreply, State}.
@@ -72,13 +204,31 @@ terminate(_Reason, _State) ->
 %%% Private functions.
 %%%===================================================================
 
-route_solution(not_set, true, Solution) ->
+received_solution(Hash, MiningAddress, PartitionNumber, Seed, NextSeed,
+		StartIntervalNumber, StepNumber, NonceLimiterOutput, ExtraLogs) ->
+	?LOG_INFO([
+		{event, solution_lifecycle},
+		{status, received},
+		{hash, ar_util:safe_encode(Hash)},
+		{mining_address, ar_util:safe_encode(MiningAddress)},
+		{partition, PartitionNumber},
+		{seed, Seed},
+		{next_seed, NextSeed},
+		{start_interval_number, StartIntervalNumber},
+		{step_number, StepNumber},
+		{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}] ++
+		ExtraLogs),
+	ar_mining_stats:solution(received).
+
+route_solution(#config{ is_pool_server = true }, Solution, Ref) ->
+	ar_pool:process_partial_solution(Solution, Ref);
+route_solution(#config{ cm_exit_peer = not_set, is_pool_client = true }, Solution, Ref) ->
 	%% When posting a partial solution the pool client will skip many of the validation steps
 	%% that are normally performed before sharing a solution.
 	ar_pool:post_partial_solution(Solution);
-route_solution(not_set, _IsPoolClient, Solution) ->
+route_solution(#config{ cm_exit_peer = not_set, is_pool_client = false }, Solution, Ref) ->
 	ar_mining_server:validate_solution(Solution);
-route_solution(ExitPeer, true, Solution) ->
+route_solution(#config{ cm_exit_peer = ExitPeer, is_pool_client = true }, Solution, Ref) ->
 	case ar_http_iface_client:post_partial_solution(ExitPeer, Solution) of
 		{ok, _} ->
 			ok;
@@ -88,7 +238,7 @@ route_solution(ExitPeer, true, Solution) ->
 			ar:console("We found a partial solution but failed to reach the exit node, "
 					"error: ~p.", [io_lib:format("~p", [Reason])])
 	end;
-route_solution(ExitPeer, _IsPoolClient, Solution) ->
+route_solution(#config{ cm_exit_peer = ExitPeer, is_pool_client = false }, Solution, Ref) ->
 	case ar_http_iface_client:cm_publish_send(ExitPeer, Solution) of
 		{ok, _} ->
 			ok;

--- a/apps/arweave/src/ar_mining_router.erl
+++ b/apps/arweave/src/ar_mining_router.erl
@@ -1,0 +1,88 @@
+-module(ar_mining_router).
+
+-behaviour(gen_server).
+
+-export([start_link/0, prepare_solution/1, post_solution/1]).
+
+-export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
+
+-include_lib("arweave/include/ar.hrl").
+-include_lib("arweave/include/ar_config.hrl").
+-include_lib("arweave/include/ar_mining.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-record(state, {
+}).
+
+%%%===================================================================
+%%% Public interface.
+%%%===================================================================
+
+%% @doc Start the gen_server.
+start_link() ->
+	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+	
+prepare_solution(Candidate) ->
+	%% A pool client does not validate VDF before sharing a solution.
+	{ok, Config} = application:get_env(arweave, config),
+	ar_mining_server:prepare_solution(Candidate, Config#config.is_pool_client).
+
+post_solution(Solution) ->
+	{ok, Config} = application:get_env(arweave, config),
+	post_solution(Config#config.cm_exit_peer, Config#config.is_pool_client, Solution).
+
+%%%===================================================================
+%%% Generic server callbacks.
+%%%===================================================================
+
+init([]) ->
+	{ok, #state{}}.
+
+handle_call(Request, _From, State) ->
+	?LOG_WARNING([{event, unhandled_call}, {module, ?MODULE}, {request, Request}]),
+	{reply, ok, State}.
+
+handle_cast(Cast, State) ->
+	?LOG_WARNING([{event, unhandled_cast}, {module, ?MODULE}, {cast, Cast}]),
+	{noreply, State}.
+
+handle_info(Message, State) ->
+	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
+	{noreply, State}.
+
+terminate(_Reason, _State) ->
+	ok.
+
+%%%===================================================================
+%%% Private functions.
+%%%===================================================================
+
+post_solution(not_set, true, Solution) ->
+	%% When posting a partial solution the pool client will skip many of the validation steps
+	%% that are normally performed before sharing a solution.
+	ar_pool:post_partial_solution(Solution);
+post_solution(not_set, _IsPoolClient, Solution) ->
+	ar_mining_server:validate_solution(Solution);
+post_solution(ExitPeer, true, Solution) ->
+	case ar_http_iface_client:post_partial_solution(ExitPeer, Solution) of
+		{ok, _} ->
+			ok;
+		{error, Reason} ->
+			?LOG_WARNING([{event, found_partial_solution_but_failed_to_reach_exit_node},
+					{reason, io_lib:format("~p", [Reason])}]),
+			ar:console("We found a partial solution but failed to reach the exit node, "
+					"error: ~p.", [io_lib:format("~p", [Reason])])
+	end;
+post_solution(ExitPeer, _IsPoolClient, Solution) ->
+	case ar_http_iface_client:cm_publish_send(ExitPeer, Solution) of
+		{ok, _} ->
+			ok;
+		{error, Reason} ->
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, failed_to_reach_exit_node},
+					{message, io_lib:format("~p", [Reason])}]),
+			ar:console("We found a solution but failed to reach the exit node, "
+					"error: ~p.", [io_lib:format("~p", [Reason])]),
+			ar_mining_stats:solution(rejected)
+	end.

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -518,6 +518,7 @@ prepare_solution_steps(Candidate, Solution) ->
 				not_found ->
 					ar_mining_router:reject_solution(Solution, failed_to_find_checkpoints,
 						[{prev_next_seed, ar_util:safe_encode(PrevNextSeed)},
+						 {prev_next_vdf_difficulty, PrevNextVDFDifficulty},
 						 {prev_step_number, PrevStepNumber}]),
 					error;
 				_ ->
@@ -527,6 +528,7 @@ prepare_solution_steps(Candidate, Solution) ->
 		false ->
 			ar_mining_router:reject_solution(Solution, stale_step_number,
 						[{prev_next_seed, ar_util:safe_encode(PrevNextSeed)},
+						 {prev_next_vdf_difficulty, PrevNextVDFDifficulty},
 						 {prev_step_number, PrevStepNumber}]),
 			error
 	end.

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -4,9 +4,9 @@
 -behaviour(gen_server).
 
 -export([start_link/0, start_mining/1, set_difficulty/1, set_merkle_rebase_threshold/1, 
-		compute_h2_for_peer/1, prepare_and_post_solution/1, post_solution/1, read_poa/3,
-		get_recall_bytes/4, active_sessions/0, encode_sessions/1, add_pool_job/6,
-		is_one_chunk_solution/1]).
+		prepare_solution/2, validate_solution/1,
+		compute_h2_for_peer/1, read_poa/3, get_recall_bytes/4, active_sessions/0,
+		encode_sessions/1, add_pool_job/6, is_one_chunk_solution/1]).
 -export([pause/0]).
 
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
@@ -28,8 +28,7 @@
 	chunk_cache_limit 			= 0,
 	gc_frequency_ms				= undefined,
 	gc_process_ref				= undefined,
-	merkle_rebase_threshold		= infinity,
-	is_pool_client				= false
+	merkle_rebase_threshold		= infinity
 }).
 
 -define(FETCH_POA_FROM_PEERS_TIMEOUT_MS, 10000).
@@ -66,12 +65,6 @@ add_pool_job(SessionKey, StepNumber, Output, PartitionUpperBound, Seed, PartialD
 	Args = {SessionKey, StepNumber, Output, PartitionUpperBound, Seed, PartialDiff},
 	gen_server:cast(?MODULE, {add_pool_job, Args}).
 
-prepare_and_post_solution(Candidate) ->
-	gen_server:cast(?MODULE, {prepare_and_post_solution, Candidate}).
-
-post_solution(Solution) ->
-	gen_server:cast(?MODULE, {post_solution, Solution}).
-
 active_sessions() ->
 	gen_server:call(?MODULE, active_sessions).
 
@@ -82,6 +75,12 @@ encode_sessions(Sessions) ->
 
 is_one_chunk_solution(Solution) ->
 	Solution#mining_solution.recall_byte2 == undefined.
+
+prepare_solution(Candidate, SkipVDF) ->
+	gen_server:cast(?MODULE, {prepare_solution, Candidate, SkipVDF}).
+
+validate_solution(Solution) ->
+	gen_server:cast(?MODULE, {validate_solution, Solution}).
 
 %%%===================================================================
 %%% Generic server callbacks.
@@ -102,8 +101,7 @@ init([]) ->
 	),
 
 	{ok, #state{
-		workers = Workers,
-		is_pool_client = ar_pool:is_client()
+		workers = Workers
 	}}.
 
 handle_call(active_sessions, _From, State) ->
@@ -165,14 +163,6 @@ handle_cast({compute_h2_for_peer, Candidate}, State) ->
 	end,
 	{noreply, State};
 
-handle_cast({prepare_and_post_solution, Candidate}, State) ->
-	prepare_and_post_solution(Candidate, State),
-	{noreply, State};
-
-handle_cast({post_solution, Solution}, State) ->
-	post_solution(Solution, State),
-	{noreply, State};
-
 handle_cast({manual_garbage_collect, Ref}, #state{ gc_process_ref = Ref } = State) ->
 	%% Reading recall ranges from disk causes a large amount of binary data to be allocated and
 	%% references to that data is spread among all the different mining processes. Because of this
@@ -198,6 +188,81 @@ handle_cast({manual_garbage_collect, Ref}, #state{ gc_process_ref = Ref } = Stat
 	{noreply, State};
 handle_cast({manual_garbage_collect, _}, State) ->
 	%% Does not originate from the running instance of the server; happens in tests.
+	{noreply, State};
+
+handle_cast({prepare_solution, Candidate, SkipVDF}, State) ->
+	#mining_candidate{
+		mining_address = MiningAddress, next_seed = NextSeed, 
+		next_vdf_difficulty = NextVDFDifficulty, nonce = Nonce,
+		nonce_limiter_output = NonceLimiterOutput, partition_number = PartitionNumber,
+		partition_upper_bound = PartitionUpperBound, poa2 = PoA2, preimage = Preimage,
+		seed = Seed, start_interval_number = StartIntervalNumber, step_number = StepNumber
+	} = Candidate,
+	
+	Solution = #mining_solution{
+		mining_address = MiningAddress,
+		next_seed = NextSeed,
+		next_vdf_difficulty = NextVDFDifficulty,
+		nonce = Nonce,
+		nonce_limiter_output = NonceLimiterOutput,
+		partition_number = PartitionNumber,
+		partition_upper_bound = PartitionUpperBound,
+		poa2 = PoA2,
+		preimage = Preimage,
+		seed = Seed,
+		start_interval_number = StartIntervalNumber,
+		step_number = StepNumber
+	},
+	
+	Solution2 = case SkipVDF of
+		true ->
+			prepare_solution_proofs(Candidate, Solution);
+		false ->
+			prepare_solution_last_step_checkpoints(Candidate, Solution)
+	end,
+	case Solution2 of
+		error -> ok;
+		_ -> ar_mining_router:post_solution(Solution2)
+	end,
+	{noreply, State};
+
+handle_cast({validate_solution, Solution}, State) ->
+	#state{ diff_pair = DiffPair } = State,
+	#mining_solution{
+		mining_address = MiningAddress,
+		nonce_limiter_output = NonceLimiterOutput, partition_number = PartitionNumber,
+		recall_byte1 = RecallByte1, recall_byte2 = RecallByte2,
+		solution_hash = H, step_number = StepNumber } = Solution,
+	case validate_solution(Solution, DiffPair) of
+		error ->
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, failed_to_validate_solution},
+					{partition, PartitionNumber},
+					{step_number, StepNumber},
+					{mining_address, ar_util:safe_encode(MiningAddress)},
+					{recall_byte1, RecallByte1},
+					{recall_byte2, RecallByte2},
+					{solution_h, ar_util:safe_encode(H)},
+					{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}]),
+			ar:console("WARNING: we failed to validate our solution. Check logs for more "
+					"details~n"),
+			ar_mining_stats:solution(rejected);
+		{false, Reason} ->
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, Reason},
+					{partition, PartitionNumber},
+					{step_number, StepNumber},
+					{mining_address, ar_util:safe_encode(MiningAddress)},
+					{recall_byte1, RecallByte1},
+					{recall_byte2, RecallByte2},
+					{solution_h, ar_util:safe_encode(H)},
+					{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}]),
+			ar:console("WARNING: the solution we found is invalid. Check logs for more "
+					"details~n"),
+			ar_mining_stats:solution(rejected);
+		{true, PoACache, PoA2Cache} ->
+			ar_events:send(miner, {found_solution, miner, Solution, PoACache, PoA2Cache})
+	end,
 	{noreply, State};
 
 handle_cast(Cast, State) ->
@@ -449,44 +514,7 @@ get_recall_bytes(H0, PartitionNumber, Nonce, PartitionUpperBound) ->
 	RelativeOffset = Nonce * (?DATA_CHUNK_SIZE),
 	{RecallRange1Start + RelativeOffset, RecallRange2Start + RelativeOffset}.
 
-prepare_and_post_solution(Candidate, State) ->
-	Solution = prepare_solution(Candidate, State),
-	post_solution(Solution, State).
-
-prepare_solution(Candidate, State) ->
-	#state{ merkle_rebase_threshold = RebaseThreshold, is_pool_client = IsPoolClient } = State,
-	#mining_candidate{
-		mining_address = MiningAddress, next_seed = NextSeed, 
-		next_vdf_difficulty = NextVDFDifficulty, nonce = Nonce,
-		nonce_limiter_output = NonceLimiterOutput, partition_number = PartitionNumber,
-		partition_upper_bound = PartitionUpperBound, poa2 = PoA2, preimage = Preimage,
-		seed = Seed, start_interval_number = StartIntervalNumber, step_number = StepNumber
-	} = Candidate,
-	
-	Solution = #mining_solution{
-		mining_address = MiningAddress,
-		merkle_rebase_threshold = RebaseThreshold,
-		next_seed = NextSeed,
-		next_vdf_difficulty = NextVDFDifficulty,
-		nonce = Nonce,
-		nonce_limiter_output = NonceLimiterOutput,
-		partition_number = PartitionNumber,
-		partition_upper_bound = PartitionUpperBound,
-		poa2 = PoA2,
-		preimage = Preimage,
-		seed = Seed,
-		start_interval_number = StartIntervalNumber,
-		step_number = StepNumber
-	},
-	%% A pool client does not validate VDF before sharing a solution.
-	case IsPoolClient of
-		true ->
-			prepare_solution(proofs, Candidate, Solution);
-		false ->
-			prepare_solution(last_step_checkpoints, Candidate, Solution)
-	end.
-
-prepare_solution(last_step_checkpoints, Candidate, Solution) ->
+prepare_solution_last_step_checkpoints(Candidate, Solution) ->
 	#mining_candidate{
 		next_seed = NextSeed, next_vdf_difficulty = NextVDFDifficulty, 
 		start_interval_number = StartIntervalNumber, step_number = StepNumber } = Candidate,
@@ -501,10 +529,10 @@ prepare_solution(last_step_checkpoints, Candidate, Solution) ->
 			_ ->
 				LastStepCheckpoints
 		end,
-	prepare_solution(steps, Candidate, Solution#mining_solution{
-			last_step_checkpoints = LastStepCheckpoints2 });
+	prepare_solution_steps(Candidate, Solution#mining_solution{
+			last_step_checkpoints = LastStepCheckpoints2 }).
 
-prepare_solution(steps, Candidate, Solution) ->
+prepare_solution_steps(Candidate, Solution) ->
 	#mining_candidate{ step_number = StepNumber } = Candidate,
 	[{_, TipNonceLimiterInfo}] = ets:lookup(node_state, nonce_limiter_info),
 	#nonce_limiter_info{ global_step_number = PrevStepNumber, next_seed = PrevNextSeed,
@@ -515,7 +543,8 @@ prepare_solution(steps, Candidate, Solution) ->
 					PrevStepNumber, StepNumber, PrevNextSeed, PrevNextVDFDifficulty),
 			case Steps of
 				not_found ->
-					?LOG_WARNING([{event, found_solution_but_failed_to_find_checkpoints},
+					?LOG_WARNING([{event, solution_rejected},
+							{reason, failed_to_find_checkpoints},
 							{start_step_number, PrevStepNumber},
 							{next_step_number, StepNumber},
 							{next_seed, ar_util:safe_encode(PrevNextSeed)},
@@ -523,21 +552,24 @@ prepare_solution(steps, Candidate, Solution) ->
 					ar:console("WARNING: found a solution but failed to find checkpoints, "
 							"start step number: ~B, end step number: ~B, next_seed: ~s.",
 							[PrevStepNumber, StepNumber, PrevNextSeed]),
+					ar_mining_stats:solution(rejected),
 					error;
 				_ ->
-					prepare_solution(proofs, Candidate,
+					prepare_solution_proofs(Candidate,
 							Solution#mining_solution{ steps = Steps })
 			end;
 		false ->
-			?LOG_WARNING([{event, found_solution_but_stale_step_number},
-							{start_step_number, PrevStepNumber},
-							{next_step_number, StepNumber},
-							{next_seed, ar_util:safe_encode(PrevNextSeed)},
-							{next_vdf_difficulty, PrevNextVDFDifficulty}]),
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, stale_step_number},
+					{start_step_number, PrevStepNumber},
+					{next_step_number, StepNumber},
+					{next_seed, ar_util:safe_encode(PrevNextSeed)},
+					{next_vdf_difficulty, PrevNextVDFDifficulty}]),
+			ar_mining_stats:solution(rejected),
 			error
-	end;
+	end.
 
-prepare_solution(proofs, Candidate, Solution) ->
+prepare_solution_proofs(Candidate, Solution) ->
 	#mining_candidate{
 		h0 = H0, h1 = H1, h2 = H2, nonce = Nonce, partition_number = PartitionNumber,
 		partition_upper_bound = PartitionUpperBound } = Candidate,
@@ -546,19 +578,21 @@ prepare_solution(proofs, Candidate, Solution) ->
 			PartitionUpperBound),
 	case { H1, H2 } of
 		{not_set, not_set} ->
-			?LOG_WARNING([{event, found_solution_but_h1_h2_not_set}]),
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, h1_h2_not_set}]),
+			ar_mining_stats:solution(rejected),
 			error;
 		{H1, not_set} ->
-			prepare_solution(poa1, Candidate, Solution#mining_solution{
+			prepare_solution_poa1(Candidate, Solution#mining_solution{
 				solution_hash = H1, recall_byte1 = RecallByte1,
 				poa1 = may_be_empty_poa(PoA1), poa2 = #poa{} });
 		{_, H2} ->
-			prepare_solution(poa2, Candidate, Solution#mining_solution{
+			prepare_solution_poa2(Candidate, Solution#mining_solution{
 				solution_hash = H2, recall_byte1 = RecallByte1, recall_byte2 = RecallByte2,
 				poa1 = may_be_empty_poa(PoA1), poa2 = may_be_empty_poa(PoA2) })
-	end;
+	end.
 
-prepare_solution(poa1, Candidate,
+prepare_solution_poa1(Candidate,
 		#mining_solution{ poa1 = #poa{ chunk = <<>> } } = Solution) ->
 	#mining_solution{
 		mining_address = MiningAddress, partition_number = PartitionNumber,
@@ -582,7 +616,8 @@ prepare_solution(poa1, Candidate,
 				not_found ->
 					{RecallRange1Start, _RecallRange2Start} = ar_block:get_recall_range(H0,
 							PartitionNumber, PartitionUpperBound),
-					?LOG_WARNING([{event, mined_block_but_failed_to_read_chunk_proofs},
+					?LOG_WARNING([{event, solution_rejected},
+							{reason, failed_to_read_chunk_proofs},
 							{recall_byte1, RecallByte1},
 							{recall_range_start1, RecallRange1Start},
 							{nonce, Nonce},
@@ -591,21 +626,22 @@ prepare_solution(poa1, Candidate,
 					ar:console("WARNING: we have mined a block but failed to find "
 							"the PoA1 proofs required for publishing it. "
 							"Check logs for more details~n"),
+					ar_mining_stats:solution(rejected),
 					error;
 				PoA1 ->
 					Solution#mining_solution{ poa1 = PoA1#poa{ chunk = Chunk1 } }
 			end
-	end;
-prepare_solution(poa2, Candidate,
+	end.
+prepare_solution_poa2(Candidate,
 		#mining_solution{ poa2 = #poa{ chunk = <<>> } } = Solution) ->
-	#mining_solution{ mining_address = MiningAddress, partition_number = PartitionNumber,
-		recall_byte2 = RecallByte2 } = Solution,
+	#mining_solution{ mining_address = MiningAddress,
+		partition_number = PartitionNumber, recall_byte2 = RecallByte2 } = Solution,
 	#mining_candidate{
 		chunk2 = Chunk2, h0 = H0, nonce = Nonce,
 		partition_upper_bound = PartitionUpperBound } = Candidate,
 	case read_poa(RecallByte2, Chunk2, MiningAddress) of
 		{ok, PoA2} ->
-			prepare_solution(poa1, Candidate, Solution#mining_solution{ poa2 = PoA2 });
+			prepare_solution_poa1(Candidate, Solution#mining_solution{ poa2 = PoA2 });
 		_ ->
 			Modules = ar_storage_module:get_all(RecallByte2 + 1),
 			ModuleIDs = [ar_storage_module:id(Module) || Module <- Modules],
@@ -619,7 +655,8 @@ prepare_solution(poa2, Candidate,
 				not_found ->
 					{_RecallRange1Start, RecallRange2Start} = ar_block:get_recall_range(H0,
 							PartitionNumber, PartitionUpperBound),
-					?LOG_ERROR([{event, mined_block_but_failed_to_read_chunk_proofs},
+					?LOG_ERROR([{event, solution_rejected},
+							{reason, failed_to_read_chunk_proofs},
 							{tags, [solution_proofs]},
 							{recall_byte2, RecallByte2},
 							{recall_range_start2, RecallRange2Start},
@@ -629,83 +666,16 @@ prepare_solution(poa2, Candidate,
 					ar:console("WARNING: we have mined a block but failed to find "
 							"the PoA2 proofs required for publishing it. "
 							"Check logs for more details~n"),
+					ar_mining_stats:solution(rejected),
 					error;
 				PoA2 ->
-					prepare_solution(poa1, Candidate,
+					prepare_solution_poa1(Candidate,
 							Solution#mining_solution{ poa2 = PoA2#poa{ chunk = Chunk2 } })
 			end
 	end;
-prepare_solution(poa2, Candidate,
+prepare_solution_poa2(Candidate,
 		#mining_solution{ poa1 = #poa{ chunk = <<>> } } = Solution) ->
-	prepare_solution(poa1, Candidate, Solution);
-prepare_solution(_, _Candidate, Solution) ->
-	Solution.
-
-post_solution(error, _State) ->
-	?LOG_WARNING([{event, found_solution_but_could_not_build_a_block}]),
-	error;
-post_solution(Solution, State) ->
-	{ok, Config} = application:get_env(arweave, config),
-	post_solution(Config#config.cm_exit_peer, Solution, State).
-
-post_solution(not_set, Solution, #state{ is_pool_client = true }) ->
-	%% When posting a partial solution the pool client will skip many of the validation steps
-	%% that are normally performed before sharing a solution.
-	ar_pool:post_partial_solution(Solution);
-post_solution(not_set, Solution, State) ->
-	#state{ diff_pair = DiffPair } = State,
-	#mining_solution{
-		mining_address = MiningAddress, nonce_limiter_output = NonceLimiterOutput,
-		partition_number = PartitionNumber, recall_byte1 = RecallByte1,
-		recall_byte2 = RecallByte2,
-		solution_hash = H, step_number = StepNumber } = Solution,
-	case validate_solution(Solution, DiffPair) of
-		error ->
-			?LOG_WARNING([{event, failed_to_validate_solution},
-					{partition, PartitionNumber},
-					{step_number, StepNumber},
-					{mining_address, ar_util:safe_encode(MiningAddress)},
-					{recall_byte1, RecallByte1},
-					{recall_byte2, RecallByte2},
-					{solution_h, ar_util:safe_encode(H)},
-					{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}]),
-			ar:console("WARNING: we failed to validate our solution. Check logs for more "
-					"details~n");
-		{false, Reason} ->
-			?LOG_WARNING([{event, found_invalid_solution},
-					{reason, Reason},
-					{partition, PartitionNumber},
-					{step_number, StepNumber},
-					{mining_address, ar_util:safe_encode(MiningAddress)},
-					{recall_byte1, RecallByte1},
-					{recall_byte2, RecallByte2},
-					{solution_h, ar_util:safe_encode(H)},
-					{nonce_limiter_output, ar_util:safe_encode(NonceLimiterOutput)}]),
-			ar:console("WARNING: the solution we found is invalid. Check logs for more "
-					"details~n");
-		{true, PoACache, PoA2Cache} ->
-			ar_events:send(miner, {found_solution, miner, Solution, PoACache, PoA2Cache})
-	end;
-post_solution(ExitPeer, Solution, #state{ is_pool_client = true }) ->
-	case ar_http_iface_client:post_partial_solution(ExitPeer, Solution) of
-		{ok, _} ->
-			ok;
-		{error, Reason} ->
-			?LOG_WARNING([{event, found_partial_solution_but_failed_to_reach_exit_node},
-					{reason, io_lib:format("~p", [Reason])}]),
-			ar:console("We found a partial solution but failed to reach the exit node, "
-					"error: ~p.", [io_lib:format("~p", [Reason])])
-	end;
-post_solution(ExitPeer, Solution, _State) ->
-	case ar_http_iface_client:cm_publish_send(ExitPeer, Solution) of
-		{ok, _} ->
-			ok;
-		{error, Reason} ->
-			?LOG_WARNING([{event, found_solution_but_failed_to_reach_exit_node},
-					{reason, io_lib:format("~p", [Reason])}]),
-			ar:console("We found a solution but failed to reach the exit node, "
-					"error: ~p.", [io_lib:format("~p", [Reason])])
-	end.
+	prepare_solution_poa1(Candidate, Solution).
 
 may_be_empty_poa(not_set) ->
 	#poa{};

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -121,6 +121,8 @@ h2_computed(PartitionNumber) ->
 	increment_count({partition, PartitionNumber, h2, total}),
 	increment_count({partition, PartitionNumber, h2, current}).
 
+h1_sent_to_peer({pool, _}, H1Count) ->
+	h1_sent_to_peer(pool, H1Count);
 h1_sent_to_peer(Peer, H1Count) ->
 	increment_count({peer, Peer, h1_to_peer, total}, H1Count),
 	increment_count({peer, Peer, h1_to_peer, current}, H1Count).
@@ -129,6 +131,8 @@ h1_received_from_peer(Peer, H1Count) ->
 	increment_count({peer, Peer, h1_from_peer, total}, H1Count),
 	increment_count({peer, Peer, h1_from_peer, current}, H1Count).
 
+h2_sent_to_peer({pool, _}) ->
+	h2_sent_to_peer(pool);
 h2_sent_to_peer(Peer) ->
 	increment_count({peer, Peer, h2_to_peer, total}).
 

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -4,7 +4,7 @@
 -export([start_link/0, start_performance_reports/0, pause_performance_reports/1, mining_paused/0,
 		set_total_data_size/1, set_storage_module_data_size/6,
 		vdf_computed/0, raw_read_rate/2, chunk_read/1, h1_computed/1, h2_computed/1,
-		h1_solution/0, h2_solution/0, block_found/0,
+		solution/1, block_found/0,
 		h1_sent_to_peer/2, h1_received_from_peer/2, h2_sent_to_peer/1, h2_received_from_peer/1]).
 
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
@@ -22,8 +22,8 @@
 -record(report, {
 	now,
 	vdf_speed = undefined,
-	h1_solution = 0,
-	h2_solution = 0,
+	solutions = #{},
+	blocks = #{},
 	confirmed_block = 0,
 	total_data_size = 0,
 	optimal_overall_read_mibps = 0.0,
@@ -135,11 +135,8 @@ h2_sent_to_peer(Peer) ->
 h2_received_from_peer(Peer) ->
 	increment_count({peer, Peer, h2_from_peer, total}).
 
-h1_solution() ->
-	increment_count(h1_solution).
-
-h2_solution() ->
-	increment_count(h2_solution).
+solution(Status) ->
+	increment_count({solution, Status}).
 
 block_found() ->
 	increment_count(confirmed_block).
@@ -365,6 +362,12 @@ optimal_partition_hash_hps(PoA1Multiplier, VDFSpeed, PartitionDataSize, TotalDat
 	H2Optimal = BasePartitionHashes * min(1.0, (TotalDataSize / WeaveSize)),
 	H1Optimal + H2Optimal.
 
+get_solutions() ->
+	#{
+		found => get_count({solution, found}),
+		rejected => get_count({solution, rejected})
+	}.
+
 generate_report() ->
 	{ok, Config} = application:get_env(arweave, config),
 	Height = ar_node:get_height(),
@@ -387,8 +390,7 @@ generate_report(Height, Partitions, Peers, WeaveSize, Now) ->
 	Report = #report{
 		now = Now,
 		vdf_speed = VDFSpeed,
-		h1_solution = get_count(h1_solution),
-		h2_solution = get_count(h2_solution),
+		solutions = get_solutions(),
 		confirmed_block = get_count(confirmed_block),
 		total_data_size = TotalDataSize,
 		total_h2_to_peer = get_overall_total(peer, h2_to_peer, total),
@@ -509,7 +511,7 @@ log_report(ReportString) ->
 log_report_lines([]) ->
 	ok;
 log_report_lines([Line | Lines]) ->
-	?LOG_INFO(Line),
+	?LOG_ERROR(Line),
 	log_report_lines(Lines).
 
 set_metrics(Report) ->
@@ -590,12 +592,9 @@ format_report(Report, WeaveSize) ->
 		"================================================= Mining Performance Report =================================================\n"
 		"\n"
 		"VDF Speed:       ~s\n"
-		"H1 Solutions:     ~B\n"
-		"H2 Solutions:     ~B\n"
 		"Confirmed Blocks: ~B\n"
 		"\n",
-		[format_vdf_speed(Report#report.vdf_speed), Report#report.h1_solution,
-			Report#report.h2_solution, Report#report.confirmed_block]
+		[format_vdf_speed(Report#report.vdf_speed), Report#report.confirmed_block]
 	),
 	PartitionTable = format_partition_report(Report, WeaveSize),
 	PeerTable = format_peer_report(Report),
@@ -603,16 +602,36 @@ format_report(Report, WeaveSize) ->
     io_lib:format("\n~s~s~s", [Preamble, PartitionTable, PeerTable]).
 
 format_partition_report(Report, WeaveSize) ->
-	Header = 
+	BlocksHeader =
+		"Solution and block stats:\n"
+		"+--------------+-----------------+------------------+-----------------+----------------+------------------+\n"
+		"| Sol'ns Found | Sol'ns Rejected | Blocks Published | Blocks Orphaned | Blocks Rebased | Blocks Confirmed |\n"
+		"+--------------+-----------------+------------------+-----------------+----------------+------------------+\n",
+	BlocksRow = format_blocks_row(Report),
+	BlocksFooter =
+		"+--------------+-----------------+-----------------+-----------------+-----------------+------------------+\n\n",
+	MiningHeader =
 		"Local mining stats:\n"
 		"+-----------+-----------+----------+---------------+---------------+---------------+------------+------------+--------------+\n"
         "| Partition | Data Size | % of Max |   Read (Cur)  |   Read (Avg)  |  Read (Ideal) | Hash (Cur) | Hash (Avg) | Hash (Ideal) |\n"
 		"+-----------+-----------+----------+---------------+---------------+---------------+------------+------------+--------------+\n",
 	TotalRow = format_partition_total_row(Report, WeaveSize),
 	PartitionRows = format_partition_rows(Report#report.partitions),
-    Footer =
+    MiningFooter =
 		"+-----------+-----------+----------+---------------+---------------+---------------+------------+------------+--------------+\n",
-	io_lib:format("~s~s~s~s", [Header, TotalRow, PartitionRows, Footer]).
+	io_lib:format("~s~s~s~s~s~s~s",
+			[BlocksHeader, BlocksRow, BlocksFooter, MiningHeader, TotalRow, PartitionRows, MiningFooter]).
+
+
+format_blocks_row(Report) ->
+	Found = maps:get(found, Report#report.solutions, 0),
+	Rejected = maps:get(rejected, Report#report.solutions, 0),
+	Published = maps:get(published, Report#report.blocks, 0),
+	Orphaned = maps:get(orphaned, Report#report.blocks, 0),
+	Rebased = maps:get(rebased, Report#report.blocks, 0),
+	Confirmed = maps:get(confirmed, Report#report.blocks, 0),
+	io_lib:format("| ~12B | ~15B | ~16B | ~15B | ~14B | ~16B |\n",
+		[Found, Rejected, Published, Orphaned, Rebased, Confirmed]).
 
 format_partition_total_row(Report, WeaveSize) ->
 	#report{
@@ -1245,9 +1264,10 @@ test_report(PoA1Multiplier) ->
 	ar_mining_stats:vdf_computed(),
 	ar_mining_stats:vdf_computed(),
 	ar_mining_stats:vdf_computed(),
-	ar_mining_stats:h1_solution(),
-	ar_mining_stats:h2_solution(),
-	ar_mining_stats:h2_solution(),
+	ar_mining_stats:solution(found),
+	ar_mining_stats:solution(found),
+	ar_mining_stats:solution(found),
+	ar_mining_stats:solution(rejected),
 	ar_mining_stats:block_found(),
 	ar_mining_stats:chunk_read(1),
 	ar_mining_stats:chunk_read(1),
@@ -1303,8 +1323,10 @@ test_report(PoA1Multiplier) ->
 	?assertEqual(#report{ 
 		now = Now+1000,
 		vdf_speed = 1.0 / 3.0,
-		h1_solution = 1,
-		h2_solution = 2,
+		solutions = #{
+			found => 3,
+			rejected => 1
+		},
 		confirmed_block = 1,
 		total_data_size = floor(0.6 * ?PARTITION_SIZE),
 		optimal_overall_read_mibps = 190.7998163223283,

--- a/apps/arweave/src/ar_mining_sup.erl
+++ b/apps/arweave/src/ar_mining_sup.erl
@@ -32,6 +32,7 @@ init([]) ->
 		ar_mining_io:get_partitions(infinity)
 	),
 	Children = MiningWorkers ++ [
+		?CHILD(ar_mining_router, worker),
 		?CHILD(ar_mining_server, worker),
 		?CHILD(ar_mining_hash, worker),
 		?CHILD(ar_mining_io, worker),

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -358,8 +358,9 @@ handle_task({computed_h1, Candidate}, State) ->
 	case DiffCheck of
 		false -> ok;
 		_ ->
-			ar_mining_router:found_solution(Candidate, h1,
+			ar_mining_router:found_solution(Candidate,
 				[{worker, State#state.name}, {difficulty, DiffPair}]),
+			%% xxx: prepare_solution, non-blocking, no-response
 			ar_mining_router:prepare_solution(Candidate)
 	end,
 
@@ -392,7 +393,7 @@ handle_task({computed_h2, Candidate}, State) ->
 	case DiffCheck of
 		false -> ok;
 		_ ->
-			ar_mining_router:found_solution(Candidate, h2,
+			ar_mining_router:found_solution(Candidate,
 				[{worker, State#state.name}, {difficulty, DiffPair}]),
 			ar_mining_router:route_h2(Candidate)
 	end,

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -8,7 +8,6 @@
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 
 -include_lib("arweave/include/ar.hrl").
--include_lib("arweave/include/ar_config.hrl").
 -include_lib("arweave/include/ar_consensus.hrl").
 -include_lib("arweave/include/ar_mining.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -355,24 +355,25 @@ handle_task({computed_h0, Candidate}, State) ->
 
 handle_task({computed_h1, Candidate}, State) ->
 	#mining_candidate{ h1 = H1, chunk1 = Chunk1, session_key = SessionKey } = Candidate,
-	case h1_passes_diff_checks(H1, Candidate, State) of
-		true ->
-			?LOG_INFO([{event, found_h1_solution}, {worker, State#state.name},
-				{h1, ar_util:encode(H1)}, {difficulty, get_difficulty(State, Candidate)}]),
-			ar_mining_stats:h1_solution(),
+	DiffCheck = h1_passes_diff_checks(H1, Candidate, State),
+	case DiffCheck of
+		false -> ok;
+		_ ->
+			?LOG_INFO([{event, solution_found}, {worker, State#state.name},
+				{h1, ar_util:encode(H1)},
+				{difficulty, get_difficulty(State, Candidate)},
+				{partial_difficulty, get_partial_difficulty(State, Candidate)}]),
+			ar_mining_stats:solution(found),
+			ar_mining_router:prepare_solution(Candidate)
+	end,
+	case DiffCheck of
+		network ->
 			%% Decrement 1 for chunk1:
 			%% Since we found a solution we won't need chunk2 (and it will be evicted if
 			%% necessary below)
 			State2 = remove_chunk_from_cache(Candidate, State),
-			ar_mining_server:prepare_and_post_solution(Candidate),
 			{noreply, State2};
-		Result ->
-			case Result of
-				partial ->
-					ar_mining_server:prepare_and_post_solution(Candidate);
-				_ ->
-					ok
-			end,
+		_ ->
 			{ok, Config} = application:get_env(arweave, config),
 			case cycle_chunk_cache(Candidate, {chunk1, Chunk1, H1}, State) of
 				{cached, State2} ->
@@ -415,28 +416,21 @@ handle_task({computed_h2, Candidate}, State) ->
 		nonce = Nonce, partition_number = Partition1, 
 		partition_upper_bound = PartitionUpperBound, cm_lead_peer = Peer
 	} = Candidate,
-	PassesDiffChecks = h2_passes_diff_checks(H2, Candidate, State),
-	case PassesDiffChecks of
-		false ->
-			ok;
-		true ->
-			?LOG_INFO([{event, found_h2_solution},
-					{worker, State#state.name},
-					{h2, ar_util:encode(H2)},
-					{difficulty, get_difficulty(State, Candidate)},
-					{partial_difficulty, get_partial_difficulty(State, Candidate)}]),
-			ar_mining_stats:h2_solution();
-		partial ->
-			?LOG_INFO([{event, found_h2_partial_solution},
-					{worker, State#state.name},
-					{h2, ar_util:encode(H2)},
-					{partial_difficulty, get_partial_difficulty(State, Candidate)}])
+	DiffCheck = h2_passes_diff_checks(H2, Candidate, State),
+	case DiffCheck of
+		false -> ok;
+		_ ->
+			?LOG_INFO([{event, solution_found}, {worker, State#state.name},
+				{h2, ar_util:encode(H2)},
+				{difficulty, get_difficulty(State, Candidate)},
+				{partial_difficulty, get_partial_difficulty(State, Candidate)}]),
+			ar_mining_stats:solution(found)
 	end,
-	case {PassesDiffChecks, Peer} of
+	case {DiffCheck, Peer} of
 		{false, _} ->
 			ok;
 		{_, not_set} ->
-			ar_mining_server:prepare_and_post_solution(Candidate);
+			ar_mining_router:prepare_solution(Candidate);
 		_ ->
 			{_RecallByte1, RecallByte2} = ar_mining_server:get_recall_bytes(H0, Partition1,
 					Nonce, PartitionUpperBound),
@@ -450,14 +444,15 @@ handle_task({computed_h2, Candidate}, State) ->
 							"the PoA2 proofs locally - searching the peers...~n"),
 						case ar_mining_server:fetch_poa_from_peers(RecallByte2) of
 							not_found ->
-								?LOG_WARNING([{event,
-										mined_block_but_failed_to_read_second_chunk_proof},
-										{worker, State#state.name},
-										{recall_byte2, RecallByte2},
-										{mining_address, ar_util:safe_encode(MiningAddress)}]),
+								?LOG_WARNING([{event, solution_rejected},
+									{reason, failed_to_read_second_chunk_proof},
+									{worker, State#state.name}, {h2, ar_util:encode(H2)},
+									{recall_byte2, RecallByte2},
+									{mining_address, ar_util:safe_encode(MiningAddress)}]),
 								ar:console("WARNING: we found an H2 solution but failed to find "
 										"the proof for the second chunk. See logs for more "
 										"details.~n"),
+								ar_mining_stats:solution(rejected),
 								not_found;
 							PeerPoA2 ->
 								PeerPoA2
@@ -522,11 +517,15 @@ h1_passes_diff_checks(H1, Candidate, State) ->
 h2_passes_diff_checks(H2, Candidate, State) ->
 	passes_diff_checks(H2, false, Candidate, State).
 
+%% @doc 
+%% If the solution passes the network difficulty: network
+%% If the solution passes a pool's partial difficulty: partial
+%% If the solution passes neither: false
 passes_diff_checks(SolutionHash, IsPoA1, Candidate, State) ->
 	DiffPair = get_difficulty(State, Candidate),
 	case ar_node_utils:passes_diff_check(SolutionHash, IsPoA1, DiffPair) of
 		true ->
-			true;
+			network;
 		false ->
 			case get_partial_difficulty(State, Candidate) of
 				not_set ->
@@ -782,7 +781,3 @@ generate_cache_ref(Candidate) ->
 		partition_upper_bound = PartitionUpperBound } = Candidate,
 	CacheRef = {Partition1, Partition2, PartitionUpperBound, make_ref()},
 	Candidate#mining_candidate{ cache_ref = CacheRef }.
-
-%%%===================================================================
-%%% Public Test interface.
-%%%===================================================================

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -358,9 +358,8 @@ handle_task({computed_h1, Candidate}, State) ->
 	case DiffCheck of
 		false -> ok;
 		_ ->
-			?LOG_INFO([{event, solution_found}, {worker, State#state.name},
-				{h1, ar_util:encode(H1)}, {difficulty, DiffPair}]),
-			ar_mining_stats:solution(found),
+			ar_mining_router:found_solution(Candidate, h1,
+				[{worker, State#state.name}, {difficulty, DiffPair}]),
 			ar_mining_router:prepare_solution(Candidate)
 	end,
 
@@ -393,9 +392,8 @@ handle_task({computed_h2, Candidate}, State) ->
 	case DiffCheck of
 		false -> ok;
 		_ ->
-			?LOG_INFO([{event, solution_found}, {worker, State#state.name},
-				{h2, ar_util:encode(H2)}, {difficulty, DiffPair}]),
-			ar_mining_stats:solution(found),
+			ar_mining_router:found_solution(Candidate, h2,
+				[{worker, State#state.name}, {difficulty, DiffPair}]),
 			ar_mining_router:route_h2(Candidate)
 	end,
 	{noreply, State};

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -3,8 +3,8 @@
 
 -export([apply_tx/3, apply_txs/3, update_accounts/3, validate/6,
 	h1_passes_diff_check/2, h2_passes_diff_check/2, solution_passes_diff_check/2,
-	block_passes_diff_check/1, block_passes_diff_check/2, passes_diff_check/3,
-	update_account/6, is_account_banned/2]).
+	candidate_passes_diff_check/2, block_passes_diff_check/1, block_passes_diff_check/2,
+	passes_diff_check/3, update_account/6, is_account_banned/2]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_pricing.hrl").
@@ -83,6 +83,12 @@ h1_passes_diff_check(H1, DiffPair) ->
 
 h2_passes_diff_check(H2, DiffPair) ->
 	passes_diff_check(H2, false, DiffPair).
+
+candidate_passes_diff_check(
+		#mining_candidate{ h2 = not_set } = Candidate, DiffPair) ->
+	passes_diff_check(Candidate#mining_candidate.h1, true, DiffPair);
+candidate_passes_diff_check(Candidate, DiffPair) ->
+	passes_diff_check(Candidate#mining_candidate.h2, false, DiffPair).
 
 solution_passes_diff_check(Solution, DiffPair) ->
 	SolutionHash = Solution#mining_solution.solution_hash,

--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -1890,8 +1890,9 @@ handle_found_solution(Args, PrevB, State) ->
 	HaveSteps =
 		case CorrectRebaseThreshold of
 			{false, Reason5} ->
-				?LOG_WARNING([{event, ignore_mining_solution},
+				?LOG_WARNING([{event, solution_rejected},
 					{reason, Reason5}, {solution, ar_util:encode(SolutionH)}]),
+				ar_mining_stats:solution(rejected),
 				false;
 			true ->
 				ar_nonce_limiter:get_steps(PrevStepNumber, StepNumber, PrevNextSeed,
@@ -1913,9 +1914,11 @@ handle_found_solution(Args, PrevB, State) ->
 		not_found ->
 			ar_events:send(solution,
 					{rejected, #{ reason => vdf_not_found, source => Source }}),
-			?LOG_WARNING([{event, did_not_find_steps_for_mined_block},
+			?LOG_WARNING([{event, solution_rejected},
+					{reason, did_not_find_steps},
 					{seed, ar_util:encode(PrevNextSeed)}, {prev_step_number, PrevStepNumber},
 					{step_number, StepNumber}]),
+			ar_mining_stats:solution(rejected),
 			{noreply, State};
 		[NonceLimiterOutput | _] = Steps ->
 			{Seed, NextSeed, PartitionUpperBound, NextPartitionUpperBound, VDFDifficulty}
@@ -2025,18 +2028,21 @@ handle_found_solution(Args, PrevB, State) ->
 							undefined -> 1;
 							_ -> 2
 						end}]),
+			ar_mining_stats:solution(accepted),
 			ar_block_cache:add(block_cache, B),
 			ar_events:send(solution, {accepted, #{ indep_hash => H, source => Source }}),
 			apply_block(update_solution_cache(H, Args, State));
 		_Steps ->
 			ar_events:send(solution,
 					{rejected, #{ reason => bad_vdf, source => Source }}),
-			?LOG_ERROR([{event, bad_steps},
+			?LOG_ERROR([{event, solution_rejected},
+					{reason, bad_steps},
 					{prev_block, ar_util:encode(PrevH)},
 					{step_number, StepNumber},
 					{prev_step_number, PrevStepNumber},
 					{prev_next_seed, ar_util:encode(PrevNextSeed)},
 					{output, ar_util:encode(NonceLimiterOutput)}]),
+			ar_mining_stats:solution(rejected),
 			{noreply, State}
 	end.
 

--- a/apps/arweave/src/ar_pool.erl
+++ b/apps/arweave/src/ar_pool.erl
@@ -35,7 +35,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/0, is_client/0, get_current_session_key_seed_pairs/0, 
+-export([start_link/0, is_client/0, is_server/0, get_current_session_key_seed_pairs/0, 
 		generate_jobs/1, get_latest_job/0, cache_jobs/1, get_cached_jobs/1,
 		process_partial_solution/2, post_partial_solution/1, pool_peer/0, process_cm_jobs/2]).
 
@@ -66,6 +66,10 @@ start_link() ->
 is_client() ->
 	{ok, Config} = application:get_env(arweave, config),
 	Config#config.is_pool_client == true.
+
+is_server() ->
+	{ok, Config} = application:get_env(arweave, config),
+	Config#config.is_pool_server == true.
 
 %% @doc Return a list of up to two most recently cached VDF session key, seed pairs.
 get_current_session_key_seed_pairs() ->

--- a/apps/arweave/src/ar_pool.erl
+++ b/apps/arweave/src/ar_pool.erl
@@ -539,7 +539,7 @@ process_h1_read_jobs([], _Partitions) ->
 process_h1_read_jobs([Candidate | Jobs], Partitions) ->
 	case we_have_partition_for_the_first_recall_byte(Candidate, Partitions) of
 		true ->
-			ar_mining_server:prepare_and_post_solution(Candidate),
+			ar_mining_router:prepare_solution(Candidate),
 			ar_mining_stats:h2_received_from_peer(pool);
 		false ->
 			ok

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -1756,7 +1756,7 @@ binary_to_signature_type(List) ->
 
 candidate_to_json_struct(
 	#mining_candidate{
-		cm_diff = DiffPair,
+		diff_pair = DiffPair,
 		cm_h1_list = H1List,
 		h0 = H0,
 		h1 = H1,
@@ -1778,7 +1778,8 @@ candidate_to_json_struct(
 		label = Label
 	}) ->
 	JSON = [
-		{cm_diff, diff_pair_to_json_list(DiffPair)},
+		%% cm_diff is the legacy name, kept for backwards compatibiltiy
+		{cm_diff, diff_pair_to_json_list(DiffPair)}, 
 		{cm_h1_list, h1_list_to_json_struct(H1List)},
 		{mining_address, ar_util:encode(MiningAddress)},
 		{h0, ar_util:encode(H0)},
@@ -1840,7 +1841,7 @@ json_map_to_candidate(JSON) ->
 	Label = maps:get(<<"label">>, JSON, <<"not_set">>),
 
 	#mining_candidate{
-		cm_diff = DiffPair,
+		diff_pair = DiffPair,
 		cm_h1_list = H1List,
 		h0 = H0,
 		h1 = H1,

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -29,7 +29,7 @@
 		candidate_to_json_struct/1, solution_to_json_struct/1, json_map_to_solution/1,
 		json_map_to_candidate/1,
 		jobs_to_json_struct/1, json_struct_to_jobs/1,
-		partial_solution_response_to_json_struct/1,
+		solution_response_to_json_struct/1,
 		pool_cm_jobs_to_json_struct/1, json_map_to_pool_cm_jobs/1]).
 
 -include_lib("arweave/include/ar.hrl").
@@ -2032,8 +2032,8 @@ json_struct_to_job(Struct) ->
 	#job{ output = Output, global_step_number = StepNumber,
 			partition_upper_bound = PartitionUpperBound }.
 
-partial_solution_response_to_json_struct(Response) ->
-	#partial_solution_response{ indep_hash = H, status = S } = Response,
+solution_response_to_json_struct(Response) ->
+	#solution_response{ indep_hash = H, status = S } = Response,
 	{[{<<"indep_hash">>, ar_util:encode(H)}, {<<"status">>, S}]}.
 
 pool_cm_jobs_to_json_struct(Jobs) ->

--- a/apps/arweave/src/ar_serialize.erl
+++ b/apps/arweave/src/ar_serialize.erl
@@ -2040,16 +2040,10 @@ pool_cm_jobs_to_json_struct(Jobs) ->
 	#pool_cm_jobs{ h1_to_h2_jobs = H1ToH2Jobs, h1_read_jobs = H1ReadJobs,
 			partitions = Partitions } = Jobs,
 	{[
-		{h1_to_h2_jobs, [pool_cm_h1_to_h2_job_to_json_struct(Job) || Job <- H1ToH2Jobs]},
-		{h1_read_jobs, [pool_cm_h1_read_job_to_json_struct(Job) || Job <- H1ReadJobs]},
+		{h1_to_h2_jobs, [candidate_to_json_struct(Job) || Job <- H1ToH2Jobs]},
+		{h1_read_jobs, [candidate_to_json_struct(Job) || Job <- H1ReadJobs]},
 		{partitions, Partitions}
 	]}.
-
-pool_cm_h1_to_h2_job_to_json_struct(Job) ->
-	candidate_to_json_struct(Job).
-
-pool_cm_h1_read_job_to_json_struct(Job) ->
-	candidate_to_json_struct(Job).
 
 json_map_to_pool_cm_jobs(Map) ->
 	H1ToH2Jobs = [json_map_to_candidate(Job)

--- a/apps/arweave/test/ar_coordinated_mining_tests.erl
+++ b/apps/arweave/test/ar_coordinated_mining_tests.erl
@@ -408,7 +408,6 @@ dummy_candidate() ->
 dummy_solution() ->
 	#mining_solution{
 		last_step_checkpoints = [],
-		merkle_rebase_threshold = rand:uniform(1024),
 		mining_address = crypto:strong_rand_bytes(32),
 		next_seed = crypto:strong_rand_bytes(32),
 		next_vdf_difficulty = rand:uniform(1024),

--- a/apps/arweave/test/ar_coordinated_mining_tests.erl
+++ b/apps/arweave/test/ar_coordinated_mining_tests.erl
@@ -389,7 +389,7 @@ assert_empty_cache(_Node) ->
 
 dummy_candidate() ->
 	#mining_candidate{
-		cm_diff = {rand:uniform(1024), rand:uniform(1024)},
+		diff_pair = {rand:uniform(1024), rand:uniform(1024)},
 		h0 = crypto:strong_rand_bytes(32),
 		h1 = crypto:strong_rand_bytes(32),
 		mining_address = crypto:strong_rand_bytes(32),

--- a/apps/arweave/test/ar_coordinated_mining_tests.erl
+++ b/apps/arweave/test/ar_coordinated_mining_tests.erl
@@ -127,7 +127,7 @@ test_no_secret() ->
 	?assertMatch(
 		{error, {ok, {{<<"421">>, _}, _, 
 			<<"CM API disabled or invalid CM API secret in request.">>, _, _}}},
-		ar_http_iface_client:cm_publish_send(Peer, dummy_solution())).
+		ar_http_iface_client:post_partial_solution(Peer, dummy_solution())).
 
 test_bad_secret() ->
 	[Node, _ExitNode, _ValidatorNode] = ar_test_node:start_coordinated(1),
@@ -150,7 +150,7 @@ test_bad_secret() ->
 	?assertMatch(
 		{error, {ok, {{<<"421">>, _}, _, 
 			<<"CM API disabled or invalid CM API secret in request.">>, _, _}}},
-		ar_http_iface_client:cm_publish_send(Peer, dummy_solution())).
+		ar_http_iface_client:post_partial_solution(Peer, dummy_solution())).
 
 test_partition_table() ->
 	[B0] = ar_weave:init([], ar_test_node:get_difficulty_for_invalid_hash(), 5 * ?PARTITION_SIZE),

--- a/apps/arweave/test/ar_serialize_tests.erl
+++ b/apps/arweave/test/ar_serialize_tests.erl
@@ -389,16 +389,16 @@ partial_solution_to_json_struct_test() ->
 		TestCases
 	).
 
-partial_solution_response_to_json_struct_test() ->
+solution_response_to_json_struct_test() ->
 	TestCases = [
-		{#partial_solution_response{}, <<>>, <<>>},
-		{#partial_solution_response{ indep_hash = <<"H">>, status = <<"S">>},
+		{#solution_response{}, <<>>, <<>>},
+		{#solution_response{ indep_hash = <<"H">>, status = <<"S">>},
 				<<"H">>, <<"S">>}
 	],
 	lists:foreach(
 		fun({Case, ExpectedH, ExpectedStatus}) ->
 			{Struct} = ar_serialize:dejsonify(ar_serialize:jsonify(
-					ar_serialize:partial_solution_response_to_json_struct(Case))),
+					ar_serialize:solution_response_to_json_struct(Case))),
 			?assertEqual(ExpectedH,
 					ar_util:decode(proplists:get_value(<<"indep_hash">>, Struct))),
 			?assertEqual(ExpectedStatus, proplists:get_value(<<"status">>, Struct))

--- a/apps/arweave/test/ar_serialize_tests.erl
+++ b/apps/arweave/test/ar_serialize_tests.erl
@@ -247,7 +247,7 @@ candidate_to_json_struct_test() ->
     end,
 
 	DefaultCandidate = #mining_candidate{
-        cm_diff = {rand:uniform(1024), rand:uniform(1024)},
+        diff_pair = {rand:uniform(1024), rand:uniform(1024)},
 		cm_h1_list = [
 			{crypto:strong_rand_bytes(32), rand:uniform(100)},
 			{crypto:strong_rand_bytes(32), rand:uniform(100)},


### PR DESCRIPTION
PR in process to allow tracking solution status as it is updated. PR grew into a refactoring of the CM/Pool code since solution status can be updated at any of several nodes depending on the mining configuration.

One change not yet implemented that I'd plan to do later: have nodes report solution status to each other via a new POST /xxxx endpoint rather than have the solution status be returned in an HTTP response. This is to avoid having long running HTTP requests waiting on a tree of other HTTP requests before they learn the solution status.

@ldmberman also suggested an improvement: have some generic way for all nodes to report status to the Pool Server or CM exit node. When we revisit this PR it may be worht giving some thought to how nodes communicate status with each other - i.e. we may not need a dedicated "solution status" endpoint but rather a generic "status" endpoint that all nodes use to keep each other up today.

This change was also beginning to deduplicate the communication protocol - there are several CM and Pool endpoints that do the same thing. When we revist this PR we can also look into having CM operate more like a Pool (e.g. use jobs) this may also allow us to simplify a lot of code by removing redundant endpoints and communication channels.