### PR TITLE
Optimize and Improve Github CI/CD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,22 +11,127 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+
+      # only arweave dependencies are being cached,
+      # those are not updated everyday and this is
+      # unecessary to fetch them everytime.
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            _build/default/lib/accept
+            _build/default/lib/b64fast
+            _build/default/lib/cowboy
+            _build/default/lib/cowlib
+            _build/default/lib/graphql
+            _build/default/lib/gun
+            _build/default/lib/jiffy
+            _build/default/lib/prometheus
+            _build/default/lib/prometheus_cowboy
+            _build/default/lib/prometheus_httpd
+            _build/default/lib/prometheus_process_collector
+            _build/default/lib/quantile_estimator
+            _build/default/lib/ranch
+            _build/default/lib/.rebar3
+            _build/default/lib/recon
+            _build/default/lib/rocksdb
+            _build/default/plugins/
+            _build/default/plugins/aleppo
+            _build/default/plugins/geas
+            _build/default/plugins/geas_rebar3
+            _build/default/plugins/hex_core
+            _build/default/plugins/katana_code
+            _build/default/plugins/pc
+            _build/default/plugins/.rebar3
+            _build/default/plugins/rebar3_archive_plugin
+            _build/default/plugins/rebar3_elvis_plugin
+            _build/default/plugins/rebar3_hex
+            _build/default/plugins/samovar
+            _build/default/plugins/verl
+            _build/default/plugins/zipper
+          key: deps-cache-${{ hashFiles('rebar.lock') }}
+          restore-keys: |
+            deps-cache-${{ hashFiles('rebar.lock') }}
+
+      - name: Get dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: ./ar-rebar3 test get-deps
+
+      - uses: actions/cache@v4
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            _build/default/lib/accept
+            _build/default/lib/b64fast
+            _build/default/lib/cowboy
+            _build/default/lib/cowlib
+            _build/default/lib/graphql
+            _build/default/lib/gun
+            _build/default/lib/jiffy
+            _build/default/lib/prometheus
+            _build/default/lib/prometheus_cowboy
+            _build/default/lib/prometheus_httpd
+            _build/default/lib/prometheus_process_collector
+            _build/default/lib/quantile_estimator
+            _build/default/lib/ranch
+            _build/default/lib/.rebar3
+            _build/default/lib/recon
+            _build/default/lib/rocksdb
+            _build/default/plugins/
+            _build/default/plugins/aleppo
+            _build/default/plugins/geas
+            _build/default/plugins/geas_rebar3
+            _build/default/plugins/hex_core
+            _build/default/plugins/katana_code
+            _build/default/plugins/pc
+            _build/default/plugins/.rebar3
+            _build/default/plugins/rebar3_archive_plugin
+            _build/default/plugins/rebar3_elvis_plugin
+            _build/default/plugins/rebar3_hex
+            _build/default/plugins/samovar
+            _build/default/plugins/verl
+            _build/default/plugins/zipper
+          key: deps-cache-${{ hashFiles('rebar.lock') }}
+
       - name: Build arweave test sources
+        run: ./ar-rebar3 test compile
+
+      # some artifacts are compiled and only available
+      # in arweave directy (libraries)
+      - name: Prepare artifacts
         run: |
-          rm -rf _build || true
-          ./ar-rebar3 test compile
           chmod -R u+w ./_build
-          tar --dereference -czf /tmp/arweave_build_${{ github.run_id }}.tar.gz _build
+          tar czfp _build.tar.gz ./_build
+          tar czfp apps.tar.gz ./apps
+
+      # to avoid reusing artifacts from someone else
+      # and generating issues, an unique artifact is
+      # produced using github checksum.
+      - name: upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
+          path: |
+            _build.tar.gz
+            apps.tar.gz
 
   eunit-tests:
     needs: build
     runs-on: self-hosted
     strategy:
       fail-fast: true
-      max-parallel: 12
+
+      # 8 parallel jobs seem to be a correct value. 12
+      # jobs were used previously, but it was requiring
+      # too much CPU and RAM (in particular if more than
+      # one developer is used the pipelines).
+      max-parallel: 8
       matrix:
         core_test_mod: [
-            ## Long-running tests. Put these first to limit the overall runtime of the 
+            ## Long-running tests. Put these first to limit the overall runtime of the
             ## test suite
             ar_coordinated_mining_tests,
             ar_data_sync_tests,
@@ -105,36 +210,36 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - name: Extract build artifact
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ github.sha }}
+
+      # Both artifacts (_build and apps dir) are
+      # required.
+      - name: Extract artifact
         run: |
