### PR TITLE
Shutdown Procedure for remaining sockets

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -130,6 +130,10 @@
 %% The number of packing workers.
 -define(DEFAULT_PACKING_WORKERS, erlang:system_info(dirty_cpu_schedulers_online)).
 
+%% The default connection tcp delay when arweave is shutting down
+-define(SHUTDOWN_TCP_CONNECTION_TIMEOUT, 60).
+-define(SHUTDOWN_TCP_MAX_CONNECTION_TIMEOUT, ?SHUTDOWN_TCP_CONNECTION_TIMEOUT*5).
+
 %% @doc Startup options with default values.
 -record(config, {
 	init = false,
@@ -232,7 +236,8 @@
 	%% Undocumented/unsupported options
 	chunk_storage_file_size = ?CHUNK_GROUP_SIZE,
 	rocksdb_flush_interval_s = ?DEFAULT_ROCKSDB_FLUSH_INTERVAL_S,
-	rocksdb_wal_sync_interval_s = ?DEFAULT_ROCKSDB_WAL_SYNC_INTERVAL_S
+	rocksdb_wal_sync_interval_s = ?DEFAULT_ROCKSDB_WAL_SYNC_INTERVAL_S,
+	shutdown_tcp_connection_timeout = ?SHUTDOWN_TCP_CONNECTION_TIMEOUT
 }).
 
 -endif.

--- a/apps/arweave/include/ar_sup.hrl
+++ b/apps/arweave/include/ar_sup.hrl
@@ -1,14 +1,27 @@
 %% The number of milliseconds the supervisor gives every process for shutdown.
 -ifdef(AR_TEST).
--define(SHUTDOWN_TIMEOUT, 30000).
+-define(SHUTDOWN_TIMEOUT, 30_000).
 -else.
--define(SHUTDOWN_TIMEOUT, 30000).
+-define(SHUTDOWN_TIMEOUT, 300_000).
 -endif.
 
--define(CHILD(I, Type), {I, {I, start_link, []}, permanent, ?SHUTDOWN_TIMEOUT, Type, [I]}).
+-define(CHILD(I, Type), #{
+	id => I,
+	start => {I, start_link, []},
+	restart => permanent,
+	shutdown => ?SHUTDOWN_TIMEOUT,
+	type => Type,
+	modules => [I]
+}).
 
--define(CHILD_WITH_ARGS(I, Type, Name, Args),
-		{Name, {I, start_link, Args}, permanent, ?SHUTDOWN_TIMEOUT, Type, [Name]}).
+-define(CHILD_WITH_ARGS(I, Type, Name, Args), #{
+	id => Name,
+	start => {I, start_link, Args},
+	restart => permanent,
+	shutdown => ?SHUTDOWN_TIMEOUT,
+	type => Type,
+	modules => [Name]
+}).
 
 %% From the Erlang docs:
 %%
@@ -18,4 +31,11 @@
 %% milliseconds, the child process is unconditionally terminated using exit(Child,kill).
 %% If the child process is another supervisor, the shutdown time must be set to infinity to
 %% give the subtree ample time to shut down.
--define(CHILD_SUP(I, Type), {I, {I, start_link, []}, permanent, infinity, Type, [I]}).
+-define(CHILD_SUP(I, Type), #{
+	id => I,
+	start => {I, start_link, []},
+	restart => permanent,
+	shutdown => infinity,
+	type => Type,
+	modules => [I]
+}).

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -365,7 +365,9 @@ show_help() ->
 				"resync and/or repack any flagged chunks. When running in verify mode several "
 				"flags are disallowed. See the node output for details."},
 			{"verify_samples (num)", io_lib:format("Number of chunks to sample and unpack "
-				"during 'verify'. Default is ~B.", [?SAMPLE_CHUNK_COUNT])}
+				"during 'verify'. Default is ~B.", [?SAMPLE_CHUNK_COUNT])},
+			{"shutdown_tcp_connection_timeout", "shutdown tcp connection timeout in seconds.",
+				"Default is ~Bs.", [?SHUTDOWN_TCP_CONNECTION_TIMEOUT]}
 		]
 	),
 	erlang:halt().
