### PR TITLE
Speed up collection of syncing intervals

### DIFF
--- a/apps/arweave/include/ar_data_sync.hrl
+++ b/apps/arweave/include/ar_data_sync.hrl
@@ -210,8 +210,6 @@
 	%% the actual disk dump, to reduce the chance of out-of-order write causing disk
 	%% fragmentation.
 	store_chunk_queue_threshold = ?STORE_CHUNK_QUEUE_FLUSH_SIZE_THRESHOLD,
-	%% Cache mapping peers to /data_sync_record responses
-	all_peers_intervals = #{},
 	%% The target packing of the storage module managed by the process.
 	packing = not_set
 }).

--- a/apps/arweave/src/ar_data_discovery.erl
+++ b/apps/arweave/src/ar_data_discovery.erl
@@ -6,8 +6,8 @@
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
--include_lib("arweave/include/ar.hrl").
--include_lib("arweave/include/ar_data_discovery.hrl").
+-include("../include/ar.hrl").
+-include("../include/ar_data_discovery.hrl").
 
 -record(state, {
 	peer_queue,

--- a/apps/arweave/src/ar_data_discovery.erl
+++ b/apps/arweave/src/ar_data_discovery.erl
@@ -6,8 +6,8 @@
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
--include("../include/ar.hrl").
--include("../include/ar_data_discovery.hrl").
+-include("ar.hrl").
+-include("ar_data_discovery.hrl").
 
 -record(state, {
 	peer_queue,

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -20,14 +20,14 @@
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2]).
 -export([enqueue_intervals/3, remove_expired_disk_pool_data_roots/0]).
 
--include("../include/ar.hrl").
--include("../include/ar_sup.hrl").
--include("../include/ar_consensus.hrl").
--include("../include/ar_config.hrl").
--include("../include/ar_poa.hrl").
--include("../include/ar_data_discovery.hrl").
--include("../include/ar_data_sync.hrl").
--include("../include/ar_sync_buckets.hrl").
+-include("ar.hrl").
+-include("ar_sup.hrl").
+-include("ar_consensus.hrl").
+-include("ar_config.hrl").
+-include("ar_poa.hrl").
+-include("ar_data_discovery.hrl").
+-include("ar_data_sync.hrl").
+-include("ar_sync_buckets.hrl").
 
 -ifdef(AR_TEST).
 -define(COLLECT_SYNC_INTERVALS_FREQUENCY_MS, 5_000).

--- a/apps/arweave/src/ar_global_sync_record.erl
+++ b/apps/arweave/src/ar_global_sync_record.erl
@@ -2,9 +2,9 @@
 
 -behaviour(gen_server).
 
--include("../include/ar.hrl").
--include("../include/ar_config.hrl").
--include("../include/ar_data_discovery.hrl").
+-include("ar.hrl").
+-include("ar_config.hrl").
+-include("ar_data_discovery.hrl").
 
 -export([start_link/0, get_serialized_sync_record/1, get_serialized_sync_buckets/0]).
 

--- a/apps/arweave/src/ar_global_sync_record.erl
+++ b/apps/arweave/src/ar_global_sync_record.erl
@@ -2,9 +2,9 @@
 
 -behaviour(gen_server).
 
--include_lib("arweave/include/ar.hrl").
--include_lib("arweave/include/ar_config.hrl").
--include_lib("arweave/include/ar_data_discovery.hrl").
+-include("../include/ar.hrl").
+-include("../include/ar_config.hrl").
+-include("../include/ar_data_discovery.hrl").
 
 -export([start_link/0, get_serialized_sync_record/1, get_serialized_sync_buckets/0]).
 
@@ -40,6 +40,7 @@ start_link() ->
 %% format			required	etf or json		serialize in Erlang Term Format or JSON
 %% random_subset	optional	any()			pick a random subset if the key is present
 %% start			optional	integer()		pick intervals with right bound >= start
+%% right_bound		optional	integer()		pick intervals with right bound <= right_bound
 %% limit			optional	integer()		the number of intervals to pick
 %%
 %% ?MAX_SHARED_SYNCED_INTERVALS_COUNT is both the default and the maximum value for limit.

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -27,14 +27,14 @@
 -export([get_tx_from_remote_peer/3]).
 %% -- End of testing exports
 
--include("../include/ar.hrl").
--include("../include/ar_config.hrl").
--include("../include/ar_consensus.hrl").
--include("../include/ar_data_sync.hrl").
--include("../include/ar_data_discovery.hrl").
--include("../include/ar_mining.hrl").
--include("../include/ar_wallets.hrl").
--include("../include/ar_pool.hrl").
+-include("ar.hrl").
+-include("ar_config.hrl").
+-include("ar_consensus.hrl").
+-include("ar_data_sync.hrl").
+-include("ar_data_discovery.hrl").
+-include("ar_mining.hrl").
+-include("ar_wallets.hrl").
+-include("ar_pool.hrl").
 
 %%--------------------------------------------------------------------
 %% @doc Send a JSON-encoded transaction to the given Peer with default

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -6,35 +6,35 @@
 
 -export([send_tx_json/3, send_tx_json/4, send_tx_binary/3, send_tx_binary/4]).
 -export([send_block_json/3, send_block_binary/3, send_block_binary/4,
-	 send_block_announcement/2,
-	 get_block/3, get_tx/2, get_txs/2, get_tx_from_remote_peers/3,
-	 get_tx_data/2, get_wallet_list_chunk/2, get_wallet_list_chunk/3,
-	 get_wallet_list/2, add_peer/1, get_info/1, get_info/2, get_peers/1,
-	 get_time/2, get_height/1, get_block_index/3,
-	 get_sync_record/1, get_sync_record/3,
-	 get_chunk_binary/3, get_mempool/1,
-	 get_sync_buckets/1, get_recent_hash_list/1,
-	 get_recent_hash_list_diff/2, get_reward_history/3,
-	 get_block_time_history/3, push_nonce_limiter_update/3,
-	 get_vdf_update/1, get_vdf_session/1, get_previous_vdf_session/1,
-	 get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
-	 cm_publish_send/2, get_jobs/2, post_partial_solution/2,
-	 get_pool_cm_jobs/2, post_pool_cm_jobs/2,
-	 post_cm_partition_table_to_pool/2]).
+	send_block_announcement/2,
+	get_block/3, get_tx/2, get_txs/2, get_tx_from_remote_peers/3,
+	get_tx_data/2, get_wallet_list_chunk/2, get_wallet_list_chunk/3,
+	get_wallet_list/2, add_peer/1, get_info/1, get_info/2, get_peers/1,
+	get_time/2, get_height/1, get_block_index/3,
+	get_sync_record/1, get_sync_record/3, get_sync_record/4,
+	get_chunk_binary/3, get_mempool/1,
+	get_sync_buckets/1, get_recent_hash_list/1,
+	get_recent_hash_list_diff/2, get_reward_history/3,
+	get_block_time_history/3, push_nonce_limiter_update/3,
+	get_vdf_update/1, get_vdf_session/1, get_previous_vdf_session/1,
+	get_cm_partition_table/1, cm_h1_send/2, cm_h2_send/2,
+	cm_publish_send/2, get_jobs/2, post_partial_solution/2,
+	get_pool_cm_jobs/2, post_pool_cm_jobs/2,
+	post_cm_partition_table_to_pool/2]).
 -export([get_block_shadow/2, get_block_shadow/3, get_block_shadow/4]).
 
 %% -- Testing exports
 -export([get_tx_from_remote_peer/3]).
 %% -- End of testing exports
 
