### PR TITLE
Decrease Linger Value to 0

### DIFF
--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -71,7 +71,7 @@ start_http_iface_listener(Config) ->
 	TlsCertfilePath = Config#config.tls_cert_file,
 	TlsKeyfilePath = Config#config.tls_key_file,
 	TransportOpts = [
-		{linger, {true, 10}},
+		{linger, {true, 0}},
 		{port, Config#config.port},
 		{keepalive, true},
 		{max_connections, Config#config.max_connections}


### PR DESCRIPTION
When setting linger to a positive value greater than zero, arweave node seems to have synchronization issue and can lead to a slow start without increased timeout.

see: https://github.com/ArweaveTeam/arweave-dev/issues/817