### PR TITLE
Fix Gun Message Leaks

### DIFF
--- a/apps/arweave/src/ar_tx_emitter_worker.erl
+++ b/apps/arweave/src/ar_tx_emitter_worker.erl
@@ -55,21 +55,6 @@ handle_cast(Msg, State) ->
 handle_info({event, tx, _}, State) ->
 	{noreply, State};
 
-handle_info({gun_down, _, http, normal, _, _}, State) ->
-	{noreply, State};
-handle_info({gun_down, _, http, closed, _, _}, State) ->
-	{noreply, State};
-handle_info({gun_down, _, http, {error,econnrefused}, _, _}, State) ->
-	{noreply, State};
-handle_info({gun_up, _, http}, State) ->
-	{noreply, State};
-handle_info({gun_response, _, _, _, _, _}, State) ->
-	{noreply, State};
-handle_info({gun_data, _, _, _, _}, state) ->
-	{noreply, state};
-handle_info({gun_error, _, _, _}, State) ->
-	{noreply, State};
-
 handle_info(Info, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.


### PR DESCRIPTION
`ar_http` client was using internal functions
from inet (`inet:start_timer/1` and `inet:stop_timer/1`). Those functions are wrapper around `timer` module and send a message to the current active process doing the http request. Unfortunately, this is not compatible with `gun:await/3è function and breaks its loop. Gun messages are after send to the active process.

see: https://github.com/ArweaveTeam/arweave-dev/issues/717