### PR TITLE
Fix Slow Node Shutdown

### DIFF
--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -71,6 +71,7 @@ start_http_iface_listener(Config) ->
 	TlsCertfilePath = Config#config.tls_cert_file,
 	TlsKeyfilePath = Config#config.tls_key_file,
 	TransportOpts = [
+		{linger, {true, 10}},
 		{port, Config#config.port},
 		{keepalive, true},
 		{max_connections, Config#config.max_connections}


### PR DESCRIPTION
This commit should fix the issue when a node is shutting down and the connections are still up/not correctly closed. It seems the default behavior is to wait for all connections to be properly closed, but this is not what we want, even more if clients are requesting huge data with slow connections.

see: https://github.com/ArweaveTeam/arweave-dev/issues/817