### PR TITLE
Fix MacOS runtime / symbol definition errors

### DIFF
--- a/apps/arweave/c_src/randomx/ar_randomx_impl.h
+++ b/apps/arweave/c_src/randomx/ar_randomx_impl.h
@@ -1,3 +1,6 @@
+#ifndef AR_RANDOMX_IMPL_H
+#define AR_RANDOMX_IMPL_H
+
 // Thif file includes the full definitions of any function that is shared between the
 // rx512 and rx4096 shared libraries. Although ugly this was the only way I could get
 // everything to work without causing symbol conflicts or seg faults once the two .so's
@@ -384,3 +387,5 @@ static void destroy_vm(struct state* statePtr, randomx_vm* vmPtr) {
 	randomx_destroy_vm(vmPtr);
 	enif_rwlock_runlock(statePtr->lockPtr);
 }
+
+#endif

--- a/apps/arweave/c_src/randomx/ar_randomx_impl.h
+++ b/apps/arweave/c_src/randomx/ar_randomx_impl.h
@@ -240,8 +240,6 @@ static void state_dtor(ErlNifEnv* envPtr, void* objPtr)
 {
 	struct state *statePtr = (struct state*) objPtr;
 
-	fprintf(stderr, "state_dtor: %p\n", statePtr);
-
     if (statePtr->datasetPtr != NULL) {
 		randomx_release_dataset(statePtr->datasetPtr);
 		statePtr->datasetPtr = NULL;
@@ -356,8 +354,6 @@ static randomx_vm* create_vm(struct state* statePtr,
 		enif_rwlock_runlock(statePtr->lockPtr);
 		return NULL;
 	}
-
-	fprintf(stderr, "create_vm: %d, %d, %d, %d\n", fullMemEnabled, jitEnabled, largePagesEnabled, hardwareAESEnabled);
 
 	randomx_flags flags = RANDOMX_FLAG_DEFAULT;
 	if (fullMemEnabled) {

--- a/apps/arweave/c_src/randomx/randomx_long_with_entropy.cpp
+++ b/apps/arweave/c_src/randomx/randomx_long_with_entropy.cpp
@@ -12,41 +12,30 @@
 
 extern "C" {
 	const unsigned char *randomx_calculate_hash_long_with_entropy_get_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const int randomxProgramCount) {
-		fprintf(stderr, "randomx_calculate_hash_long_with_entropy_get_entropy\n");
 		assert(machine != nullptr);
 		assert(inputSize == 0 || input != nullptr);
 		alignas(16) uint64_t tempHash[8];
-		fprintf(stderr, "A\n");
-		int blakeResult = blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
+		int blakeResult = randomx_blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
 		assert(blakeResult == 0);
-		fprintf(stderr, "B\n");
 		machine->initScratchpad(&tempHash);
-		fprintf(stderr, "C\n");
 		machine->resetRoundingMode();
-		fprintf(stderr, "D\n");
 		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
-			fprintf(stderr, "E\n");
 			machine->run(&tempHash);
-			fprintf(stderr, "F1\n");
-			blakeResult = blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
-			fprintf(stderr, "F2\n");
+			blakeResult = randomx_blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
 			assert(blakeResult == 0);
 		}
-		fprintf(stderr, "F3\n");
 		machine->run(&tempHash);
 		unsigned char output[64];
 		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
-		fprintf(stderr, "G\n");
 		return (const unsigned char*)machine->getScratchpad();
 	}
 
 	// feistel_encrypt accepts padded message with 2*FEISTEL_BLOCK_LENGTH = 64 bytes
 	RANDOMX_EXPORT void randomx_encrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t inChunkSize, unsigned char *outChunk, const int randomxProgramCount) {
-		fprintf(stderr, "randomx_encrypt_chunk\n");
 		assert(inChunkSize <= RANDOMX_ENTROPY_SIZE);
 		assert(inChunkSize % (2*FEISTEL_BLOCK_LENGTH) == 0);
 		const unsigned char *outputEntropy = randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
-		fprintf(stderr, "randomx_encrypt_chunk2\n");
+
 		feistel_encrypt((const unsigned char*)inChunk, inChunkSize, outputEntropy, (unsigned char*)outChunk);
 	}
 

--- a/apps/arweave/c_src/randomx/randomx_long_with_entropy.cpp
+++ b/apps/arweave/c_src/randomx/randomx_long_with_entropy.cpp
@@ -12,30 +12,41 @@
 
 extern "C" {
 	const unsigned char *randomx_calculate_hash_long_with_entropy_get_entropy(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const int randomxProgramCount) {
+		fprintf(stderr, "randomx_calculate_hash_long_with_entropy_get_entropy\n");
 		assert(machine != nullptr);
 		assert(inputSize == 0 || input != nullptr);
 		alignas(16) uint64_t tempHash[8];
+		fprintf(stderr, "A\n");
 		int blakeResult = blake2b(tempHash, sizeof(tempHash), input, inputSize, nullptr, 0);
 		assert(blakeResult == 0);
+		fprintf(stderr, "B\n");
 		machine->initScratchpad(&tempHash);
+		fprintf(stderr, "C\n");
 		machine->resetRoundingMode();
+		fprintf(stderr, "D\n");
 		for (int chain = 0; chain < randomxProgramCount - 1; ++chain) {
+			fprintf(stderr, "E\n");
 			machine->run(&tempHash);
+			fprintf(stderr, "F1\n");
 			blakeResult = blake2b(tempHash, sizeof(tempHash), machine->getRegisterFile(), sizeof(randomx::RegisterFile), nullptr, 0);
+			fprintf(stderr, "F2\n");
 			assert(blakeResult == 0);
 		}
+		fprintf(stderr, "F3\n");
 		machine->run(&tempHash);
 		unsigned char output[64];
 		machine->getFinalResult(output, RANDOMX_HASH_SIZE);
+		fprintf(stderr, "G\n");
 		return (const unsigned char*)machine->getScratchpad();
 	}
 
 	// feistel_encrypt accepts padded message with 2*FEISTEL_BLOCK_LENGTH = 64 bytes
 	RANDOMX_EXPORT void randomx_encrypt_chunk(randomx_vm *machine, const unsigned char *input, const size_t inputSize, const unsigned char *inChunk, const size_t inChunkSize, unsigned char *outChunk, const int randomxProgramCount) {
+		fprintf(stderr, "randomx_encrypt_chunk\n");
 		assert(inChunkSize <= RANDOMX_ENTROPY_SIZE);
 		assert(inChunkSize % (2*FEISTEL_BLOCK_LENGTH) == 0);
 		const unsigned char *outputEntropy = randomx_calculate_hash_long_with_entropy_get_entropy(machine, input, inputSize, randomxProgramCount);
-
+		fprintf(stderr, "randomx_encrypt_chunk2\n");
 		feistel_encrypt((const unsigned char*)inChunk, inChunkSize, outputEntropy, (unsigned char*)outChunk);
 	}
 

--- a/apps/arweave/c_src/randomx/rx4096/ar_rx4096_nif.c
+++ b/apps/arweave/c_src/randomx/rx4096/ar_rx4096_nif.c
@@ -182,7 +182,7 @@ static ERL_NIF_TERM rx4096_encrypt_composite_chunk_nif(
 	// The number of sub-chunks in the chunk.
 	int subChunkCount;
 	int jitEnabled, largePagesEnabled, hardwareAESEnabled;
-	state* statePtr;
+	struct state* statePtr;
 	ErlNifBinary inputData;
 	ErlNifBinary inputChunk;
 
@@ -254,7 +254,7 @@ static ERL_NIF_TERM rx4096_decrypt_composite_chunk_nif(
 	// The number of sub-chunks in the chunk.
 	int subChunkCount;
 	int jitEnabled, largePagesEnabled, hardwareAESEnabled;
-	state* statePtr;
+	struct state* statePtr;
 	ErlNifBinary inputData;
 	ErlNifBinary inputChunk;
 
@@ -334,7 +334,7 @@ static ERL_NIF_TERM rx4096_decrypt_composite_sub_chunk_nif(
 	// add it to the base packing key, and SHA256-hash it to get the packing key.
 	uint32_t offset;
 	int jitEnabled, largePagesEnabled, hardwareAESEnabled;
-	state* statePtr;
+	struct state* statePtr;
 	ErlNifBinary inputData;
 	ErlNifBinary inputChunk;
 
@@ -433,7 +433,7 @@ static ERL_NIF_TERM rx4096_reencrypt_composite_chunk_nif(
 	int decryptRandomxRoundCount, encryptRandomxRoundCount;
 	int jitEnabled, largePagesEnabled, hardwareAESEnabled;
 	int decryptSubChunkCount, encryptSubChunkCount, decryptIterations, encryptIterations;
-	state* statePtr;
+	struct state* statePtr;
 	ErlNifBinary decryptKey;
 	ErlNifBinary encryptKey;
 	ErlNifBinary inputChunk;

--- a/apps/arweave/c_src/randomx/rx512/ar_rx512_nif.c
+++ b/apps/arweave/c_src/randomx/rx512/ar_rx512_nif.c
@@ -50,29 +50,23 @@ static ERL_NIF_TERM encrypt_chunk(ErlNifEnv* envPtr,
 		randomx_vm *machine, const unsigned char *input, const size_t inputSize,
 		const unsigned char *inChunk, const size_t inChunkSize,
 		const int randomxProgramCount) {
-	fprintf(stderr, "encrypt_chunk\n");
 	ERL_NIF_TERM encryptedChunkTerm;
 	unsigned char* encryptedChunk = enif_make_new_binary(
 										envPtr, MAX_CHUNK_SIZE, &encryptedChunkTerm);
 
-	fprintf(stderr, "A\n");
 	if (inChunkSize < MAX_CHUNK_SIZE) {
 		unsigned char *paddedInChunk = (unsigned char*)malloc(MAX_CHUNK_SIZE);
 		memset(paddedInChunk, 0, MAX_CHUNK_SIZE);
 		memcpy(paddedInChunk, inChunk, inChunkSize);
-		fprintf(stderr, "B1\n");
 		randomx_encrypt_chunk(
 			machine, input, inputSize, paddedInChunk, MAX_CHUNK_SIZE,
 			encryptedChunk, randomxProgramCount);
-		fprintf(stderr, "C\n");
 		free(paddedInChunk);
 	} else {
-		fprintf(stderr, "B2\n");
 		randomx_encrypt_chunk(
 			machine, input, inputSize, inChunk, inChunkSize,
 			encryptedChunk, randomxProgramCount);
 	}
-	fprintf(stderr, "D\n");
 
 	return encryptedChunkTerm;
 }
@@ -86,8 +80,6 @@ static ERL_NIF_TERM rx512_encrypt_chunk_nif(
 	struct state* statePtr;
 	ErlNifBinary inputData;
 	ErlNifBinary inputChunk;
-
-	fprintf(stderr, "rx512_encrypt_chunk_nif\n");
 
 	if (argc != 7) {
 		return enif_make_badarg(envPtr);
@@ -116,12 +108,9 @@ static ERL_NIF_TERM rx512_encrypt_chunk_nif(
 		return enif_make_badarg(envPtr);
 	}
 
-	fprintf(stderr, "A\n");
-
 	int isRandomxReleased;
 	randomx_vm *vmPtr = create_vm(statePtr, (statePtr->mode == HASHING_MODE_FAST),
 		jitEnabled, largePagesEnabled, hardwareAESEnabled, &isRandomxReleased);
-	fprintf(stderr, "B\n");
 	if (vmPtr == NULL) {
 		if (isRandomxReleased != 0) {
 			return error_tuple(envPtr, "state has been released");
@@ -129,13 +118,10 @@ static ERL_NIF_TERM rx512_encrypt_chunk_nif(
 		return error_tuple(envPtr, "randomx_create_vm failed");
 	}
 
-	fprintf(stderr, "C\n");
 	ERL_NIF_TERM outChunkTerm = encrypt_chunk(envPtr, vmPtr,
 		inputData.data, inputData.size, inputChunk.data, inputChunk.size, randomxRoundCount);
 
-	fprintf(stderr, "D\n");
 	destroy_vm(statePtr, vmPtr);
-	fprintf(stderr, "E\n");
 	return ok_tuple(envPtr, outChunkTerm);
 }
 

--- a/apps/arweave/test/ar_mine_randomx_tests.erl
+++ b/apps/arweave/test/ar_mine_randomx_tests.erl
@@ -49,11 +49,12 @@ reencrypt_composite_chunk({rx4096, RandomXState}, Key1, Key2, Chunk, PackingRoun
 setup() ->
     FastState512 = ar_mine_randomx:init_fast2(rx512, ?RANDOMX_PACKING_KEY, 0, 0,
 		erlang:system_info(dirty_cpu_schedulers_online)),
-    LightState512 = ar_mine_randomx:init_light2(rx512, ?RANDOMX_PACKING_KEY, 0, 0),
-    FastState4096 = ar_mine_randomx:init_fast2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0,
-		erlang:system_info(dirty_cpu_schedulers_online)),
-    LightState4096 = ar_mine_randomx:init_light2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0),
-    {FastState512, LightState512, FastState4096, LightState4096}.
+	{FastState512, FastState512, FastState512, FastState512}.
+    % LightState512 = ar_mine_randomx:init_light2(rx512, ?RANDOMX_PACKING_KEY, 0, 0),
+    % FastState4096 = ar_mine_randomx:init_fast2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0,
+	% 	erlang:system_info(dirty_cpu_schedulers_online)),
+    % LightState4096 = ar_mine_randomx:init_light2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0),
+    % {FastState512, LightState512, FastState4096, LightState4096}.
 
 test_register(TestFun, Fixture) ->
 	{timeout, 120, {with, Fixture, [TestFun]}}.
@@ -62,19 +63,19 @@ randomx_suite_test_() ->
 	{setup, fun setup/0,
 		fun (SetupData) ->
 			[
-				test_register(fun test_state/1, SetupData),
-				test_register(fun test_bad_state/1, SetupData),
-				test_register(fun test_regression/1, SetupData),
-				test_register(fun test_empty_chunk_fails/1, SetupData),
-				test_register(fun test_nif_wrappers/1, SetupData),
-				test_register(fun test_pack_unpack/1, SetupData),
-				test_register(fun test_repack/1, SetupData),
-				test_register(fun test_input_changes_packing/1, SetupData),
-				test_register(fun test_composite_packing/1, SetupData),
-				test_register(fun test_composite_packs_incrementally/1, SetupData),
-				test_register(fun test_composite_unpacked_sub_chunks/1, SetupData),
-				test_register(fun test_composite_repack/1, SetupData),
-				test_register(fun test_hash/1, SetupData)
+				% test_register(fun test_state/1, SetupData),
+				% test_register(fun test_bad_state/1, SetupData),
+				test_register(fun test_regression/1, SetupData)
+				% test_register(fun test_empty_chunk_fails/1, SetupData),
+				% test_register(fun test_nif_wrappers/1, SetupData),
+				% test_register(fun test_pack_unpack/1, SetupData),
+				% test_register(fun test_repack/1, SetupData),
+				% test_register(fun test_input_changes_packing/1, SetupData),
+				% test_register(fun test_composite_packing/1, SetupData),
+				% test_register(fun test_composite_packs_incrementally/1, SetupData),
+				% test_register(fun test_composite_unpacked_sub_chunks/1, SetupData),
+				% test_register(fun test_composite_repack/1, SetupData),
+				% test_register(fun test_hash/1, SetupData)
 			]
 		end
 	}.
@@ -161,48 +162,51 @@ test_regression({FastState512, LightState512, FastState4096, LightState4096}) ->
 	test_regression(FastState512,
 		"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
 		fun encrypt_chunk/8, fun decrypt_chunk/8),
-	test_regression(FastState512,
-		"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
-		fun encrypt_chunk/8, fun decrypt_chunk/8),
-	test_regression(FastState4096,
-		"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(FastState4096,
-		"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(FastState4096,
-		"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(FastState4096,
-		"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(LightState512,
-		"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
-		fun encrypt_chunk/8, fun decrypt_chunk/8),
-	test_regression(LightState512,
-		"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
-		fun encrypt_chunk/8, fun decrypt_chunk/8),
-	test_regression(LightState4096,
-		"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(LightState4096,
-		"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(LightState4096,
-		"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	test_regression(LightState4096,
-		"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
-		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8).
+	% test_regression(FastState512,
+	% 	"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
+	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
+	% test_regression(FastState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(FastState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(FastState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(FastState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(LightState512,
+	% 	"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
+	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
+	% test_regression(LightState512,
+	% 	"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
+	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
+	% test_regression(LightState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(LightState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(LightState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	% test_regression(LightState4096,
+	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
+	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8).
+	ok.
 
 test_regression(State, Fixture, JIT, ExtraArgs, EncryptFun, DecryptFun) ->
 	Key = ar_test_node:load_fixture("ar_mine_randomx_tests/key.bin"),
 	UnpackedFixture = ar_test_node:load_fixture("ar_mine_randomx_tests/unpacked.bin"),
 	PackedFixture = ar_test_node:load_fixture(Fixture),
 
+	?LOG_ERROR([{event, encrypt_chunk}]),
 	{ok, Packed} = EncryptFun(State, Key, UnpackedFixture, 8, JIT, 0, 0, ExtraArgs),
 	?assertEqual(PackedFixture, Packed, Fixture),
 
+	?LOG_ERROR([{event, decrypt_chunk}]),
 	{ok, Unpacked} = DecryptFun(State, Key, PackedFixture, 8, JIT, 0, 0, ExtraArgs),
 	?assertEqual(UnpackedFixture, Unpacked, Fixture).
 

--- a/apps/arweave/test/ar_mine_randomx_tests.erl
+++ b/apps/arweave/test/ar_mine_randomx_tests.erl
@@ -49,12 +49,12 @@ reencrypt_composite_chunk({rx4096, RandomXState}, Key1, Key2, Chunk, PackingRoun
 setup() ->
     FastState512 = ar_mine_randomx:init_fast2(rx512, ?RANDOMX_PACKING_KEY, 0, 0,
 		erlang:system_info(dirty_cpu_schedulers_online)),
-	{FastState512, FastState512, FastState512, FastState512}.
-    % LightState512 = ar_mine_randomx:init_light2(rx512, ?RANDOMX_PACKING_KEY, 0, 0),
-    % FastState4096 = ar_mine_randomx:init_fast2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0,
-	% 	erlang:system_info(dirty_cpu_schedulers_online)),
-    % LightState4096 = ar_mine_randomx:init_light2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0),
-    % {FastState512, LightState512, FastState4096, LightState4096}.
+	% {FastState512, FastState512, FastState512, FastState512}.
+    LightState512 = ar_mine_randomx:init_light2(rx512, ?RANDOMX_PACKING_KEY, 0, 0),
+    FastState4096 = ar_mine_randomx:init_fast2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0,
+		erlang:system_info(dirty_cpu_schedulers_online)),
+    LightState4096 = ar_mine_randomx:init_light2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0),
+    {FastState512, LightState512, FastState4096, LightState4096}.
 
 test_register(TestFun, Fixture) ->
 	{timeout, 120, {with, Fixture, [TestFun]}}.
@@ -63,19 +63,19 @@ randomx_suite_test_() ->
 	{setup, fun setup/0,
 		fun (SetupData) ->
 			[
-				% test_register(fun test_state/1, SetupData),
-				% test_register(fun test_bad_state/1, SetupData),
-				test_register(fun test_regression/1, SetupData)
-				% test_register(fun test_empty_chunk_fails/1, SetupData),
-				% test_register(fun test_nif_wrappers/1, SetupData),
-				% test_register(fun test_pack_unpack/1, SetupData),
-				% test_register(fun test_repack/1, SetupData),
-				% test_register(fun test_input_changes_packing/1, SetupData),
-				% test_register(fun test_composite_packing/1, SetupData),
-				% test_register(fun test_composite_packs_incrementally/1, SetupData),
-				% test_register(fun test_composite_unpacked_sub_chunks/1, SetupData),
-				% test_register(fun test_composite_repack/1, SetupData),
-				% test_register(fun test_hash/1, SetupData)
+				test_register(fun test_state/1, SetupData),
+				test_register(fun test_bad_state/1, SetupData),
+				test_register(fun test_regression/1, SetupData),
+				test_register(fun test_empty_chunk_fails/1, SetupData),
+				test_register(fun test_nif_wrappers/1, SetupData),
+				test_register(fun test_pack_unpack/1, SetupData),
+				test_register(fun test_repack/1, SetupData),
+				test_register(fun test_input_changes_packing/1, SetupData),
+				test_register(fun test_composite_packing/1, SetupData),
+				test_register(fun test_composite_packs_incrementally/1, SetupData),
+				test_register(fun test_composite_unpacked_sub_chunks/1, SetupData),
+				test_register(fun test_composite_repack/1, SetupData),
+				test_register(fun test_hash/1, SetupData)
 			]
 		end
 	}.
@@ -162,39 +162,39 @@ test_regression({FastState512, LightState512, FastState4096, LightState4096}) ->
 	test_regression(FastState512,
 		"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
 		fun encrypt_chunk/8, fun decrypt_chunk/8),
-	% test_regression(FastState512,
-	% 	"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
-	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
-	% test_regression(FastState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(FastState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(FastState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(FastState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(LightState512,
-	% 	"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
-	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
-	% test_regression(LightState512,
-	% 	"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
-	% 	fun encrypt_chunk/8, fun decrypt_chunk/8),
-	% test_regression(LightState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(LightState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(LightState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
-	% test_regression(LightState4096,
-	% 	"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
-	% 	fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8).
+	test_regression(FastState512,
+		"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
+		fun encrypt_chunk/8, fun decrypt_chunk/8),
+	test_regression(FastState4096,
+		"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(FastState4096,
+		"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(FastState4096,
+		"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(FastState4096,
+		"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(LightState512,
+		"ar_mine_randomx_tests/packed.spora26.bin", 0, [],
+		fun encrypt_chunk/8, fun decrypt_chunk/8),
+	test_regression(LightState512,
+		"ar_mine_randomx_tests/packed.spora26.bin", 1, [],
+		fun encrypt_chunk/8, fun decrypt_chunk/8),
+	test_regression(LightState4096,
+		"ar_mine_randomx_tests/packed.composite.1.bin", 0, [1, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(LightState4096,
+		"ar_mine_randomx_tests/packed.composite.1.bin", 1, [1, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(LightState4096,
+		"ar_mine_randomx_tests/packed.composite.2.bin", 0, [2, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
+	test_regression(LightState4096,
+		"ar_mine_randomx_tests/packed.composite.2.bin", 1, [2, 32],
+		fun encrypt_composite_chunk/8, fun decrypt_composite_chunk/8),
 	ok.
 
 test_regression(State, Fixture, JIT, ExtraArgs, EncryptFun, DecryptFun) ->
@@ -202,11 +202,9 @@ test_regression(State, Fixture, JIT, ExtraArgs, EncryptFun, DecryptFun) ->
 	UnpackedFixture = ar_test_node:load_fixture("ar_mine_randomx_tests/unpacked.bin"),
 	PackedFixture = ar_test_node:load_fixture(Fixture),
 
-	?LOG_ERROR([{event, encrypt_chunk}]),
 	{ok, Packed} = EncryptFun(State, Key, UnpackedFixture, 8, JIT, 0, 0, ExtraArgs),
 	?assertEqual(PackedFixture, Packed, Fixture),
 
-	?LOG_ERROR([{event, decrypt_chunk}]),
 	{ok, Unpacked} = DecryptFun(State, Key, PackedFixture, 8, JIT, 0, 0, ExtraArgs),
 	?assertEqual(UnpackedFixture, Unpacked, Fixture).
 

--- a/apps/arweave/test/ar_mine_randomx_tests.erl
+++ b/apps/arweave/test/ar_mine_randomx_tests.erl
@@ -49,7 +49,6 @@ reencrypt_composite_chunk({rx4096, RandomXState}, Key1, Key2, Chunk, PackingRoun
 setup() ->
     FastState512 = ar_mine_randomx:init_fast2(rx512, ?RANDOMX_PACKING_KEY, 0, 0,
 		erlang:system_info(dirty_cpu_schedulers_online)),
-	% {FastState512, FastState512, FastState512, FastState512}.
     LightState512 = ar_mine_randomx:init_light2(rx512, ?RANDOMX_PACKING_KEY, 0, 0),
     FastState4096 = ar_mine_randomx:init_fast2(rx4096, ?RANDOMX_PACKING_KEY, 0, 0,
 		erlang:system_info(dirty_cpu_schedulers_online)),

--- a/rebar.config
+++ b/rebar.config
@@ -378,14 +378,14 @@
 {pre_hooks, [
 	% Build for randomx512 configuration
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile,
-		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build512 && cd apps/arweave/lib/RandomX/build512 && cmake -DSYMBOL_PREFIX=rx_512 -DRANDOMX_ARGON_MEMORY=262144 -DRANDOMX_DATASET_BASE_SIZE=536870912 .. > /dev/null\""},
+		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build512 && cd apps/arweave/lib/RandomX/build512 && cmake  -DUSE_HIDDEN_VISIBILITY=ON -DRANDOMX_ARGON_MEMORY=262144 -DRANDOMX_DATASET_BASE_SIZE=536870912 .. > /dev/null\""},
 	{"(darwin)", compile, "make randomx -C apps/arweave/lib/RandomX/build512"},
 	{"(linux)", compile, "make -C apps/arweave/lib/RandomX/build512"},
 	{"(freebsd|netbsd|openbsd)", compile, "gmake -C apps/arweave/lib/RandomX/build512"},
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile, "bash -c \"cd apps/arweave/lib/RandomX/build512 && mv librandomx.a librandomx512.a\""},
 	% Build for randomx4096 configuration
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile,
-		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build4096 && cd apps/arweave/lib/RandomX/build4096 && cmake -DSYMBOL_PREFIX=rx_4096 -DRANDOMX_ARGON_MEMORY=524288 -DRANDOMX_DATASET_BASE_SIZE=4294967296 .. > /dev/null\""},
+		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build4096 && cd apps/arweave/lib/RandomX/build4096 && cmake -DUSE_HIDDEN_VISIBILITY=ON -DRANDOMX_ARGON_MEMORY=524288 -DRANDOMX_DATASET_BASE_SIZE=4294967296 .. > /dev/null\""},
 	{"(darwin)", compile, "make randomx -C apps/arweave/lib/RandomX/build4096"},
 	{"(linux)", compile, "make -C apps/arweave/lib/RandomX/build4096"},
 	{"(freebsd|netbsd|openbsd)", compile, "gmake -C apps/arweave/lib/RandomX/build4096"},

--- a/rebar.config
+++ b/rebar.config
@@ -378,14 +378,14 @@
 {pre_hooks, [
 	% Build for randomx512 configuration
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile,
-		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build512 && cd apps/arweave/lib/RandomX/build512 && cmake -DRANDOMX_ARGON_MEMORY=262144 -DRANDOMX_DATASET_BASE_SIZE=536870912 .. > /dev/null\""},
+		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build512 && cd apps/arweave/lib/RandomX/build512 && cmake -DSYMBOL_PREFIX=rx_512 -DRANDOMX_ARGON_MEMORY=262144 -DRANDOMX_DATASET_BASE_SIZE=536870912 .. > /dev/null\""},
 	{"(darwin)", compile, "make randomx -C apps/arweave/lib/RandomX/build512"},
 	{"(linux)", compile, "make -C apps/arweave/lib/RandomX/build512"},
 	{"(freebsd|netbsd|openbsd)", compile, "gmake -C apps/arweave/lib/RandomX/build512"},
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile, "bash -c \"cd apps/arweave/lib/RandomX/build512 && mv librandomx.a librandomx512.a\""},
 	% Build for randomx4096 configuration
 	{"(darwin|linux|freebsd|netbsd|openbsd)", compile,
-		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build4096 && cd apps/arweave/lib/RandomX/build4096 && cmake -DRANDOMX_ARGON_MEMORY=524288 -DRANDOMX_DATASET_BASE_SIZE=4294967296 .. > /dev/null\""},
+		"bash -c \"mkdir -p apps/arweave/lib/RandomX/build4096 && cd apps/arweave/lib/RandomX/build4096 && cmake -DSYMBOL_PREFIX=rx_4096 -DRANDOMX_ARGON_MEMORY=524288 -DRANDOMX_DATASET_BASE_SIZE=4294967296 .. > /dev/null\""},
 	{"(darwin)", compile, "make randomx -C apps/arweave/lib/RandomX/build4096"},
 	{"(linux)", compile, "make -C apps/arweave/lib/RandomX/build4096"},
 	{"(freebsd|netbsd|openbsd)", compile, "gmake -C apps/arweave/lib/RandomX/build4096"},


### PR DESCRIPTION
On MacOS the symbols in each of the statically linked librandomx.a libraries conflicted at runtime causing error or segfaults. The fix is to build the libraries with the `-fvisibility=hidden` flag. This prevents the symbols from being exported beyond the .so that the libraries are linked into.