### PR TITLE
Improve Domain Name Resolution

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -408,8 +408,9 @@ parse_cli_args(["verify_samples", N | Rest], C) ->
 	parse_cli_args(Rest, C#config{ verify_samples = list_to_integer(N) });
 parse_cli_args(["peer", Peer | Rest], C = #config{ peers = Ps }) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ValidPeer} ->
-			parse_cli_args(Rest, C#config{ peers = [ValidPeer|Ps] });
+		{ok, ValidPeers} when is_list(ValidPeers) ->
+			NewConfig = C#config{peers = ValidPeers ++ Ps},
+			parse_cli_args(Rest, NewConfig);
 		{error, _} ->
 			io:format("Peer ~p is invalid.~n", [Peer]),
 			parse_cli_args(Rest, C)
@@ -417,16 +418,16 @@ parse_cli_args(["peer", Peer | Rest], C = #config{ peers = Ps }) ->
 parse_cli_args(["block_gossip_peer", Peer | Rest],
 		C = #config{ block_gossip_peers = Peers }) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ValidPeer} ->
-			parse_cli_args(Rest, C#config{ block_gossip_peers = [ValidPeer | Peers] });
+		{ok, ValidPeer} when is_list(ValidPeer) ->
+			parse_cli_args(Rest, C#config{ block_gossip_peers = ValidPeer ++ Peers });
 		{error, _} ->
 			io:format("Peer ~p invalid ~n", [Peer]),
 			parse_cli_args(Rest, C)
 	end;
 parse_cli_args(["local_peer", Peer | Rest], C = #config{ local_peers = Peers }) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ValidPeer} ->
-			parse_cli_args(Rest, C#config{ local_peers = [ValidPeer | Peers] });
+		{ok, ValidPeer} when is_list(ValidPeer) ->
+			parse_cli_args(Rest, C#config{ local_peers = ValidPeer ++ Peers });
 		{error, _} ->
 			io:format("Peer ~p is invalid.~n", [Peer]),
 			parse_cli_args(Rest, C)
@@ -651,15 +652,15 @@ parse_cli_args(["cm_poll_interval", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config{ cm_poll_interval = list_to_integer(Num) });
 parse_cli_args(["cm_peer", Peer | Rest], C = #config{ cm_peers = Ps }) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ValidPeer} ->
-			parse_cli_args(Rest, C#config{ cm_peers = [ValidPeer|Ps] });
+		{ok, ValidPeer} when is_list(ValidPeer) ->
+			parse_cli_args(Rest, C#config{ cm_peers = ValidPeer ++ Ps });
 		{error, _} ->
 			io:format("Peer ~p is invalid.~n", [Peer]),
 			parse_cli_args(Rest, C)
 	end;
 parse_cli_args(["cm_exit_peer", Peer | Rest], C) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ValidPeer} ->
+		{ok, [ValidPeer|_]} ->
 			parse_cli_args(Rest, C#config{ cm_exit_peer = ValidPeer });
 		{error, _} ->
 			io:format("Peer ~p is invalid.~n", [Peer]),

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -639,7 +639,7 @@ parse_options([{<<"cm_peers">>, Peers} | Rest], Config) when is_list(Peers) ->
 
 parse_options([{<<"cm_exit_peer">>, Peer} | Rest], Config) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ParsedPeer} ->
+		{ok, [ParsedPeer|_]} ->
 			parse_options(Rest, Config#config{ cm_exit_peer = ParsedPeer });
 		{error, _} ->
 			{error, bad_cm_exit_peer, Peer}
@@ -767,11 +767,13 @@ safe_map(Fun, List) ->
 
 parse_peers([Peer | Rest], ParsedPeers) ->
 	case ar_util:safe_parse_peer(Peer) of
-		{ok, ParsedPeer} -> parse_peers(Rest, [ParsedPeer | ParsedPeers]);
+		{ok, ParsedPeer} -> parse_peers(Rest, ParsedPeer ++ ParsedPeers);
 		{error, _} -> error
 	end;
 parse_peers([], ParsedPeers) ->
-	{ok, lists:reverse(ParsedPeers)}.
+	Flatten = lists:flatten(ParsedPeers),
+	Reverse = lists:reverse(Flatten),
+	{ok, Reverse}.
 
 parse_webhooks([{WebhookConfig} | Rest], ParsedWebhookConfigs) when is_list(WebhookConfig) ->
 	case parse_webhook(WebhookConfig, #config_webhook{}) of

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -1255,7 +1255,8 @@ get_peers(Peer) ->
 					timeout => 2 * 1000
 				}),
 			PeerArray = ar_serialize:dejsonify(Body),
-			lists:map(fun ar_util:parse_peer/1, PeerArray)
+			PeersList = lists:map(fun ar_util:parse_peer/1, PeerArray),
+			lists:flatten(PeersList)
 		end
 	catch _:_ -> unavailable
 	end.

--- a/apps/arweave/src/ar_peers.erl
+++ b/apps/arweave/src/ar_peers.erl
@@ -209,7 +209,7 @@ resolve_peers([]) ->
 resolve_peers([RawPeer | Peers]) ->
 	case ar_util:safe_parse_peer(RawPeer) of
 		{ok, Peer} ->
-			[Peer | resolve_peers(Peers)];
+			Peer ++ resolve_peers(Peers);
 		{error, invalid} ->
 			?LOG_WARNING([{event, failed_to_resolve_trusted_peer},
 					{peer, RawPeer}]),
@@ -221,11 +221,11 @@ get_trusted_peers() ->
 	case Config#config.peers of
 		[] ->
 			ArweavePeers = [
-				"sfo-1.na-west-1.arweave.xyz",
-				"ams-1.eu-central-1.arweave.xyz",
-				"fra-1.eu-central-2.arweave.xyz",
-				"blr-1.ap-central-1.arweave.xyz",
-				"sgp-1.ap-central-2.arweave.xyz"
+				"asia.peers.arweave.xyz",
+				"europe.peers.arweave.xyz",
+				"india.peers.arweave.xyz",
+				"north-america.peers.arweave.xyz",
+				"oceania.peers.arweave.xyz"
 			],
 			resolve_peers(ArweavePeers);
 		Peers ->
@@ -346,7 +346,7 @@ resolve_and_cache_peer(RawPeer, Type) ->
 	case ets:lookup(?MODULE, {raw_peer, RawPeer}) of
 		[] ->
 			case ar_util:safe_parse_peer(RawPeer) of
-				{ok, Peer} ->
+				{ok, [Peer]} ->
 					ets:insert(?MODULE, {{raw_peer, RawPeer}, {Peer, Now}}),
 					ets:insert(?MODULE, {{Type, Peer}, RawPeer}),
 					{ok, Peer};
@@ -357,7 +357,7 @@ resolve_and_cache_peer(RawPeer, Type) ->
 			case Timestamp + ?STORE_RESOLVED_DOMAIN_S < Now of
 				true ->
 					case ar_util:safe_parse_peer(RawPeer) of
-						{ok, Peer2} ->
+						{ok, [Peer2]} ->
 							%% The cache entry has expired.
 							ets:delete(?MODULE, {Type, {Peer, Timestamp}}),
 							ets:insert(?MODULE, {{raw_peer, RawPeer}, {Peer2, Now}}),


### PR DESCRIPTION
Current arweave behavior is to select one IP address when a record contains more than one value (round robin). The new behavior is to retrieve the complete list and then, give the possibility to create DNS pool. Each IP address is simply added in the peer list (with the default port if not specified).

## Implementation Notes and Review

Few DNS pools have been created to help users and miners to select the closest trusted peers for their region. It has been inspired by the [`pool.ntp.org`](https://www.ntppool.org/zone) convention. Below the list of the current domain name pool available:

 - `peers.arweave.xyz`: contain all available trusted peers
   - `asia.peers.arweave.xyz`:
   - `europe.peers.arweave.xyz`
   - `north-america.peers.arweave.xyz`
   - `india.peers.arweave.xyz`
   - `oceania.peers.arweave.xyz`

The idea is to offer a simple naming convention hiding the name of arweave hosts and their IPs. In case of change, users will always have more than 1 node available from the pool. It will help system administrators to deal with the outages.

Furthermore, it will also be easier to monitor and offers a better view for everybody. Most of our trusted peers are still publicly available and a [status page](https://status.arweave.xyz/) for each of them can be seen. This is a quick view to check if the peer is correctly to HTTP requests.

This new implementation is quite easy at first glance, it only replace `inet:getaddr/2` by `inet:getaddrs/2`. This simple change allows to get the full list of IP addresses set on a domain name instead of one randomly. This function is called when a peer is configured via `ar` module (from command line or configuration file).

These peers (from the DNS pool) are then available in the trusted peers list through `ar_peers:get_trusted_peers/0`. When setting `peer europe.peers.arweave.xyz`, the function returns 6 peers available:

```erlang
ar_peers:get_trusted_peers().
% returns:
% [{91,239,53,95,1984},
%  {57,128,189,200,1984},
%  {67,220,66,3,1984},
%  {57,129,64,100,1984},
%  {23,88,18,239,1984},
%  {23,166,88,225,1984}]
```

To be sure, `dig` command can be used to list the whole list IP addresses available from this record. In this case, dig also returns 6 peers, with the same IP addresses.

```sh
$ dig +short europe.peers.arweave.xyz
23.88.18.239
57.129.64.100
23.166.88.225
91.239.53.95
67.220.66.3
57.128.189.200
```

Let check now what happens when a node goes down. Instead of shutdown the node directly, a new iptables rule will be added:

```sh
# drop all packets coming from 23.88.18.239
sudo iptables -I INPUT -i ${interface} -s 23.88.18.239 -j DROP

# drop all packets going to 23.88.18.239
sudo iptables -I INPUT -i ${interface} -d 23.88.18.239 -j DROP

# check if the peer is still reachable
nc -zvw3  23.88.18.239 1984
# it should return:
# nc: connect to 23.88.18.239 port 1984 (tcp) timed out: Operation now in progress

# kill the remaining connections if present
sudo ss -K dst 23.88.18.239
sudo ss -K src 23.88.18.239
```

When starting the server:

```
Setting the data chunk cache size limit to 1100 chunks.

        Peer 23.88.18.239:1984 is not available.

Joining the Arweave network...
Downloaded the block index successfully.
```

All other nodes are still reachable, only the blocked one is not available.

EDIT: renamed DNS pool records with `peers` instead of `pool` to avoid confusion with mining pools.