### PR TITLE
Modify Gitstamp Github Action

### DIFF
--- a/.github/workflows/gitstamp.yaml
+++ b/.github/workflows/gitstamp.yaml
@@ -3,12 +3,13 @@
 name: Gitstamp
 on: 
   push:
-  pull_request_target:
-    types: [opened]
     branches:
       - 'master'
       - 'release/**'
       - 'releases/**'
+  pull_request_target:
+    types: [closed]
+
 jobs:
   gitstamp:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Gitstamp should be executed only on few branches and not on every push. Furthermore, gitstamp should also be executed when a PR is merged and closed.

see: https://github.com/ArweaveTeam/arweave-dev/issues/772