### PR TITLE
Add Packing Difficulty in v2_index_data_size_by_packing

### DIFF
--- a/apps/arweave/src/ar_metrics.erl
+++ b/apps/arweave/src/ar_metrics.erl
@@ -158,10 +158,11 @@ register() ->
 	]),
 	prometheus_gauge:new([
 		{name, v2_index_data_size_by_packing},
-		{labels, [store_id, packing, partition_number, storage_module_size, storage_module_index]},
+		{labels, [store_id, packing, partition_number, storage_module_size, storage_module_index,
+			  packing_difficulty]},
 		{help, "The size (in bytes) of the data stored and indexed. Grouped by the "
 				"store ID, packing, partition number, storage module size, "
-				"and storage module index."}
+				"storage module index, and packing difficulty."}
 	]),
 
 	%% Disk pool.

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -162,8 +162,11 @@ set_storage_module_data_size(
 	StoreLabel = ar_storage_module:label_by_id(StoreID),
 	PackingLabel = ar_storage_module:packing_label(Packing),
 	try	
+		PackingDifficulty = get_packing_difficulty(Packing),
 		prometheus_gauge:set(v2_index_data_size_by_packing,
-			[StoreLabel, PackingLabel, PartitionNumber, StorageModuleSize, StorageModuleIndex],
+			[StoreLabel, PackingLabel, PartitionNumber,
+			 StorageModuleSize, StorageModuleIndex,
+			 PackingDifficulty],
 			DataSize),
 		ets:insert(?MODULE, {
 			{partition, PartitionNumber, storage_module, StoreID, packing, Packing}, DataSize})


### PR DESCRIPTION
This commit adds the packing difficulty in `v2_index_data_size_by_packing` metric.

see: https://github.com/ArweaveTeam/arweave-dev/issues/568