-          if [ ! -d "_build_${{ github.run_id }}" ]; then
-            rm -rf _build || true
-            tar -xzf /tmp/arweave_build_${{ github.run_id }}.tar.gz
-            mv ./_build ./_build_${{ github.run_id }}
-          fi
-      - name: Restart epmd
-        run: |
-          if ! pgrep -x "epmd" > /dev/null
-          then
-            echo "Starting epmd"
-            epmd -relaxed_command_check -daemon
-          fi
+          tar zxfp _build.tar.gz
+          tar zxfp apps.tar.gz
+
       - name: ${{ matrix.core_test_mod }}.erl
         id: tests
         run: |
-          rm -f *.out || true
           EXIT_CODE=0
-          export PATH=$(pwd)/_build_${{ github.run_id }}/erts/bin:$PATH
+          export PATH=$(pwd)/_build/erts/bin:$PATH
           export ERL_EPMD_ADDRESS=127.0.0.1
-          export TIMESTAMP_IN_MILLISECONDS=$(date +%s%3N)
-          export NAMESPACE="${{ matrix.core_test_mod }}_${TIMESTAMP_IN_MILLISECONDS}"
-          export ERL_TEST_OPTS="-pa $(echo $(pwd)/_build_${{ github.run_id }}/test/lib/*/ebin) $(pwd)/_build_${{ github.run_id }}/test/lib/arweave/test -config $(pwd)/config/sys.config"
+          export NAMESPACE="${{ matrix.core_test_mod }}"
+          export ERL_PATH_ADD="$(echo $(pwd)/_build/test/lib/*/ebin)"
+          export ERL_PATH_TEST="$(pwd)/_build/test/lib/arweave/test"
+          export ERL_PATH_CONF="$(pwd)/config/sys.config"
+          export ERL_TEST_OPTS="-pa ${ERL_PATH_ADD} ${ERL_PATH_TEST} -config ${ERL_PATH_CONF}"
           RETRYABLE=1
           while [[ $RETRYABLE -eq 1 ]]; do
             RETRYABLE=0
             set +e
             set -x
-            erl +S 4:4 $ERL_TEST_OPTS -noshell -name main-${NAMESPACE}@127.0.0.1 -setcookie ${{ matrix.core_test_mod }} -run ar tests "${{ matrix.core_test_mod }}" -s init stop 2>&1 | tee main.out
+            erl +S 4:4 $ERL_TEST_OPTS -noshell -name "main-${NAMESPACE}@127.0.0.1" -setcookie "${{ matrix.core_test_mod }}" -run ar tests "${{ matrix.core_test_mod }}" -s init stop 2>&1 | tee main.out
             EXIT_CODE=${PIPESTATUS[0]}
             set +x
             set -e
@@ -191,20 +296,3 @@ jobs:
           done
           echo "exit_code=$EXIT_CODE" >> $GITHUB_ENV # Set the exit_code output variable using Environment Files
           exit $EXIT_CODE # exit with the exit code of the tests
-      - name: Cleanup successful test
-        if: steps.tests.outputs.exit_code == '0' # Conditional based on the output variable
-        run: rm -rf logs *.out .tmp
-
-  cleanup:
-    needs: eunit-tests
-    runs-on: self-hosted
-    if: ${{ success() && needs.eunit-tests.result == 'success' }}
-    steps:
-      - name: Cleanup build directories
-        run: |
-          rm -rf /tmp/arweave_build_${{ github.run_id }}.tar.gz
-          find /home/runner -type d -name "_build_${{ github.run_id }}" -exec rm -rf {} +
-      - name: Cleanup old build artifacts
-        run: |
-          find /tmp -maxdepth 1 -name "arweave_build_*" -type f -mtime +7 -exec rm -f {} +
-          find /home/runner -name "_build_*" -type d -mtime +7 -exec rm -rf {} +

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -934,7 +934,7 @@ docs() ->
 
 %% @doc Ensure that parsing of core command line options functions correctly.
 commandline_parser_test_() ->
