### PR TITLE
Fix Multi-Node support

### DIFF
--- a/config/vm.args
+++ b/config/vm.args
@@ -12,10 +12,10 @@
 ## schedulers that will be used, to do that: +S 16:16
 ######################################################################
 ## Name of the node
--name arweave@127.0.0.1
+-name ${ARNODE:-arweave@127.0.0.1}
 
 ## Cookie for distributed erlang
--setcookie arweave
+-setcookie ${ARCOOKIE:-arweave}
 
 ## This is now the default as of OTP-26
 ## Multi-time warp mode in combination with time correction is the

--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -12,10 +12,10 @@
 ## schedulers that will be used, to do that: +S 16:16
 ######################################################################
 ## Name of the node
--name arweave@127.0.0.1
+-name ${ARNODE:-arweave@127.0.0.1}
 
 ## Cookie for distributed erlang
--setcookie arweave
+-setcookie ${ARCOOKIE:-arweave}
 
 ## This is now the default as of OTP-26
 ## Multi-time warp mode in combination with time correction is the

--- a/priv/templates/vm_args
+++ b/priv/templates/vm_args
@@ -12,10 +12,10 @@
 ## schedulers that will be used, to do that: +S 16:16
 ######################################################################
 ## Name of the node
--name {{ release_name }}@127.0.0.1
+-name ${ARNAME:-{{ release_name }}@127.0.0.1}
 
 ## Cookie for distributed erlang
--setcookie {{ release_name }}
+-setcookie ${ARCOOKIE:-{{ release_name }}}
 
 ## This is now the default as of OTP-26
 ## Multi-time warp mode in combination with time correction is the


### PR DESCRIPTION
Nodes with custom name and cookies can be started by setting ARNODE and ARCOOKIE variables. By default, ARNODE is set to arweave@127.0.0.1 and ARCOOKIE is set to `arweave`. Here an usage example:

    ARNODE=mynode@127.0.0.1 ARCOOKIE=test ./bin/start ${params}

see: https://github.com/ArweaveTeam/arweave-dev/issues/834