@@ -686,6 +688,10 @@ parse_cli_args(["rocksdb_flush_interval", Seconds | Rest], C) ->
 parse_cli_args(["rocksdb_wal_sync_interval", Seconds | Rest], C) ->
 	parse_cli_args(Rest, C#config{ rocksdb_wal_sync_interval_s = list_to_integer(Seconds) });
 
+%% tcp shutdown procedure
+parse_cli_args(["shutdown_tcp_connection_timeout", Delay|Rest], C) ->
+		parse_cli_args(Rest, C#config{ shutdown_tcp_connection_timeout = list_to_integer(Delay) });
+
 %% Undocumented/unsupported options
 parse_cli_args(["chunk_storage_file_size", Num | Rest], C) ->
 	parse_cli_args(Rest, C#config{ chunk_storage_file_size = list_to_integer(Num) });
@@ -850,7 +856,7 @@ shutdown([NodeName]) ->
 	rpc:cast(NodeName, init, stop, []).
 
 stop(_State) ->
-	ok.
+	?LOG_INFO([{stop, ?MODULE}]).
 
 stop_dependencies() ->
 	{ok, [_Kernel, _Stdlib, _SASL, _OSMon | Deps]} = application:get_key(arweave, applications),
@@ -995,3 +1001,4 @@ console(Format) ->
 console(Format, Params) ->
 	io:format(Format, Params).
 -endif.
+

--- a/apps/arweave/src/ar_blacklist_middleware.erl
+++ b/apps/arweave/src/ar_blacklist_middleware.erl
@@ -4,6 +4,7 @@
 
 -export([start/0, execute/2, reset/0, reset_rate_limit/3,
 		ban_peer/2, is_peer_banned/1, cleanup_ban/1, decrement_ip_addr/2]).
+-export([start_link/0]).
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_config.hrl").
@@ -29,16 +30,18 @@ execute(Req, Env) ->
 			end
 	end.
 
+start_link() ->
+	{ok, spawn_link(fun() -> start() end)}.
+
 start() ->
-	?LOG_INFO([{event, ar_blacklist_middleware_start}]),
+	?LOG_INFO([{start, ?MODULE}, {pid, self()}]),
 	{ok, _} =
 		timer:apply_after(
 			?BAN_CLEANUP_INTERVAL,
 			?MODULE,
 			cleanup_ban,
 			[ets:whereis(?MODULE)]
-		),
-	ok.
+		).
 
 %% Ban a peer completely for TTLSeconds seoncds. Since we cannot trust the port,
 %% we ban the whole IP address.

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -705,6 +705,14 @@ parse_options([{<<"data_sync_request_packed_chunks">>, Bool} | Rest], Config)
 parse_options([{<<"data_sync_request_packed_chunks">>, InvalidValue} | _Rest], _Config) ->
 	{error, {bad_type, data_sync_request_packed_chunks, boolean}, InvalidValue};
 
+%% shutdown procedure
+parse_options([{<<"shutdown_tcp_connection_timeout">>, Delay} | Rest], Config)
+	when is_integer(Delay) andalso Delay > 0 ->
+		NewConfig = Config#config{ shutdown_tcp_connection_timeout = Delay },
+		parse_options(Rest, NewConfig);
+parse_options([{<<"shutdown_tcp_connection_timeout">>, InvalidValue} | Rest], Config) ->
+	{error, {bad_type, shutdown_tcp_connection_timeout, integer}, InvalidValue};
+
 parse_options([Opt | _], _) ->
 	{error, unknown, Opt};
 parse_options([], Config) ->

--- a/apps/arweave/src/ar_node_sup.erl
+++ b/apps/arweave/src/ar_node_sup.erl
@@ -1,10 +1,9 @@
-%% This Source Code Form is subject to the terms of the GNU General 
-%% Public License, v. 2.0. If a copy of the GPLv2 was not distributed 
-%% with this file, You can obtain one at 
+%% This Source Code Form is subject to the terms of the GNU General
+%% Public License, v. 2.0. If a copy of the GPLv2 was not distributed
+%% with this file, You can obtain one at
 %% https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html
 
 -module(ar_node_sup).
-
 -behaviour(supervisor).
 
 %% API
@@ -13,6 +12,7 @@
 %% Supervisor callbacks
 -export([init/1]).
 
+-include_lib("arweave/include/ar_config.hrl").
 -include_lib("arweave/include/ar_sup.hrl").
 
 %% ===================================================================
@@ -25,6 +25,78 @@ start_link() ->
 %% Supervisor callbacks
 %% ===================================================================
 init([]) ->
-	{ok, {{one_for_all, 5, 10}, [
-		?CHILD(ar_node_worker, worker)
-	]}}.
+	{ok, {supervisor_spec(), children_spec()}}.
+
+supervisor_spec() ->
+	#{ strategy => one_for_all
+	 , intensity => 5
+	 , period => 10
+	 }.
+
+%%--------------------------------------------------------------------
+%% the order is important. the first process to be started is
+%% ar_node_worker, then other processes in order. The shutdown
+%% is in reverse, the last process to be stopped is ar_node_worker.
+%%--------------------------------------------------------------------
+children_spec() ->
+	lists:flatten([
+		ar_node_worker_spec(),
+		ar_semaphores_spec(),
+		ar_blacklist_middleware_spec(),
+		ar_http_iface_server_spec()
+	]).
+
+%%--------------------------------------------------------------------
+%% ar_node_worker is the main process, must be started before others,
+%% and should be stopped at last. This process should not be restarted.
+%%--------------------------------------------------------------------
+ar_node_worker_spec() ->
+	#{ id => ar_node_worker
+	 , start => {ar_node_worker, start_link, []}
+	 , type => worker
+	 , shutdown => ?SHUTDOWN_TIMEOUT
+	 , restart => temporary
+	 }.
+
+%%--------------------------------------------------------------------
+%% ar_http_iface_server process is a frontend to cowboy:start*/3,
+%% and will return a worker. This worker is protecting the
+%% cowboy listener (stored in its state). The timeout should be
+%% greater or equal to the TCP_MAX_CONNECTION to avoid killing the
+%% child too early during the shutdown procedure.
+%%--------------------------------------------------------------------
+ar_http_iface_server_spec() ->
+	#{ id => ar_http_iface_server
+	 , start => {ar_http_iface_server, start_link, []}
+	 , type => worker
+	 , shutdown => ?SHUTDOWN_TCP_MAX_CONNECTION_TIMEOUT
+	 }.
+
+%%--------------------------------------------------------------------
+%% ar_blacklist_middle process is transient, it will configure
+%% a timer and then return. In case of error, it should be
+%% restarted.
+%%--------------------------------------------------------------------
+ar_blacklist_middleware_spec() ->
+	#{ id => ar_blacklist_middleware
+	 , start => {ar_blacklist_middleware, start_link, []}
+	 , type => worker
+	 , restart => transient
+	 , shutdown => ?SHUTDOWN_TIMEOUT
+	 }.
+
+%%--------------------------------------------------------------------
+%% ar_semaphores are processes started based on arweave
+%% configuration.
+%%--------------------------------------------------------------------
+ar_semaphores_spec() ->
+	{ok, Config} = application:get_env(arweave, config),
+	Semaphores = Config#config.semaphores,
+	[ ar_semaphore_spec(Name, N) || {Name, N} <- maps:to_list(Semaphores) ].
+
+ar_semaphore_spec(Name, N) ->
+	#{ id => Name
+	 , start => {ar_semaphore, start_link, [Name, N]}
+	 , type => worker
+	 , shutdown => ?SHUTDOWN_TIMEOUT
+	 }.

