### PR TITLE
Arweave Should Not Build Before Being Stopped

### DIFF
--- a/bin/arweave.env
+++ b/bin/arweave.env
@@ -18,7 +18,13 @@ else
     # extended start script to run from our current directory (which is necessary for relative
     # paths to work correctly and not be relative to the rebar3 _build release directory)
     echo Building dependencies for target ${ARWEAVE_BUILD_TARGET:-default}...
-    (cd ${PARENT_DIR} && ./ar-rebar3 ${ARWEAVE_BUILD_TARGET:-default} release)
+
+    # sometimes, arweave does not need to be build, for example
+    # when someone is stopping a node.
+    if ! [ "${SKIP_BUILD}" ]; then
+        (cd ${PARENT_DIR} && ./ar-rebar3 ${ARWEAVE_BUILD_TARGET:-default} release)
+    fi
+
     export ARWEAVE="${SCRIPT_DIR}/arweave-dev"
     export ARWEAVE_COMMAND="console"
 fi

--- a/bin/stop
+++ b/bin/stop
@@ -5,6 +5,7 @@ set -e
 SCRIPT_DIR="$(dirname "$0")"
 
 # Sets $ARWEAVE and $ARWEAVE_* variables
+SKIP_BUILD=yes
 source $SCRIPT_DIR/arweave.env
 
 $ARWEAVE stop


### PR DESCRIPTION
This commit fixes an issue related to `./bin/stop` script and `./bin/arweave.env`. When stopping Arweave application in dev environment, a full release is always created. It is not clean and could probably leads to errors (even if was not the case previously).

The compilation is now made only when SCRIPT_ACTION variable is not set to "stop" or if `./bin/arweave-dev` does not exist.