--include_lib("arweave/include/ar.hrl").
--include_lib("arweave/include/ar_config.hrl").
--include_lib("arweave/include/ar_consensus.hrl").
--include_lib("arweave/include/ar_data_sync.hrl").
--include_lib("arweave/include/ar_data_discovery.hrl").
--include_lib("arweave/include/ar_mining.hrl").
--include_lib("arweave/include/ar_wallets.hrl").
--include_lib("arweave/include/ar_pool.hrl").
+-include("../include/ar.hrl").
+-include("../include/ar_config.hrl").
+-include("../include/ar_consensus.hrl").
+-include("../include/ar_data_sync.hrl").
+-include("../include/ar_data_discovery.hrl").
+-include("../include/ar_mining.hrl").
+-include("../include/ar_wallets.hrl").
+-include("../include/ar_pool.hrl").
 
 %%--------------------------------------------------------------------
 %% @doc Send a JSON-encoded transaction to the given Peer with default
@@ -370,7 +370,7 @@ get_sync_record(Peer) ->
 		peer => Peer,
 		method => get,
 		path => "/data_sync_record",
-		timeout => 180 * 1000,
+		timeout => 30 * 1000,
 		connect_timeout => 2000,
 		limit => ?MAX_ETF_SYNC_RECORD_SIZE,
 		headers => Headers
