### PR TITLE
Fix High Load Average on Transaction Interface

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -67,6 +67,7 @@
 -define(MAX_PARALLEL_POST_CHUNK_REQUESTS, 100).
 -define(MAX_PARALLEL_GET_SYNC_RECORD_REQUESTS, 10).
 -define(MAX_PARALLEL_REWARD_HISTORY_REQUESTS, 1).
+-define(MAX_PARALLEL_GET_TX_REQUESTS, 20).
 
 %% The number of parallel tx validation processes.
 -define(MAX_PARALLEL_POST_TX_REQUESTS, 20).
@@ -179,7 +180,8 @@
 		get_wallet_list => ?MAX_PARALLEL_WALLET_LIST_REQUESTS,
 		get_sync_record => ?MAX_PARALLEL_GET_SYNC_RECORD_REQUESTS,
 		post_tx => ?MAX_PARALLEL_POST_TX_REQUESTS,
-		get_reward_history => ?MAX_PARALLEL_REWARD_HISTORY_REQUESTS
+		get_reward_history => ?MAX_PARALLEL_REWARD_HISTORY_REQUESTS,
+		get_tx => ?MAX_PARALLEL_GET_TX_REQUESTS
 	},
 	disk_cache_size = ?DISK_CACHE_SIZE,
 	packing_rate,

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -1593,6 +1593,7 @@ handle_get_tx(Hash, Req, Encoding) ->
 		{error, invalid} ->
 			{400, #{}, <<"Invalid hash.">>, Req};
 		{ok, ID} ->
+			ok = ar_semaphore:acquire(get_tx, infinity),
 			case ar_storage:read_tx(ID) of
 				unavailable ->
 					maybe_tx_is_pending_response(ID, Req);


### PR DESCRIPTION
When a server has the full transaction locally, and uses spinning disk, the amount of requests from other nodes is too high, and leads to a bottleneck on rocksdb database.

This commit adds a semaphore to control the amount of requests on `ar_http_iface_middleware:handle_get_tx/3` function, to avoid a node to be overflooded by requests.

see: https://github.com/ArweaveTeam/arweave-dev/issues/704