-	{timeout, 20, fun() ->
+	{timeout, 60, fun() ->
 		Addr = crypto:strong_rand_bytes(32),
 		Tests =
 			[

--- a/apps/arweave/test/ar_coordinated_mining_tests.erl
+++ b/apps/arweave/test/ar_coordinated_mining_tests.erl
@@ -8,12 +8,16 @@
 
 -import(ar_test_node, [http_get_block/2]).
 
+-define(MINING_TEST_TIMEOUT, 240).
+-define(API_TEST_TIMEOUT, 120).
+-define(PARTITION_TEST_TIMEOUT, 120).
+
 %% --------------------------------------------------------------------
 %% Test registration
 %% --------------------------------------------------------------------
 mining_test_() ->
 	[
-		{timeout, 120, fun test_single_node_one_chunk/0},
+		{timeout, ?MINING_TEST_TIMEOUT, fun test_single_node_one_chunk/0},
 		ar_test_node:test_with_mocked_functions([
 			ar_test_node:mock_to_force_invalid_h1()],
 			fun test_single_node_two_chunk/0, 120),
@@ -22,22 +26,22 @@ mining_test_() ->
 			fun test_cross_node/0, 240),
 		ar_test_node:test_with_mocked_functions([
 			ar_test_node:mock_to_force_invalid_h1()],
-			fun test_cross_node_retarget/0, 240),
-		{timeout, 240, fun test_two_node_retarget/0},
-		{timeout, 240, fun test_three_node/0},
-		{timeout, 120, fun test_no_exit_node/0}
+			fun test_cross_node_retarget/0, ?MINING_TEST_TIMEOUT),
+		{timeout, ?MINING_TEST_TIMEOUT, fun test_two_node_retarget/0},
+		{timeout, ?MINING_TEST_TIMEOUT, fun test_three_node/0},
+		{timeout, ?MINING_TEST_TIMEOUT, fun test_no_exit_node/0}
 	].
 
 api_test_() ->
 	[
-		{timeout, 120, fun test_no_secret/0},
-		{timeout, 120, fun test_bad_secret/0},
-		{timeout, 120, fun test_partition_table/0}
+		{timeout, ?API_TEST_TIMEOUT, fun test_no_secret/0},
+		{timeout, ?API_TEST_TIMEOUT, fun test_bad_secret/0},
+		{timeout, ?API_TEST_TIMEOUT, fun test_partition_table/0}
 	].
 
 refetch_partitions_test_() ->
 	[
-		{timeout, 120, fun test_peers_by_partition/0}
+		{timeout, ?PARTITION_TEST_TIMEOUT, fun test_peers_by_partition/0}
 	].
 
 %% --------------------------------------------------------------------

--- a/apps/arweave/test/ar_data_sync_tests.erl
+++ b/apps/arweave/test/ar_data_sync_tests.erl
@@ -135,8 +135,8 @@ test_mines_off_only_last_chunks() ->
 							ar_nonce_limiter:get_current_step_number()
 									> PrevStepNumber + ?NONCE_LIMITER_RESET_FREQUENCY
 						end,
-						200,
-						20000
+						100,
+						60000
 					);
 				0 ->
 					%% Wait until the new chunks fall below the new upper bound and
@@ -211,7 +211,7 @@ test_mines_off_only_second_last_chunks() ->
 	).
 
 disk_pool_rotation_test_() ->
-	{timeout, 60, fun test_disk_pool_rotation/0}.
+	{timeout, 120, fun test_disk_pool_rotation/0}.
 
 test_disk_pool_rotation() ->
 	Addr = ar_wallet:to_address(ar_wallet:new_keyfile()),

--- a/apps/arweave/test/ar_fork_recovery_tests.erl
+++ b/apps/arweave/test/ar_fork_recovery_tests.erl
@@ -7,7 +7,7 @@
 		assert_wait_until_height/2, wait_until_height/1, read_block_when_stored/1]).
 
 height_plus_one_fork_recovery_test_() ->
-	{timeout, 120, fun test_height_plus_one_fork_recovery/0}.
+	{timeout, 240, fun test_height_plus_one_fork_recovery/0}.
 
 test_height_plus_one_fork_recovery() ->
 	%% Mine on two nodes until they fork. Mine an extra block on one of them.
@@ -36,7 +36,7 @@ test_height_plus_one_fork_recovery() ->
 	?assertEqual(PeerBI, wait_until_height(4)).
 
 height_plus_three_fork_recovery_test_() ->
