### PR TITLE
Header Synchronization Improvement

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -106,6 +106,9 @@
 %% The default number of chunks fetched from disk at a time during in-place repacking.
 -define(DEFAULT_REPACK_BATCH_SIZE, 100).
 
+%% default filtering value for the peer list (30days)
+-define(CURRENT_PEERS_LIST_FILTER, 30*60*60*24).
+
 %% The default rocksdb databases flush interval, 30 minutes.
 -define(DEFAULT_ROCKSDB_FLUSH_INTERVAL_S, 1800).
 %% The default rocksdb WAL sync interval, 1 minute.

--- a/apps/arweave/src/ar_header_sync.erl
+++ b/apps/arweave/src/ar_header_sync.erl
@@ -482,7 +482,7 @@ check_fork(Height, H, TXRoot) ->
 	end.
 
 download_block(H, H2, TXRoot) ->
-	Peers = ar_peers:get_peers(lifetime),
+	Peers = ar_peers:get_peers(current),
 	case ar_storage:read_block(H) of
 		unavailable ->
 			download_block(Peers, H, H2, TXRoot);
@@ -492,7 +492,8 @@ download_block(H, H2, TXRoot) ->
 
 download_block(Peers, H, H2, TXRoot) ->
 	Fork_2_0 = ar_fork:height_2_0(),