--- a/apps/arweave/src/ar_semaphore.erl
+++ b/apps/arweave/src/ar_semaphore.erl
@@ -15,8 +15,7 @@ start_link(Name, InitCapacity) ->
 		{name, Name},
 		{help, "The size of the corresponding semaphore queue."}
 	]),
-	{ok, _} = gen_server:start_link({local, Name}, ?MODULE, [InitCapacity], []),
-	ok.
+	gen_server:start_link({local, Name}, ?MODULE, [InitCapacity], []).
 
 %% @doc Acquire the semaphore, willing to wait for the provided
 %% Timeout.

--- a/apps/arweave/test/ar_semaphore_tests.erl
+++ b/apps/arweave/test/ar_semaphore_tests.erl
@@ -68,7 +68,7 @@ wait_for_two_processes_at_a_time_test_() ->
 
 with_semaphore_(Name, Value, Fun) ->
 	{setup,
-		fun() -> ok = ar_semaphore:start_link(Name, Value) end,
+		fun() -> {ok, _} = ar_semaphore:start_link(Name, Value) end,
 		fun(_) -> _ = ar_semaphore:stop(Name) end,
 		[Fun]
 	}.


### PR DESCRIPTION
When stopping a node, cowboy is waiting for all connections to be correctly closed. Usually, it waits for the buffer to be empty before closing the socket. In most of the cases, this behavior is acceptable, but in some cases, in particular when a connection is very slow, this can have a direct impact on the delay to shutdown a node.

This commit adds a shutdown procedure when stopping the client connections. It has 3 stages: (1) when a node is stopped, all sockets are set in read-only mode and all clients are noticed of this change, and they will try to fetch the data before closing the connection (2) if some nodes are still present, the procedure sends another closing requests and will wait for a specific delay (3) if the connection is still up, the connection is simply killed, linger option is set to {true, 0} and the socket is definitively closed.

This draining procedure was inspired by ranch documentation example, that can be found at: https://ninenines.eu/docs/en/ranch/2.2/guide/connection_draining/

see: https://github.com/ArweaveTeam/arweave-dev/issues/817