### PR TITLE
Fix user script to follow logs

### DIFF
--- a/bin/debug-logs
+++ b/bin/debug-logs
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-
 set -e
 
 SCRIPT_DIR="$(dirname "$0")"
-LOGS_DIR="$(cd $SCRIPT_DIR/../logs/debug_logs/ && pwd -P)"
-
-ls -1 -t $LOGS_DIR \
-    | grep -F -v '(?!.*(idx|siz))' \
-    | grep -v slave \
-    | head -1 \
-    | xargs -I % tail -n 500 "$@" "$LOGS_DIR/%"
+LOGS_DIR="$(cd $SCRIPT_DIR/../logs && pwd -P)"
+tail -n 500 ${*} ${LOGS_DIR}/*debug.log

--- a/bin/logs
+++ b/bin/logs
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-
 set -e
 
 SCRIPT_DIR="$(dirname "$0")"
 LOGS_DIR="$(cd $SCRIPT_DIR/../logs && pwd -P)"
-
-ls -1 -t $LOGS_DIR \
-    | grep -F -v '(?!.*(idx|siz))' \
-    | grep -v slave \
-    | head -1 \
-    | xargs -I % tail -n 500 "$@" "$LOGS_DIR/%"
+tail -n 500 ${*} ${LOGS_DIR}/*info.log


### PR DESCRIPTION
With the new entry-point and the modification of the format used for the logs, this script was not able to follow correctly the log files in ./logs/ directory.

see: https://github.com/ArweaveTeam/arweave-dev/issues/833