-	case ar_http_iface_client:get_block_shadow(Peers, H) of
+	Opts = #{ rand_min => length(Peers) },
+	case ar_http_iface_client:get_block_shadow(Peers, H, Opts) of
 		unavailable ->
 			?LOG_WARNING([
 				{event, ar_header_sync_failed_to_download_block_header},

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -4,19 +4,22 @@
 
 -module(ar_http_iface_client).
 
--export([send_block_json/3, send_block_binary/3, send_block_binary/4, send_tx_json/3,
-		send_tx_binary/3, send_block_announcement/2, get_block_shadow/2, get_block_shadow/3,
-		get_block/3, get_tx/2, get_txs/2, get_tx_from_remote_peer/2, get_tx_data/2,
-		get_wallet_list_chunk/2, get_wallet_list_chunk/3, get_wallet_list/2,
-		add_peer/1, get_info/1, get_info/2, get_peers/1, get_time/2, get_height/1,
-		get_block_index/3, get_sync_record/1, get_sync_record/3,
-		get_chunk_binary/3, get_mempool/1, get_sync_buckets/1,
-		get_recent_hash_list/1, get_recent_hash_list_diff/2, get_reward_history/3,
-		get_block_time_history/3,
-		push_nonce_limiter_update/3, get_vdf_update/1, get_vdf_session/1,
-		get_previous_vdf_session/1, get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
-		cm_publish_send/2, get_jobs/2, post_partial_solution/2,
-		get_pool_cm_jobs/2, post_pool_cm_jobs/2, post_cm_partition_table_to_pool/2]).
+-export([send_block_json/3, send_block_binary/3, send_block_binary/4,
+	 send_tx_json/3, send_tx_binary/3, send_block_announcement/2,
+	 get_block/3, get_tx/2, get_txs/2, get_tx_from_remote_peer/2,
+	 get_tx_data/2, get_wallet_list_chunk/2, get_wallet_list_chunk/3,
+	 get_wallet_list/2, add_peer/1, get_info/1, get_info/2, get_peers/1,
+	 get_time/2, get_height/1, get_block_index/3, get_sync_record/1,
+	 get_sync_record/3, get_chunk_binary/3, get_mempool/1,
+	 get_sync_buckets/1, get_recent_hash_list/1,
+	 get_recent_hash_list_diff/2, get_reward_history/3,
+	 get_block_time_history/3, push_nonce_limiter_update/3,
+	 get_vdf_update/1, get_vdf_session/1, get_previous_vdf_session/1,
+	 get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
+	 cm_publish_send/2, get_jobs/2, post_partial_solution/2,
+	 get_pool_cm_jobs/2, post_pool_cm_jobs/2,
+	 post_cm_partition_table_to_pool/2]).
+-export([get_block_shadow/2, get_block_shadow/3, get_block_shadow/4]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_config.hrl").
@@ -122,20 +125,38 @@ get_block(Peer, H, TXIndices) ->
 			{B, Time, Size}
 	end.
 
-%% @doc Retreive a block shadow by hash or height from one of the given peers.
-get_block_shadow([], _ID) ->
-	unavailable;
+%%--------------------------------------------------------------------
+%% @doc get a block shadow using default parameter.
+%% @end
+%%--------------------------------------------------------------------
 get_block_shadow(Peers, ID) ->
-	Peer = lists:nth(rand:uniform(min(5, length(Peers))), Peers),
-	case get_block_shadow(ID, Peer, binary) of
+	get_block_shadow(Peers, ID, #{}).
+
+%%--------------------------------------------------------------------
+%% @doc Retrieve a block shadow by hash or height from one of the given
+%%      peers. Some options can be modified like `rand_min',
+%%      `connect_timeout' and `timeout'.
+%% @see get_block_shadow/4
+%% @end
+%%--------------------------------------------------------------------
+get_block_shadow([], _ID, _Opts) ->
+	unavailable;
+get_block_shadow(Peers, ID, Opts) ->
+	RandMin = maps:get(rand_min, Opts, 5),
+	Random = rand:uniform(min(RandMin, length(Peers))),
+	Peer = lists:nth(Random, Peers),
+	case get_block_shadow(ID, Peer, binary, Opts) of
 		not_found ->
-			get_block_shadow(Peers -- [Peer], ID);
+			get_block_shadow(Peers -- [Peer], ID, Opts);
 		{ok, B, Time, Size} ->
 			{Peer, B, Time, Size}
 	end.
 
-%% @doc Retreive a block shadow by hash or height from the given peer.
-get_block_shadow(ID, Peer, Encoding) ->
+%%--------------------------------------------------------------------
+%% @doc Retrieve a block shadow by hash or height from the given peer.
+%% @end
+%%--------------------------------------------------------------------
+get_block_shadow(ID, Peer, Encoding, _Opts) ->
 	handle_block_response(Peer, Encoding,
 		ar_http:req(#{
 			method => get,
@@ -1097,7 +1118,7 @@ get_info(Peer) ->
 			timeout => 2 * 1000
 		})
 	of
-		{ok, {{<<"200">>, _}, _, JSON, _, _}} -> 
+		{ok, {{<<"200">>, _}, _, JSON, _, _}} ->
 			case ar_serialize:json_decode(JSON, [return_maps]) of
 				{ok, JsonMap} ->
 					JsonMap;

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -648,7 +648,7 @@ handle(<<"GET">>, [<<"peers">>], Req, _Pid) ->
 			[
 				list_to_binary(ar_util:format_peer(P))
 			||
-				P <- ar_peers:get_peers(lifetime),
+				P <- ar_peers:get_peers(current),
 				P /= ar_http_util:arweave_peer(Req),
 				ar_peers:is_public_peer(P)
 			]

--- a/apps/arweave/test/ar_fork_recovery_tests.erl
+++ b/apps/arweave/test/ar_fork_recovery_tests.erl
@@ -165,7 +165,10 @@ test_invalid_block_with_high_cumulative_difficulty() ->
 	%% Assert the nodes have continued building on the original fork.
 	[{H3, _, _} | _] = ar_test_node:wait_until_height(peer1, 2),
 	?assertNotEqual(B2#block.indep_hash, H3),
-	{_Peer, B3, _Time, _Size} = ar_http_iface_client:get_block_shadow(1, ar_test_node:peer_ip(peer1), binary),
+	{_Peer, B3, _Time, _Size} =
+	ar_http_iface_client:get_block_shadow(1,
+		ar_test_node:peer_ip(peer1),
+		binary, #{}),
 	?assertEqual(H2, B3#block.indep_hash).
 
 fake_block_with_strong_cumulative_difficulty(B, PrevB, CDiff) ->

--- a/apps/arweave/test/ar_http_iface_tests.erl
+++ b/apps/arweave/test/ar_http_iface_tests.erl
@@ -458,15 +458,14 @@ test_get_last_tx_single({_, _, _, {_, StaticPub}}) ->
 %% @doc Ensure that blocks can be received via a hash.
 test_get_block_by_hash({B0, _, _, _}) ->
 	{_Peer, B1, _Time, _Size} = ar_http_iface_client:get_block_shadow(B0#block.indep_hash,
-			ar_test_node:peer_ip(main), binary),
+			ar_test_node:peer_ip(main), binary, #{}),
 	TXIDs = [TX#tx.id || TX <- B0#block.txs],
 	?assertEqual(B0#block{ size_tagged_txs = unset, account_tree = undefined, txs = TXIDs,
 			reward_history = [], block_time_history = [] }, B1).
 
 %% @doc Ensure that blocks can be received via a height.
 test_get_block_by_height({B0, _, _, _}) ->
-	{_Peer, B1, _Time, _Size} = ar_http_iface_client:get_block_shadow(0, ar_test_node:peer_ip(main),
-			binary),
+	{_Peer, B1, _Time, _Size} = ar_http_iface_client:get_block_shadow(0, ar_test_node:peer_ip(main), binary, #{}),
 	TXIDs = [TX#tx.id || TX <- B0#block.txs],
 	?assertEqual(B0#block{ size_tagged_txs = unset, account_tree = undefined, txs = TXIDs,
 			reward_history = [], block_time_history = [] }, B1).
@@ -474,7 +473,8 @@ test_get_block_by_height({B0, _, _, _}) ->
 test_get_current_block({B0, _, _, _}) ->
 	Peer = ar_test_node:peer_ip(main),
 	{ok, BI} = ar_http_iface_client:get_block_index(Peer, 0, 100),
-	{_Peer, B1, _Time, _Size} = ar_http_iface_client:get_block_shadow(hd(BI), Peer, binary),
+	{_Peer, B1, _Time, _Size} =
+	ar_http_iface_client:get_block_shadow(hd(BI), Peer, binary, #{}),
 	TXIDs = [TX#tx.id || TX <- B0#block.txs],
 	?assertEqual(B0#block{ size_tagged_txs = unset, txs = TXIDs, reward_history = [],
 			block_time_history = [], account_tree = undefined }, B1),

--- a/bin/console
+++ b/bin/console
@@ -8,4 +8,4 @@ SCRIPT_ACTION="remote_console"
 
 # Sets $ARWEAVE and $ARWEAVE_* variables
 source ${SCRIPT_DIR}/arweave.env
-$(ARWEAVE} ${SCRIPT_ACTION}
+${ARWEAVE} ${SCRIPT_ACTION}


### PR DESCRIPTION
Added a way to know if a peer is up or down
in `ar_peers` by calling `ar_peers:connected_peer/1`
and `ar_peers:disconnected_peer/1` functions. To
know if a peer is activate, one can call
`ar_peers:is_connected_peer/1` function. The full
list of active peers (present in the ranking) can
be returned by calling `ar_peers:get_peers/1`
function.

    % returns the list of all connected peers.
    % this list is highly unstable, it will depend
    % on the gun HTTP connection
    ar_peers:get_peers(connected)

All connected peers are now being tagged with a
timestamp with one connection is successful. This
timestamp can be retrieved using `ar_peers:get_connection_timestamp/1`
function. To filter peers based on their timestamps,
`ar_peers:get_peers/1` can be used like this:

    % returns the list of peers connected during the
    % last 2 days
    ar_peers:get_peers({current, 2}).

Arweave can be started with a new option, controlling
the nodes returned by `/peers`. Only `current` value
can be filtered at this time of writing, and only
a number of positive days can be configured.

    peers_list_filter current
    peers_list_filter current:365

The default peers filtering is set to 30 days: `{current, 30}`.

"tags" are used as simple key in `ar_peers`
ets table, prefixed with the `ar_tags` atom. They
are saved in the `peers` file maintained with
`ar_storage` function.

Modified `ar_http_iface_client:get_block_shadow/2`
function to add more parameters, in particular
to modify default timeout and the value used to
pick a peer from peer list.

Modified `ar_header_sync` module to only select
active peer when synchronizing headers.

Fixed a typo in `bin/console`.