@@ -383,7 +383,20 @@ get_sync_record(Peer, Start, Limit) ->
 		method => get,
 		path => "/data_sync_record/" ++ integer_to_list(Start) ++ "/"
 				++ integer_to_list(Limit),
-		timeout => 180 * 1000,
+		timeout => 30 * 1000,
+		connect_timeout => 5000,
+		limit => ?MAX_ETF_SYNC_RECORD_SIZE,
+		headers => Headers
+	}), Start, Limit).
+
+get_sync_record(Peer, Start, End, Limit) ->
+	Headers = [{<<"Content-Type">>, <<"application/etf">>}],
+	handle_sync_record_response(ar_http:req(#{
+		peer => Peer,
+		method => get,
+		path => "/data_sync_record/" ++ integer_to_list(Start) ++ "/"
+				++ integer_to_list(End) ++ "/" ++ integer_to_list(Limit),
+		timeout => 30 * 1000,
 		connect_timeout => 5000,
 		limit => ?MAX_ETF_SYNC_RECORD_SIZE,
 		headers => Headers

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -4,13 +4,13 @@
 
 -export([execute/2, read_body_chunk/4]).
 
--include("../include/ar.hrl").
--include("../include/ar_config.hrl").
--include("../include/ar_mining.hrl").
--include("../include/ar_data_sync.hrl").
--include("../include/ar_data_discovery.hrl").
+-include("ar.hrl").
+-include("ar_config.hrl").
+-include("ar_mining.hrl").
+-include("ar_data_sync.hrl").
+-include("ar_data_discovery.hrl").
 
--include("../include/ar_pool.hrl").
+-include("ar_pool.hrl").
 
 
 -define(HANDLER_TIMEOUT, 55000).

--- a/apps/arweave/src/ar_peer_intervals.erl
+++ b/apps/arweave/src/ar_peer_intervals.erl
@@ -1,24 +1,47 @@
 -module(ar_peer_intervals).
 
--export([fetch/4]).
+-export([fetch/3]).
 
--include_lib("arweave/include/ar.hrl").
--include_lib("arweave/include/ar_config.hrl").
--include_lib("arweave/include/ar_data_discovery.hrl").
+-include("../include/ar.hrl").
+-include("../include/ar_config.hrl").
+-include("../include/ar_data_discovery.hrl").
+
+%% The size of the span of the weave we search at a time.
+%% By searching we mean asking peers about the intervals they have in the given span
+%% and finding the intersection with the unsynced intervals.
+-ifdef(AR_TEST).
+-define(QUERY_RANGE_STEP_SIZE, 10_000_000). % 10 MB
+-else.
+-define(QUERY_RANGE_STEP_SIZE, 1_000_000_000). % 1 GB
+-endif.
+
+%% Fetch at most this many sync intervals from a peer at a time.
+-ifdef(AR_TEST).
+-define(QUERY_SYNC_INTERVALS_COUNT_LIMIT, 10).
+-else.
+-define(QUERY_SYNC_INTERVALS_COUNT_LIMIT, 1000).
+-endif.
+
+%% The number of peers to fetch sync intervals from in parallel at a time.
+-define(GET_SYNC_RECORD_BATCH_SIZE, 2).
+
+%% The number of the release adding support for the
+%% GET /data_sync_record/[start]/[end]/[limit] endpoint.
+-define(GET_SYNC_RECORD_RIGHT_BOUND_SUPPORT_RELEASE, 82).
 
 %%%===================================================================
 %%% Public interface.
 %%%===================================================================
 
-fetch(Start, End, StoreID, _AllPeersIntervals) when Start >= End ->
+fetch(Start, End, StoreID) when Start >= End ->
 	%% We've reached the end of the range, next time through we'll start with a clear cache.
 	?LOG_DEBUG([{event, fetch_peer_intervals_end}, {pid, StoreID}, {store_id, StoreID},
 		{start, Start}]),
 	gen_server:cast(ar_data_sync:name(StoreID), {update_all_peers_intervals, #{}});
-fetch(Start, End, StoreID, AllPeersIntervals) ->
+fetch(Start, End, StoreID) ->
 	spawn_link(fun() ->
 		try
-			End2 = min(ar_util:ceil_int(Start, ?NETWORK_DATA_BUCKET_SIZE), End),
+			End2 = min(Start + ?QUERY_RANGE_STEP_SIZE, End),
 			UnsyncedIntervals = get_unsynced_intervals(Start, End2, StoreID),
 
 			Bucket = Start div ?NETWORK_DATA_BUCKET_SIZE,
@@ -33,15 +56,17 @@ fetch(Start, End, StoreID, AllPeersIntervals) ->
 
 			%% The updated AllPeersIntervals cache is returned so it can be added to the State
 			Parent = ar_data_sync:name(StoreID),
-			case ar_intervals:is_empty(UnsyncedIntervals) of
-				true ->
-					ok;
-				false ->
-					fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals, AllPeersIntervals)
-			end,
+			End3 =
+				case ar_intervals:is_empty(UnsyncedIntervals) of
+					true ->
+						End2;
+					false ->
+						min(End2,
+							fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals))
+				end,
 
 			%% Schedule the next sync bucket. The cast handler logic will pause collection if needed.
-			gen_server:cast(Parent, {collect_peer_intervals, End2, End})
+			gen_server:cast(Parent, {collect_peer_intervals, End3, End})
 		catch
 			Class:Reason ->
 				?LOG_INFO([{event, fetch_peers_process_exit}, {pid, StoreID},
@@ -77,13 +102,13 @@ get_unsynced_intervals(Start, End, Intervals, StoreID) ->
 			end
 	end.
 
-fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals, AllPeersIntervals) ->
+fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals) ->
 	Intervals =
-		ar_util:pmap(
+		ar_util:batch_pmap(
 			fun(Peer) ->
-				case get_peer_intervals(Peer, Start, UnsyncedIntervals, AllPeersIntervals) of
-					{ok, SoughtIntervals, PeerIntervals, Left} ->
-						{Peer, SoughtIntervals, PeerIntervals, Left};
+				case get_peer_intervals(Peer, Start, UnsyncedIntervals) of
+					{ok, SoughtIntervals, PeerRightBound} ->
+						{Peer, SoughtIntervals, PeerRightBound};
 					{error, Reason} ->
 						?LOG_DEBUG([{event, failed_to_fetch_peer_intervals},
 								{peer, ar_util:format_peer(Peer)},
@@ -91,61 +116,57 @@ fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals, AllPeersIntervals)
 						ok
 				end
 			end,
-			Peers
+			Peers,
+			?GET_SYNC_RECORD_BATCH_SIZE % fetch sync intervals from so many peers at a time
 		),
-	EnqueueIntervals =
+	{EnqueueIntervals, MinRightBound} =
 		lists:foldl(
-			fun	({Peer, SoughtIntervals, _, _}, Acc) ->
+			fun	({Peer, SoughtIntervals, RightBound}, {IntervalsAcc, RightBoundAcc}) ->
 					case ar_intervals:is_empty(SoughtIntervals) of
 						true ->
-							Acc;
+							{IntervalsAcc, RightBoundAcc};
 						false ->
-							[{Peer, SoughtIntervals} | Acc]
+							{[{Peer, SoughtIntervals} | IntervalsAcc],
+								min(RightBound, RightBoundAcc)}
 					end;
 				(_, Acc) ->
 					Acc
 			end,
-			[],
+			{[], infinity},
 			Intervals
 		),
 	gen_server:cast(Parent, {enqueue_intervals, EnqueueIntervals}),
-
-	AllPeersIntervals2 = lists:foldl(
-		fun	({Peer, _, PeerIntervals, Left}, Acc) ->
-				case ar_intervals:is_empty(PeerIntervals) of
-					true ->
-						Acc;
-					false ->
-						Right = element(1, ar_intervals:largest(PeerIntervals)),
-						maps:put(Peer, {Right, Left, PeerIntervals}, Acc)
-				end;
-			(_, Acc) ->
-				Acc
-		end,
-		AllPeersIntervals,
-		Intervals
-	),
-	gen_server:cast(Parent, {update_all_peers_intervals, AllPeersIntervals2}).
+	MinRightBound.
 
 %% @doc
-%% @return {ok, Intervals, PeerIntervals, Left} | Error
+%% @return {ok, Intervals, PeerRightBound} | Error
 %% Intervals: the intersection of the intervals we are looking for and the intervals that
-%%            the peer advertises
-%% PeerIntervals: all of the intervals (up to ?MAX_SHARED_SYNCED_INTERVALS_COUNT total
-%%                intervals) that the peer advertises starting at offset Left.
-get_peer_intervals(Peer, Left, SoughtIntervals, AllPeersIntervals) ->
-	Limit = ?MAX_SHARED_SYNCED_INTERVALS_COUNT,
+%%            the peer advertised inside the recently queried range
+%% PeerRightBound: the right bound of the intervals the peer advertised; for example,
+%%                 we may ask for at most 100 continuous intervals inside the given gigabyte,
+%%                 but the peer may have this region very fractured and 100 intervals will
+%%                 not be all intervals covering this gigabyte, so we take the right bound
+%%                 to know where to query next
+get_peer_intervals(Peer, Left, SoughtIntervals) ->
+	Limit = ?QUERY_SYNC_INTERVALS_COUNT_LIMIT,
 	Right = element(1, ar_intervals:largest(SoughtIntervals)),
-	case maps:get(Peer, AllPeersIntervals, not_found) of
-		{Right2, Left2, PeerIntervals} when Right2 >= Right, Left2 =< Left ->
-			{ok, ar_intervals:intersection(PeerIntervals, SoughtIntervals), PeerIntervals,
-					Left2};
-		_ ->
-			case ar_http_iface_client:get_sync_record(Peer, Left + 1, Limit) of
-				{ok, PeerIntervals2} ->
-					{ok, ar_intervals:intersection(PeerIntervals2, SoughtIntervals),
-							PeerIntervals2, Left};
-				Error ->
-					Error
-			end
+	PeerReply =
+		case ar_peers:get_peer_release(Peer) >= ?GET_SYNC_RECORD_RIGHT_BOUND_SUPPORT_RELEASE of
+			true ->
+				ar_http_iface_client:get_sync_record(Peer, Left + 1, Right, Limit);
+			false ->
+				ar_http_iface_client:get_sync_record(Peer, Left + 1, Limit)
+		end,
+	case PeerReply of
+		{ok, PeerIntervals2} ->
+			PeerRightBound =
+				case ar_intervals:is_empty(PeerIntervals2) of
+					true ->
+						infinity;
+					false ->
+						element(1, ar_intervals:largest(PeerIntervals2))
+				end,
+			{ok, ar_intervals:intersection(PeerIntervals2, SoughtIntervals), PeerRightBound};
+		Error ->
+			Error
 	end.

--- a/apps/arweave/src/ar_peer_intervals.erl
+++ b/apps/arweave/src/ar_peer_intervals.erl
@@ -2,9 +2,9 @@
 
 -export([fetch/3]).
 
--include("../include/ar.hrl").
--include("../include/ar_config.hrl").
--include("../include/ar_data_discovery.hrl").
+-include("ar.hrl").
+-include("ar_config.hrl").
+-include("ar_data_discovery.hrl").
 
 %% The size of the span of the weave we search at a time.
 %% By searching we mean asking peers about the intervals they have in the given span

--- a/apps/arweave/src/ar_util.erl
+++ b/apps/arweave/src/ar_util.erl
@@ -15,6 +15,8 @@
 -include("../include/ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(DEFAULT_PMAP_TIMEOUT, 60_000).
+
 bool_to_int(true) -> 1;
 bool_to_int(_) -> 0.
 
@@ -173,9 +175,14 @@ unique(Res, [X|Xs]) ->
 		true -> unique(Res, Xs)
 	end.
 
-%% @doc Run a map in parallel.
-%% NOTE: Make this efficient for large lists.
+%% @doc Run a map in parallel, throw {pmap_timeout, ?DEFAULT_PMAP_TIMEOUT}
+%% if a worker takes longer than ?DEFAULT_PMAP_TIMEOUT milliseconds.
 pmap(Mapper, List) ->
+	pmap(Mapper, List, ?DEFAULT_PMAP_TIMEOUT).
+
+%% @doc Run a map in parallel, throw {pmap_timeout, Timeout} if a worker
+%% takes longer than Timeout milliseconds.
+pmap(Mapper, List, Timeout) ->
 	Master = self(),
 	ListWithRefs = [{Elem, make_ref()} || Elem <- List],
 	lists:foreach(fun({Elem, Ref}) ->
@@ -187,15 +194,26 @@ pmap(Mapper, List) ->
 		fun({_, Ref}) ->
 			receive
 				{pmap_work, Ref, Mapped} -> Mapped
+			after Timeout ->
+				throw({pmap_timeout, Timeout})
 			end
 		end,
 		ListWithRefs
 	).
 
-%% @doc Run a map in parallel, one batch at a time.
-batch_pmap(_Mapper, [], _BatchSize) ->
-	[];
+%% @doc Run a map in parallel, one batch at a time,
+%% throw {batch_pmap_timeout, ?DEFAULT_PMAP_TIMEOUT} if a worker
+%% takes longer than ?DEFAULT_PMAP_TIMEOUT milliseconds.
 batch_pmap(Mapper, List, BatchSize) ->
+	batch_pmap(Mapper, List, BatchSize, ?DEFAULT_PMAP_TIMEOUT).
+
+%% @doc Run a map in parallel, one batch at a time,
+%% throw {batch_pmap_timeout, Timeout} if a worker takes
+%% longer than Timeout milliseconds.
+batch_pmap(_Mapper, [], _BatchSize, _Timeout) ->
+	[];
+batch_pmap(Mapper, List, BatchSize, Timeout)
+		when BatchSize > 0 ->
 	Self = self(),
 	{Batch, Rest} =
 		case length(List) >= BatchSize of
@@ -214,10 +232,12 @@ batch_pmap(Mapper, List, BatchSize) ->
 		fun({_, Ref}) ->
 			receive
 				{pmap_work, Ref, Mapped} -> Mapped
+			after Timeout ->
+				throw({batch_pmap_timeout, Timeout})
 			end
 		end,
 		ListWithRefs
-	) ++ batch_pmap(Mapper, Rest, BatchSize).
+	) ++ batch_pmap(Mapper, Rest, BatchSize, Timeout).
 
 %% @doc Filter the list in parallel.
 pfilter(Fun, List) ->

--- a/apps/arweave/src/ar_util.erl
+++ b/apps/arweave/src/ar_util.erl
@@ -6,13 +6,13 @@
 		invert_map/1,
 		parse_peer/1, peer_to_str/1, parse_port/1, safe_parse_peer/1, format_peer/1,
 		unique/1, count/2,
-		genesis_wallets/0, pmap/2, pfilter/2,
+		genesis_wallets/0, pmap/2, batch_pmap/3, pfilter/2,
 		do_until/3, block_index_entry_from_block/1,
 		bytes_to_mb_string/1, cast_after/3, encode_list_indices/1, parse_list_indices/1,
 		take_every_nth/2, safe_divide/2, terminal_clear/0, print_stacktrace/0, shuffle_list/1,
 		assert_file_exists_and_readable/1, get_system_device/1]).
 
--include_lib("arweave/include/ar.hrl").
+-include("../include/ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 bool_to_int(true) -> 1;
@@ -191,6 +191,33 @@ pmap(Mapper, List) ->
 		end,
 		ListWithRefs
 	).
+
+%% @doc Run a map in parallel, one batch at a time.
+batch_pmap(_Mapper, [], _BatchSize) ->
+	[];
+batch_pmap(Mapper, List, BatchSize) ->
+	Self = self(),
+	{Batch, Rest} =
+		case length(List) >= BatchSize of
+			true ->
+				lists:split(BatchSize, List);
+			false ->
+				{List, []}
+		end,
+	ListWithRefs = [{Elem, make_ref()} || Elem <- Batch],
+	lists:foreach(fun({Elem, Ref}) ->
+		spawn_link(fun() ->
+			Self ! {pmap_work, Ref, Mapper(Elem)}
+		end)
+	end, ListWithRefs),
+	lists:map(
+		fun({_, Ref}) ->
+			receive
+				{pmap_work, Ref, Mapped} -> Mapped
+			end
+		end,
+		ListWithRefs
+	) ++ batch_pmap(Mapper, Rest, BatchSize).
 
 %% @doc Filter the list in parallel.
 pfilter(Fun, List) ->

--- a/apps/arweave/src/ar_util.erl
+++ b/apps/arweave/src/ar_util.erl
@@ -12,7 +12,7 @@
 		take_every_nth/2, safe_divide/2, terminal_clear/0, print_stacktrace/0, shuffle_list/1,
 		assert_file_exists_and_readable/1, get_system_device/1]).
 
--include("../include/ar.hrl").
+-include("ar.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
 -define(DEFAULT_PMAP_TIMEOUT, 60_000).


### PR DESCRIPTION
The core motivation was to reduce the memory footprint of AllPeerIntervals. Now, instead of remembering peer intervals we make sure to only ask every peer for the intervals of every weave range once. To simplify the task, we introduce GET
/data_sync_record/[start]/[end]/[count_limit] on top of GET /data_sync_record/[start]/[count_limit]. We expect redundant data_sync_record calls to peers until the network adopts the new release, however the patch also reduces the size of each individual request (querying at most 100 intervals for each GB of range.)