### PR TITLE
fix(nix): add missing arweave.pkg attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
   outputs = { self, nixpkgs, utils, ... }: utils.lib.eachDefaultSystem (system:
     let
       pkgs = import nixpkgs { inherit system; };
-      arweave = pkgs.callPackage ./nix/arweave.nix { inherit pkgs; };
+      arweave = (pkgs.callPackage ./nix/arweave.nix { inherit pkgs; }).arweave;
     in
     {
       packages = utils.lib.flattenTree {


### PR DESCRIPTION
I just changed the output recently of the package derivation and I forgot to update the import of it in the flake.nix