### PR TITLE
Change Logging Feature Mode

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -707,54 +707,11 @@ start(Config) ->
 	end,
 	start_dependencies().
 
+
 start(normal, _Args) ->
 	{ok, Config} = application:get_env(arweave, config),
-	%% Configure logging for console output.
-	LoggerFormatterConsole = #{
-		legacy_header => false,
-		single_line => true,
-		chars_limit => 16256,
-		max_size => 8128,
-		depth => 256,
-		template => [time," [",level,"] ",mfa,":",line," ",msg,"\n"]
-	},
-	logger:set_handler_config(default, formatter, {logger_formatter, LoggerFormatterConsole}),
-	logger:set_handler_config(default, level, error),
-	%% Configure logging to the logfile.
-	LoggerConfigDisk = #{
-		file => lists:flatten(filename:join(Config#config.log_dir, atom_to_list(node()))),
-		type => wrap,
-		max_no_files => 10,
-		max_no_bytes => 51418800 % 10 x 5MB
-	},
-	logger:add_handler(disk_log, logger_disk_log_h,
-			#{ config => LoggerConfigDisk, level => info }),
-	Level =
-		case Config#config.debug of
-			false ->
-				info;
-			true ->
-				DebugLoggerConfigDisk = #{
-					file => lists:flatten(filename:join([Config#config.log_dir, "debug_logs",
-							atom_to_list(node())])),
-					type => wrap,
-					max_no_files => 20,
-					max_no_bytes => 51418800 % 10 x 5MB
-				},
-				logger:add_handler(disk_debug_log, logger_disk_log_h,
-						#{ config => DebugLoggerConfigDisk, level => debug }),
-				debug
-		end,
-	LoggerFormatterDisk = #{
-		chars_limit => 16256,
-		max_size => 8128,
-		depth => 256,
-		legacy_header => false,
-		single_line => true,
-		template => [time," [",level,"] ",mfa,":",line," ",msg,"\n"]
-	},
-	logger:set_handler_config(disk_log, formatter, {logger_formatter, LoggerFormatterDisk}),
-	logger:set_application_level(arweave, Level),
+	%% Configure logger
+	ar_logger:init(Config),
 	%% Start the Prometheus metrics subsystem.
 	prometheus_registry:register_collector(prometheus_process_collector),
 	prometheus_registry:register_collector(ar_metrics_collector),

--- a/apps/arweave/src/ar_logger.erl
+++ b/apps/arweave/src/ar_logger.erl
@@ -1,0 +1,83 @@
+%%%===================================================================
+%%% @doc module in charge of the logging features.
+%%% @end
+%%%===================================================================
+-module(ar_logger).
+-export([init/1]).
+-include_lib("arweave/include/ar.hrl").
+-include_lib("arweave/include/ar_config.hrl").
+
+%%--------------------------------------------------------------------
+%% @doc Uses #config{} record by default.
+%% @end
+%%--------------------------------------------------------------------
+init(Config) ->
+    init_console(Config),
+    init_default(Config),
+    init_debug(Config).
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% @doc Configure logging for console output.
+%% @end
+%%--------------------------------------------------------------------
+init_console(Config) ->
+    Template = [time," [",level,"] ",mfa,":",line," ",msg,"\n"],
+    LoggerFormatterConsole = #{ legacy_header => false
+			      , single_line => true
+			      , chars_limit => 16256
+			      , max_size => 8128
+			      , depth => 256
+			      , template => Template
+			      },
+    logger:set_handler_config(default, formatter, {logger_formatter, LoggerFormatterConsole}),
+    logger:set_handler_config(default, level, error).
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% @doc Configure logging to the logfile.
+%% @end
+%%--------------------------------------------------------------------
+init_default(Config) ->
+    Level = info,
+    FileName = "arweave.log",
+    FilePath = lists:flatten(filename:join(Config#config.log_dir, FileName)),
+    LoggerConfigDisk = #{ file => FilePath
+			, type => file
+			, max_no_files => 10
+			, max_no_bytes => 51418800 % 10 x 5MB
+			, modes => [raw, append]
+			},
+    LoggerConfig = #{ config => LoggerConfigDisk, level => Level },
+    Template = [time," [",level,"] ",mfa,":",line," ",msg,"\n"],
+    LoggerFormatterDisk = #{ chars_limit => 16256
+			   , max_size => 8128
+			   , depth => 256
+			   , legacy_header => false
+			   , single_line => true
+			   , template => Template
+			   },
+    logger:add_handler(disk_log, logger_std_h, LoggerConfig),
+    logger:set_handler_config(disk_log, formatter, {logger_formatter, LoggerFormatterDisk}).
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% @doc set debug logging feature
+%% @end
+%%--------------------------------------------------------------------
+init_debug(#config{ debug = true } = Config) ->
+    Level = debug,
+    FileName = "debug.log",
+    FilePath = lists:flatten(filename:join([Config#config.log_dir, "debug.log"])),
+    DebugLoggerConfigDisk = #{ file => FilePath
+			     , type => file
+			     , max_no_files => 20
+			     , max_no_bytes => 51418800 % 10 x 5MB
+			     , modes => [raw, append]
+			     },
+    LoggerConfig = #{ config => DebugLoggerConfigDisk, level => Level },
+    logger:add_handler(disk_debug_log, logger_std_h, LoggerConfig),
+    logger:set_application_level(arweave, Level);
+init_debug(_) ->
+    Level = info,
+    logger:set_application_level(arweave, Level).


### PR DESCRIPTION
This commit creates a new module called `ar_logger` where all functions related to logging are present. The goal here is also to get rid of the `disk_log` logging type causing sync issues on rsyslog and using a more conventional "Unix way" to store logs.

The previous method using `disk_log` was using a wrap method, creating also two files ending with .siz and .idx to follow the logs. One of the important feature of `disk_log` is to repair logs, but it seems this feature is not used. Instead, using a simple append method with `logger_std_h` mode will make things easier when collecting logs.