### PR TITLE
Improve Arweave Entry Point Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ release/output
 .tmp
 node_modules
 screenlog.0
+_*

--- a/ar-rebar3
+++ b/ar-rebar3
@@ -9,13 +9,49 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROFILE=$1
 COMMAND=$2
 
+create_overlay_var() {
+  local target="_vars.config"
+  local name="${1}"
+  local value="$(eval ${2} 2>/dev/null || echo undefined)"
+
+  if ! echo "${name}" | grep -E '^[a-z]+[0-9A-Za-z_]+$' >/dev/null
+  then
+    echo "invalid variable ${name}" 1>&2
+    return 1
+  fi
+
+  if ! echo "${value}" | grep -E '^[[:print:]]+$' >/dev/null
+  then
+    echo "invalid value ${value}" 1>&2
+    return 1
+  fi
+
+  if test -e "${target}"
+  then
+    printf '{%s, "%s"}.\n' "${name}" "${value}" >> "${target}"
+    return 0
+  fi
+
+  printf '{%s, "%s"}.\n' "${name}" "${value}" > "${target}"
+  return 0
+}
+
 echo Removing build artifacts...
 set -x
+rm -f "_vars.config"
 rm -f "${SCRIPT_DIR}/lib"
 rm -f "${SCRIPT_DIR}/releases"
 { set +x; } 2>/dev/null
 echo
 
+echo "Crafting overlay variables..."
+create_overlay_var git_rev "git rev-parse HEAD"
+create_overlay_var datetime "date -u '+%Y-%m-%dT%H:%M:%SZ'"
+create_overlay_var cc_version "cc --version | head -n1"
+create_overlay_var gmake_version "gmake --version | head -n1"
+create_overlay_var cmake_version "cmake --version | head -n1"
+
+echo "Executing rebar3 as ${PROFILE} ${COMMAND}"
 ${SCRIPT_DIR}/rebar3 as ${PROFILE} ${COMMAND}
 
 if [ "${COMMAND}" = "release" ]; then

--- a/arweave-server
+++ b/arweave-server
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
 set -e
-
 SCRIPT_DIR="$(dirname "$0")"
-
+ARWEAVE_DEV=1
 "$SCRIPT_DIR/bin/start" "$@"

--- a/bin/e2e
+++ b/bin/e2e
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
 SCRIPT_DIR=$(dirname ${0})
+ARWEAVE_DEV=1
 ARWEAVE=${SCRIPT_DIR}/arweave
 ${ARWEAVE} test_e2e ${*}

--- a/bin/shell
+++ b/bin/shell
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(dirname "$0")"
+cd "$SCRIPT_DIR/.."
+
+./ar-rebar3 test compile
+
+if [ `uname -s` == "Darwin" ]; then
+    RANDOMX_JIT="disable randomx_jit"
+else
+    RANDOMX_JIT=
+fi
+
+export ERL_EPMD_ADDRESS=127.0.0.1
+
+ERL_TEST_OPTS="-pa `./rebar3 as test path` `./rebar3 as test path --base`/lib/arweave/test -config config/sys.config"
+echo -e "\033[0;32m===> Running tests...\033[0m"
+
+# Check if BEAM process is running
+if pgrep -f "beam.smp" > /dev/null; then
+    echo "BEAM is already running. Exiting."
+    exit 1
+else
+    erl $ERL_TEST_OPTS -name main-localtest@127.0.0.1 -setcookie test -run ar shell 2>&1
+fi
+kill 0

--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
 SCRIPT_DIR=$(dirname ${0})
+ARWEAVE_DEV=1
 ARWEAVE=${SCRIPT_DIR}/arweave
 ${ARWEAVE} test ${*}

--- a/priv/templates/extended_bin
+++ b/priv/templates/extended_bin
@@ -50,6 +50,12 @@ REL_VSN="{{ release_version }}"
 # export these to match mix release environment variables
 export RELEASE_NAME="{{ release_name }}"
 export RELEASE_VSN="{{ release_version }}"
+export RELEASE_GIT_REV="{{ git_rev }}"
+export RELEASE_DATETIME="{{ datetime }}"
+export RELEASE_ERTS="{{ release_erts_version }}"
+export RELEASE_CC="{{ cc_version }}"
+export RELEASE_CMAKE="{{ cmake_version }}"
+export RELEASE_GMAKE="{{ gmake_version }}"
 export RELEASE_PROG="${SCRIPT}"
 
 ERTS_VSN="{{ erts_vsn }}"
@@ -312,7 +318,11 @@ arweave_version() {
 }
 
 arweave_version_light() {
-    echo "{{ release_name }} {{ release_version }} (erts {{ erts_vsn }})"
+    echo "${RELEASE_NAME} ${RELEASE_VSN} (${RELEASE_GIT_REV}) ${RELEASE_DATETIME}"
+    echo "   erts ${RELEASE_ERTS}"
+    echo "   ${RELEASE_CC}"
+    echo "   ${RELEASE_GMAKE}"
+    echo "   ${RELEASE_CMAKE}"
     exit 0
 }
 

--- a/rebar.config
+++ b/rebar.config
@@ -39,6 +39,9 @@
 	{sys_config, "./config/sys.config"},
 	{vm_args_src, "./config/vm.args.src"},
 
+	% dynamically generated overlay variable, required for
+	% extra variables during script generation.
+	{overlay_vars, "_vars.config"},
 	{overlay, [
 		{template, "priv/templates/extended_bin", "bin/arweave"},
 		{template, "priv/templates/extended_bin", "{{output_dir}}/{{release_version}}/bin/arweave"},


### PR DESCRIPTION
This commit adds new template variable generated
during release creation and insert them in the
version message. Example:

```
$ ./bin/arweave version
arweave 2.9.4 (9838e65e0dcc5830a3d387257d89a83d0b6c7e81) 2025-02-13T10:46:12Z
   erts 12.2.1
   cc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
   GNU Make 4.3
   cmake version 3.22.1
```

ARWEAVE_DEV environment variable has been set
by default in bin/e2e and bin/test.

bin/shell script has been restored.

see: https://github.com/ArweaveTeam/arweave-dev/issues/796