-	{timeout, 120, fun test_height_plus_three_fork_recovery/0}.
+	{timeout, 240, fun test_height_plus_three_fork_recovery/0}.
 
 test_height_plus_three_fork_recovery() ->
 	%% Mine on two nodes until they fork. Mine three extra blocks on one of them.
@@ -64,7 +64,7 @@ test_height_plus_three_fork_recovery() ->
 	?assertEqual(MainBI, ar_test_node:wait_until_height(peer1, 4)).
 
 missing_txs_fork_recovery_test_() ->
-	{timeout, 120, fun test_missing_txs_fork_recovery/0}.
+	{timeout, 240, fun test_missing_txs_fork_recovery/0}.
 
 test_missing_txs_fork_recovery() ->
 	%% Mine a block with a transaction on the peer1 node
@@ -86,7 +86,7 @@ test_missing_txs_fork_recovery() ->
 	?assertEqual(1, length((read_block_when_stored(H1))#block.txs)).
 
 orphaned_txs_are_remined_after_fork_recovery_test_() ->
-	{timeout, 120, fun test_orphaned_txs_are_remined_after_fork_recovery/0}.
+	{timeout, 240, fun test_orphaned_txs_are_remined_after_fork_recovery/0}.
 
 test_orphaned_txs_are_remined_after_fork_recovery() ->
 	%% Mine a transaction on peer1, mine two blocks on main to
@@ -156,7 +156,7 @@ test_invalid_block_with_high_cumulative_difficulty() ->
 		{event, block, Other} ->
 			?debugFmt("Unexpected block event: ~p", [Other]),
 			?assert(false, "Unexpected block event")
-	after 5000 ->
+	after 60_000 ->
 		?assert(false, "Timed out waiting for the node to pre-validate the fake "
 				"block.")
 	end,

--- a/apps/arweave/test/ar_http_iface_tests.erl
+++ b/apps/arweave/test/ar_http_iface_tests.erl
@@ -860,7 +860,8 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 	timer:sleep(200),
 	ar_test_node:mine(),
 	wait_until_height(LocalHeight + 2),
-	{ok, {_, _, GetTXBody, _, _}} =
+	timer:sleep(200),
+	{ok, {{<<"200">>, <<"OK">>}, _, GetTXBody, _, _}} =
 		ar_http:req(#{
 			method => get,
 			peer => ar_test_node:peer_ip(main),

--- a/apps/arweave/test/ar_semaphore_tests.erl
+++ b/apps/arweave/test/ar_semaphore_tests.erl
@@ -39,35 +39,35 @@ wait_for_two_processes_at_a_time_test_() ->
 		TestPid = self(),
 		spawn_link(fun() ->
 			ok = ar_semaphore:acquire(wait_for_two_processes_at_a_time_sem, infinity),
-			timer:sleep(200),
+			timer:sleep(400),
 			TestPid ! p1_done
 		end),
 		spawn_link(fun() ->
 			ok = ar_semaphore:acquire(wait_for_two_processes_at_a_time_sem, infinity),
-			timer:sleep(200),
+			timer:sleep(400),
 			TestPid ! p2_done
 		end),
 		spawn_link(fun() ->
 			ok = ar_semaphore:acquire(wait_for_two_processes_at_a_time_sem, infinity),
-			timer:sleep(200),
+			timer:sleep(400),
 			TestPid ! p3_done
 		end),
 		spawn_link(fun() ->
 			ok = ar_semaphore:acquire(wait_for_two_processes_at_a_time_sem, infinity),
-			timer:sleep(200),
+			timer:sleep(400),
 			TestPid ! p4_done
 		end),
-		?assert(receive _ -> false after 180 -> true end),
-		?assert(receive p1_done -> true after 20 -> false end),
-		?assert(receive p2_done -> true after 20 -> false end),
-		?assert(receive _ -> false after 170 -> true end),
-		?assert(receive p3_done -> true after 30 -> false end),
-		?assert(receive p4_done -> true after 30 -> false end)
+		?assert(receive _ -> false after 360 -> true end),
+		?assert(receive p1_done -> true after 40 -> false end),
+		?assert(receive p2_done -> true after 40 -> false end),
+		?assert(receive _ -> false after 340 -> true end),
+		?assert(receive p3_done -> true after 60 -> false end),
+		?assert(receive p4_done -> true after 60 -> false end)
 	end).
 
 with_semaphore_(Name, Value, Fun) ->
 	{setup,
-		fun() -> ar_semaphore:start_link(Name, Value) end,
-		fun(_) -> ar_semaphore:stop(Name) end,
+		fun() -> ok = ar_semaphore:start_link(Name, Value) end,
+		fun(_) -> _ = ar_semaphore:stop(Name) end,
 		[Fun]
 	}.

--- a/apps/arweave/test/ar_test_data_sync.erl
+++ b/apps/arweave/test/ar_test_data_sync.erl
@@ -14,6 +14,8 @@
         generate_random_split/1, generate_random_original_split/1,
         generate_random_standard_split/0, generate_random_original_v1_split/0]).
 
