### PR TITLE
Create an Interface to remote_console release command

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+######################################################################
+# Connect to arweave Erlang shell.
+######################################################################
+set -e
+SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_ACTION="remote_console"
+
+# Sets $ARWEAVE and $ARWEAVE_* variables
+source ${SCRIPT_DIR}/arweave.env
+$(ARWEAVE} ${SCRIPT_ACTION}


### PR DESCRIPTION
Arweave is started with Distributed Erlang feature enabled by default. This means it is possible to connect to the node using its node name and a cookie. These values are configured in `arweave.env` script. `remote_console` command is available through the release generated during compilation, used to give access to Erlang node. In fact, this is a shortcut for the following command:

    erl -rsh -cookie ${arweave_cookie} -sname ${console_name}

This kind of feature is required if we want to use something different than screen during the starting process, and offering a better way to deal with the main arweave process.