### PR TITLE
Switch to arweave.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ limits](https://docs.arweave.org/info/mining/mining-guide#preparation-file-descr
 
 ```sh
 ./arweave-server \
-peer ams-1.eu-central-1.arweave.net \
-peer fra-1.eu-central-2.arweave.net \
-peer sgp-1.ap-central-2.arweave.net \
-peer blr-1.ap-central-1.arweave.net \
-peer sfo-1.na-west-1.arweave.net
+peer ams-1.eu-central-1.arweave.xyz \
+peer fra-1.eu-central-2.arweave.xyz \
+peer sgp-1.ap-central-2.arweave.xyz \
+peer blr-1.ap-central-1.arweave.xyz \
+peer sfo-1.na-west-1.arweave.xyz
 ```
 
 **Make a production build:**
@@ -105,7 +105,7 @@ The tarball is created at `_build/testnet/rel/arweave/arweave-x.y.z.tar.gz`.
 You can join the public testnet now:
 
 ```
-./bin/start peer testnet-1.arweave.net peer testnet-2.arweave.net peer testnet-3.arweave.net
+./bin/start peer testnet-1.arweave.xyz peer testnet-2.arweave.xyz peer testnet-3.arweave.xyz
 ```
 
 We recommend you do not use your mainnet mining address on testnet. Also, do not join the

--- a/apps/arweave/src/ar_peers.erl
+++ b/apps/arweave/src/ar_peers.erl
@@ -219,9 +219,13 @@ get_trusted_peers() ->
 	{ok, Config} = application:get_env(arweave, config),
 	case Config#config.peers of
 		[] ->
-			ArweavePeers = ["sfo-1.na-west-1.arweave.net", "ams-1.eu-central-1.arweave.net",
-					"fra-1.eu-central-2.arweave.net", "blr-1.ap-central-1.arweave.net",
-					"sgp-1.ap-central-2.arweave.net"],
+			ArweavePeers = [
+				"sfo-1.na-west-1.arweave.xyz",
+				"ams-1.eu-central-1.arweave.xyz",
+				"fra-1.eu-central-2.arweave.xyz",
+				"blr-1.ap-central-1.arweave.xyz",
+				"sgp-1.ap-central-2.arweave.xyz"
+			],
 			resolve_peers(ArweavePeers);
 		Peers ->
 			Peers

--- a/testnet/config/testnet-1.json
+++ b/testnet/config/testnet-1.json
@@ -6,19 +6,19 @@
     ],
     "mining_addr": "HnjnoDf25mJroiFgY3FJLYw3EsUtcF9LDcJYMI3gKZs",
     "peers": [
-        "testnet-2.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-4.arweave.net",
-        "testnet-5.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-2.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-4.arweave.xyz",
+        "testnet-5.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "coordinated_mining": true,
     "cm_api_secret": "testnet_cm_secret",
-    "cm_exit_peer": "testnet-2.arweave.net",
+    "cm_exit_peer": "testnet-2.arweave.xyz",
     "cm_peers": [
-        "testnet-2.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-2.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "debug": true,
     "mine": true,

--- a/testnet/config/testnet-2.json
+++ b/testnet/config/testnet-2.json
@@ -5,21 +5,21 @@
     ],
     "mining_addr": "HnjnoDf25mJroiFgY3FJLYw3EsUtcF9LDcJYMI3gKZs",
     "peers": [
-        "testnet-1.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-4.arweave.net",
-        "testnet-5.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-4.arweave.xyz",
+        "testnet-5.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "vdf_server_trusted_peers": [
-        "testnet-4.arweave.net"
+        "testnet-4.arweave.xyz"
     ],
     "coordinated_mining": true,
     "cm_api_secret": "testnet_cm_secret",
     "cm_peers": [
-        "testnet-1.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "debug": true,
     "mine": true,

--- a/testnet/config/testnet-3.json
+++ b/testnet/config/testnet-3.json
@@ -6,14 +6,14 @@
     ],
     "mining_addr": "peHwdWtsEr27dC7SeTT1hoympOePTO7vlJt2zhQMAtg",
     "peers": [
-        "testnet-1.arweave.net",
-        "testnet-2.arweave.net",
-        "testnet-4.arweave.net",
-        "testnet-5.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-2.arweave.xyz",
+        "testnet-4.arweave.xyz",
+        "testnet-5.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "vdf_server_trusted_peers": [
-        "testnet-4.arweave.net"
+        "testnet-4.arweave.xyz"
     ],
     "debug": true,
     "mine": true,

--- a/testnet/config/testnet-4.json
+++ b/testnet/config/testnet-4.json
@@ -7,7 +7,7 @@
     ],
     "mining_addr": "hDdptPiuAlrP5RxEHwZoffm7obIyvvBi40T5PPvp57w",
     "vdf_client_peers": [
-        "testnet-3.arweave.net"
+        "testnet-3.arweave.xyz"
     ],
     "header_sync_jobs": 0,
     "debug": true,

--- a/testnet/config/testnet-5.json
+++ b/testnet/config/testnet-5.json
@@ -10,11 +10,11 @@
     ],
     "mining_addr": "v0AnxIi2DhwdyKUEHR_GrHjIGJtv1ImSB2z2ZWyQzSc",
     "peers": [
-        "testnet-1.arweave.net",
-        "testnet-2.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-4.arweave.net",
-        "testnet-6.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-2.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-4.arweave.xyz",
+        "testnet-6.arweave.xyz"
     ],
     "debug": true,
     "mine": true,

--- a/testnet/config/testnet-6.json
+++ b/testnet/config/testnet-6.json
@@ -10,21 +10,21 @@
     ],
     "mining_addr": "HnjnoDf25mJroiFgY3FJLYw3EsUtcF9LDcJYMI3gKZs",
     "peers": [
-        "testnet-1.arweave.net",
-        "testnet-2.arweave.net",
-        "testnet-3.arweave.net",
-        "testnet-4.arweave.net",
-        "testnet-5.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-2.arweave.xyz",
+        "testnet-3.arweave.xyz",
+        "testnet-4.arweave.xyz",
+        "testnet-5.arweave.xyz"
     ],
     "vdf_server_trusted_peers": [
-        "testnet-4.arweave.net"
+        "testnet-4.arweave.xyz"
     ],
     "cm_api_secret": "testnet_cm_secret",
-    "cm_exit_peer": "testnet-2.arweave.net",
+    "cm_exit_peer": "testnet-2.arweave.xyz",
     "cm_peers": [
-        "testnet-1.arweave.net",
-        "testnet-2.arweave.net",
-        "testnet-3.arweave.net"
+        "testnet-1.arweave.xyz",
+        "testnet-2.arweave.xyz",
+        "testnet-3.arweave.xyz"
     ],
     "debug": true,
     "mine": true,


### PR DESCRIPTION
Arweave domains are moving from arweave.net to arweave.xyz.