### PR TITLE
Possible TODO removal

### DIFF
--- a/apps/arweave/src/ar_node_worker.erl
+++ b/apps/arweave/src/ar_node_worker.erl
@@ -2002,7 +2002,6 @@ handle_found_solution(Args, PrevB, State) ->
 	HaveSteps2 =
 		case HaveSteps of
 			not_found ->
-				% TODO verify
 				SuppliedSteps;
 			_ ->
 				HaveSteps


### PR DESCRIPTION
I was looking into the TODOs in the code and noticed this. I don't think we need to verify it (or at least to my understanding) since these steps will be validated in the `apply_block` call at the end of this function. This will run `request_nonce_limiter_validation(B, PrevB),` asyncronously which will validate if the `SuppliedSteps` field is valid or not. 

Or if my interpretation is wrong, should we have some other kind of field validation synchronously?