+-define(SYNC_CHUNKS_CHECK, 1000).
+-define(SYNC_CHUNKS_TIMEOUT, 300*1000).
 
 get_records_with_proofs(B, TX, Chunks) ->
 	[{B, TX, Chunks, Proof} || Proof <- build_proofs(B, TX, Chunks)].
@@ -351,7 +353,7 @@ wait_until_syncs_chunk(Offset, ExpectedProof) ->
 			end
 		end,
 		100,
-		5000
+		20_000
 	).
 
 wait_until_syncs_chunks(Proofs) ->
@@ -385,8 +387,8 @@ wait_until_syncs_chunks(Node, Proofs, UpperBound) ->
 							end
 					end
 				end,
-				5 * 1000,
-				180 * 1000
+				?SYNC_CHUNKS_CHECK,
+				?SYNC_CHUNKS_TIMEOUT
 			)
 		end,
 		Proofs

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -36,9 +36,9 @@ setup_external_update() ->
 	%% Start the testnode with a configured VDF server so that it doesn't compute its own VDF -
 	%% this is necessary so that we can test the behavior of apply_external_update without any
 	%% auto-computed VDF steps getting in the way.
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
-		Config#config{ nonce_limiter_server_trusted_peers = [ 
+		Config#config{ nonce_limiter_server_trusted_peers = [
 			ar_util:format_peer(vdf_server_1()),
 			ar_util:format_peer(vdf_server_2()) ],
 			mine = true}),
@@ -160,12 +160,12 @@ test_vdf_server_push_fast_block() ->
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 	timer:sleep(3000),
 
 	{ok, Config} = application:get_env(arweave, config),
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ nonce_limiter_client_peers = [ "127.0.0.1:" ++ integer_to_list(VDFPort) ]}),
 
@@ -206,13 +206,13 @@ test_vdf_server_push_slow_block() ->
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
 	{ok, Config} = application:get_env(arweave, config),
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ nonce_limiter_client_peers = [ "127.0.0.1:1986" ]}),
 	timer:sleep(3000),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 
 	%% Setup a server to listen for VDF pushes
@@ -272,7 +272,7 @@ test_vdf_client_fast_block() ->
 	PeerAddress = ar_wallet:to_address(ar_test_node:remote_call(peer1, ar_wallet, new_keyfile, [])),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 	timer:sleep(20000),
 
@@ -284,14 +284,14 @@ test_vdf_client_fast_block() ->
 
 	%% Restart peer1 as a VDF client
 	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
-	ar_test_node:start_peer(peer1, 
+	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
-		PeerConfig#config{ nonce_limiter_server_trusted_peers = [ 
+		PeerConfig#config{ nonce_limiter_server_trusted_peers = [
 			ar_util:format_peer(ar_test_node:peer_ip(main)) ] }),
 	%% Start main as a VDF server
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
-		Config#config{ nonce_limiter_client_peers = [ 
+		Config#config{ nonce_limiter_client_peers = [
 			ar_util:format_peer(ar_test_node:peer_ip(peer1)) ]}),
 	ar_test_node:connect_to_peer(peer1),
 
@@ -319,8 +319,8 @@ test_vdf_client_fast_block_pull_interface() ->
 	PeerAddress = ar_wallet:to_address(ar_test_node:remote_call(peer1, ar_wallet, new_keyfile, [])),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
-	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
+	_ = ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 	timer:sleep(20000),
 
 	%% Mine a block that will be ahead of main in the VDF chain
@@ -331,12 +331,12 @@ test_vdf_client_fast_block_pull_interface() ->
 
 	%% Restart peer1 as a VDF client
 	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
