### PR TITLE
Allow to run test in all the modules or single test inside module

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ bin/shell
 Run a specific test (the shell offers autocompletion):
 
 ```sh
-bin/test ar_fork_recovery_tests:height_plus_one_fork_recovery_test_()
+bin/test ar_fork_recovery_tests:height_plus_one_fork_recovery_test_
 ```
 
 If it fails, the nodes keep running so you can inspect them through Erlang shell or HTTP API.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ $ bin/shell
 Run a specific test (the shell offers autocompletion):
 
 ```sh
-(master@127.0.0.1)1> eunit:test(ar_fork_recovery_tests:height_plus_one_fork_recovery_test_()).
+bin/test ar_fork_recovery_tests:height_plus_one_fork_recovery_test_()
 ```
 
 If it fails, the nodes keep running so you can inspect them through Erlang shell or HTTP API.

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -871,9 +871,11 @@ tests(Mods, Config) when is_list(Mods) ->
 			io:format("Failed to start the peers due to ~p:~p~n", [Type, Reason]),
 			erlang:halt(1)
 	end,
+	Tests = extract_single_test(Mods),
+	io:format(user, "~nTests to run : ~p~n", [Tests]),
 	Result =
 		try
-			eunit:test({timeout, ?TEST_TIMEOUT, [Mods]}, [verbose, {print_depth, 100}])
+			eunit:test({timeout, ?TEST_TIMEOUT, [Tests]}, [verbose, {print_depth, 100}])
 		after
 			ar_test_node:stop_peers()
 		end,
@@ -882,6 +884,23 @@ tests(Mods, Config) when is_list(Mods) ->
 		_ -> erlang:halt(1)
 	end.
 
+extract_single_test(Mods) -> 
+	lists:map(
+		fun(TestRep) ->
+			case string:split(atom_to_list(TestRep), ":") of
+				[M, F] ->
+					case string:split(F, "_test_") of
+						[_, []] ->
+							{generator, list_to_atom(M), list_to_atom(F)};
+						_ ->
+							{test, list_to_atom(M), list_to_atom(F)}
+					end;
+				_ ->
+					TestRep
+			end
+		end,
+		Mods
+	).
 
 start_for_tests(Config) ->
 	UniqueName = ar_test_node:get_node_namespace(),

--- a/bin/test
+++ b/bin/test
@@ -8,10 +8,20 @@ cd "$SCRIPT_DIR/.."
 
 export ERL_EPMD_ADDRESS=127.0.0.1
 
+if [[ $# -gt 0 ]]; then
+	MODULES=$@
+else
+	SRC_MODULES=$(ls $SCRIPT_DIR/../apps/arweave/src | sed -n 's/.erl$//p' | sort)
+	TEST_MODULE_BASENAMES=$(ls $SCRIPT_DIR/../apps/arweave/test | sed -n 's/_tests.erl$//p' | sort)
+	NON_SRC_TEST_MODULE_BASENAMES=$(comm -13 <(printf "%s\n" $SRC_MODULES) <(printf "%s\n" $TEST_MODULE_BASENAMES))
+	NON_SRC_TEST_MODULES=$(echo $NON_SRC_TEST_MODULE_BASENAMES | xargs -I{} echo '{}_tests')
+	MODULES="$SRC_MODULES $NON_SRC_TEST_MODULES"
+fi
+
 ERL_TEST_OPTS="-pa `./rebar3 as test path` `./rebar3 as test path --base`/lib/arweave/test -config config/sys.config"
 echo -e "\033[0;32m===> Running tests...\033[0m"
 
 set -x
 set -o pipefail
-stdbuf -oL -eL erl $ERL_TEST_OPTS -noshell -name main-localtest@127.0.0.1 -setcookie test -run ar tests ${@:1} -s init stop 2>&1 | tee main-localtest.out
+stdbuf -oL -eL erl $ERL_TEST_OPTS -noshell -name main-localtest@127.0.0.1 -setcookie test -run ar tests $MODULES -s init stop 2>&1 | tee main-localtest.out
 set +x


### PR DESCRIPTION
This change can facilitate testing. The first one allows running all tests (in both `src` and `test` modules) when no parameter is given, and the second one allows running a single test inside a module using for example `./bin/test ar_fork_recovery_tests:height_plus_one_fork_recovery_test_` instead of using `bin/shell`.