### PR TITLE
Fix p3 missing pattern

### DIFF
--- a/apps/arweave/src/ar_p3.erl
+++ b/apps/arweave/src/ar_p3.erl
@@ -22,6 +22,10 @@ allow_request(Req) ->
 	case catch gen_server:call(?MODULE, {allow_request, Req}) of
 		{'EXIT', {timeout, {gen_server, call, _}}} ->
 			{false, timeout};
+		{error, timeout} ->
+			{false, timeout};
+		timeout ->
+			{false, timeout};
 		Reply ->
 			Reply
 	end.


### PR DESCRIPTION
This fix an issue with p3 protocol. When the call returns timeout, the message is not correctly matched and crash the process.