-	ar_test_node:start_peer(peer1, 
+	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ nonce_limiter_server_trusted_peers = [ "127.0.0.1:" ++ integer_to_list(Config#config.port) ],
 				enable = [vdf_server_pull | PeerConfig#config.enable] }),
 	%% Start the main as a VDF server
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ nonce_limiter_client_peers = [ "127.0.0.1:" ++ integer_to_list(ar_test_node:peer_port(peer1)) ]}),
 	ar_test_node:connect_to_peer(peer1),
@@ -365,7 +365,7 @@ test_vdf_client_slow_block() ->
 	PeerAddress = ar_wallet:to_address(ar_test_node:remote_call(peer1, ar_wallet, new_keyfile, [])),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 
 	%% Mine a block that will be ahead of main in the VDF chain
@@ -376,13 +376,13 @@ test_vdf_client_slow_block() ->
 
 	%% Restart peer1 as a VDF client
 	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
-	ar_test_node:start_peer(peer1, 
+	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ nonce_limiter_server_trusted_peers = [
 			"127.0.0.1:" ++ integer_to_list(Config#config.port)
 		] }),
 	%% Start the main as a VDF server
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ nonce_limiter_client_peers = [
 			"127.0.0.1:" ++ integer_to_list(ar_test_node:peer_port(peer1))
@@ -403,7 +403,7 @@ test_vdf_client_slow_block_pull_interface() ->
 	PeerAddress = ar_wallet:to_address(ar_test_node:remote_call(peer1, ar_wallet, new_keyfile, [])),
 
 	%% Let peer1 get ahead of main in the VDF chain
-	ar_test_node:start_peer(peer1, B0),
+	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 
 	%% Mine a block that will be ahead of main in the VDF chain
@@ -414,14 +414,14 @@ test_vdf_client_slow_block_pull_interface() ->
 
 	%% Restart peer1 as a VDF client
 	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
-	ar_test_node:start_peer(peer1, 
+	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ nonce_limiter_server_trusted_peers = [
 			"127.0.0.1:" ++ integer_to_list(Config#config.port) ],
 				enable = [vdf_server_pull | PeerConfig#config.enable] }),
 	%% Start the main as a VDF server
 	{ok, Config} = application:get_env(arweave, config),
-	ar_test_node:start(
+	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ nonce_limiter_client_peers = [
 			"127.0.0.1:" ++ integer_to_list(ar_test_node:peer_port(peer1))
@@ -702,7 +702,7 @@ test_2_servers_backtrack() ->
 		[20, 20, 20, 20, 20, 20, 20, 20, 10, 10, 10, 10, 10, 20, 30],
 		computed_upper_bounds()).
 
-test_mining_session() -> 
+test_mining_session() ->
 	SessionKey0 = get_current_session_key(),
 	SessionKey1 = {<<"session1">>, 1, 1},
 	SessionKey2 = {<<"session2">>, 2, 1},
@@ -973,8 +973,8 @@ get_current_session_key() ->
 
 mock_add_task() ->
 	{
-		ar_mining_worker, add_task, 
-		fun(Worker, TaskType, Candidate) -> 
+		ar_mining_worker, add_task,
+		fun(Worker, TaskType, Candidate) ->
 			ets:insert(add_task, {Worker, TaskType, Candidate#mining_candidate.step_number})
 		end
 	}.


### PR DESCRIPTION
Github Workflow has been improved and optimized to run in a parallel environment using dynamic runner spawned on demand. Artifacts are now uploaded and copied across each builds. A build will always start from a fresh installation (meaning the compilation time will take longer).

This commit fixes also few bugs in the test suite, causing random crash during execution. They are mainly related to the load of the system where the tests are running.

 - A race condition was found when starting test on test peer. Sometimes, peers are not ready to start the tests and crash.

 - Many race conditions because of timeouts, mainly in `ar_vdf_server_tests`, `ar_http_iface_tests`, `ar_poa_tests` and `ar_tx_blacklist_tests`

The number of workers has been set to `8` instead of `12`. The current server is having trouble dealing with more than `12` workers in parallel.

A cache has been added for dependencies, this is inefficient to fetch dependencies for every build. To avoid that, deps are updated when rebar.lock checksum is different from the previous build. If deps cache is not found on the cache store, it is created and uploaded.

see: https://github.com/ArweaveTeam/infra/issues/114