### PR TITLE
fix: fix join error when trusted peer times out

### DIFF
--- a/apps/arweave/src/ar_join.erl
+++ b/apps/arweave/src/ar_join.erl
@@ -522,3 +522,18 @@ node_join_test() ->
 		ar_test_node:mine(peer1),
 		ar_test_node:wait_until_height(main, 3)
 	end}.
+
+%% @doc Ensure that get_tx works with a single peer and a list of peers.
+get_tx_test_() ->
+	[
+		ar_test_node:test_with_mocked_functions(
+			[{ar_http_iface_client, get_tx_from_remote_peer,
+				fun(_, _, _) -> {error,{closed,"The connection was lost."}} end}],
+			fun test_get_tx/0)
+	].
+
+test_get_tx() ->
+	?assertEqual(ar_http_iface_client:get_tx({127, 0, 0, 1, 1984}, <<"123">>), not_found),
+	?assertEqual(ar_http_iface_client:get_tx([{127, 0, 0, 1, 1984}], <<"123">>), not_found),
+	?assertEqual(ar_http_iface_client:get_tx(
+		[{127, 0, 0, 1, 1984}, {127, 0, 0, 1, 1985}], <<"123">>), not_found).

--- a/apps/arweave/src/ar_tx_poller.erl
+++ b/apps/arweave/src/ar_tx_poller.erl
@@ -134,7 +134,7 @@ check_for_received_txs(#state{ pending_txids = [] } = State) ->
 download_and_verify_tx(TXID) ->
 	ar_ignore_registry:add_temporary(TXID, 10_000),
 	Peers = lists:sublist(ar_peers:get_peers(current), ?QUERY_PEERS_COUNT),
-	case ar_http_iface_client:get_tx_from_remote_peer(Peers, TXID, false) of
+	case ar_http_iface_client:get_tx_from_remote_peers(Peers, TXID, false) of
 		not_found ->
 			ar_ignore_registry:remove_temporary(TXID),
 			?LOG_DEBUG([{event, failed_to_get_tx_from_peers},

--- a/apps/arweave/test/ar_http_iface_tests.erl
+++ b/apps/arweave/test/ar_http_iface_tests.erl
@@ -641,7 +641,7 @@ test_find_external_tx(_) ->
 	{ok, FoundTXID} =
 		ar_util:do_until(
 			fun() ->
-				case ar_http_iface_client:get_tx([ar_test_node:peer_ip(main)], TX#tx.id) of
+				case ar_http_iface_client:get_tx(ar_test_node:peer_ip(main), TX#tx.id) of
 					not_found ->
 						false;
 					TX ->


### PR DESCRIPTION
If a trusted peer timed out while querying transactions it hit an unhandled case clause and could prevent the node from joining. This PR addresses the failed case clause by ensuring a list argument is always a list.