### PR TITLE
refactor: expand use of #chunk_metadata and #chunk_proof

### DIFF
--- a/apps/arweave/e2e/ar_e2e.erl
+++ b/apps/arweave/e2e/ar_e2e.erl
@@ -482,12 +482,13 @@ assert_chunk(Node, RequestPacking, Packing, Block, EndOffset, ChunkSize) ->
 	Proof = ar_serialize:json_map_to_poa_map(
 		jiffy:decode(EncodedProof, [return_maps])
 	),
-	{true, _} = ar_test_node:remote_call(Node, ar_poa, validate_paths, [
-		Block#block.tx_root,
-		maps:get(tx_path, Proof),
-		maps:get(data_path, Proof),
-		EndOffset - 1
-	]),
+	ChunkMetadata = #chunk_metadata{
+		tx_root = Block#block.tx_root,
+		tx_path = maps:get(tx_path, Proof),
+		data_path = maps:get(data_path, Proof)
+	},
+	ChunkProof = ar_poa:chunk_proof(ChunkMetadata, EndOffset - 1),
+	{true, _} = ar_test_node:remote_call(Node, ar_poa, validate_paths, [ChunkProof]),
 	Chunk = maps:get(chunk, Proof),
 
 	maybe_write_chunk_fixture(Packing, EndOffset, Chunk),

--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -759,6 +759,22 @@
 	signature_type = ?DEFAULT_KEY_TYPE
 }).
 
+-record(chunk_metadata, {
+	chunk_data_key = not_set :: not_set | not_found | binary(),
+	tx_root = not_set :: not_set | not_found | binary(),
+	tx_path = not_set :: not_set | not_found | binary(),
+	data_root = not_set :: not_set | not_found | binary(),
+	data_path = not_set :: not_set | not_found | binary(),
+	chunk_size = not_set :: not_set | not_found | non_neg_integer()
+}).
+
+-record(chunk_offsets, {
+	absolute_offset = not_set :: not_set | non_neg_integer(),
+	bucket_end_offset = not_set :: not_set | non_neg_integer(),
+	padded_end_offset = not_set :: not_set | non_neg_integer(),
+	relative_offset = not_set :: not_set | non_neg_integer()
+}).
+
 %% A macro to convert AR into Winstons.
 -define(AR(AR), (?WINSTON_PER_AR * AR)).
 

--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -759,13 +759,18 @@
 	signature_type = ?DEFAULT_KEY_TYPE
 }).
 
+%% @doc The data_path field will only be not_found if the chunk record is corrupt/invalid.
+%% This can happen if the chunk entry exists in the chunks_index but not in the chunk_data_db.
+%% In this case:
+%% - not_set means that a field has not been queried yet.
+%% - not_found means that the field has been queried but could not be found.
 -record(chunk_metadata, {
-	chunk_data_key = not_set :: not_set | not_found | binary(),
-	tx_root = not_set :: not_set | not_found | binary(),
-	tx_path = not_set :: not_set | not_found | binary(),
-	data_root = not_set :: not_set | not_found | binary(),
+	chunk_data_key = not_set :: not_set | binary(),
+	tx_root = not_set :: not_set | binary(),
+	tx_path = not_set :: not_set | binary(),
+	data_root = not_set :: not_set | binary(),
 	data_path = not_set :: not_set | not_found | binary(),
-	chunk_size = not_set :: not_set | not_found | non_neg_integer()
+	chunk_size = not_set :: not_set | non_neg_integer()
 }).
 
 -record(chunk_offsets, {

--- a/apps/arweave/include/ar_poa.hrl
+++ b/apps/arweave/include/ar_poa.hrl
@@ -1,12 +1,11 @@
 -ifndef(AR_POA_HRL).
 -define(AR_POA_HRL, true).
 
+-include("ar.hrl").
+
 -record(chunk_proof, {
+	metadata :: #chunk_metadata{},
 	absolute_offset :: non_neg_integer(),
-	tx_root :: binary(),
-	tx_path :: binary(),
-	data_root :: binary(),
-	data_path :: binary(),
 	tx_start_offset :: non_neg_integer(),
 	tx_end_offset :: non_neg_integer(),
 	block_start_offset :: non_neg_integer(),

--- a/apps/arweave/include/ar_poa.hrl
+++ b/apps/arweave/include/ar_poa.hrl
@@ -5,7 +5,7 @@
 
 -record(chunk_proof, {
 	metadata :: #chunk_metadata{},
-	absolute_offset :: non_neg_integer(),
+	seek_byte :: non_neg_integer(),
 	tx_start_offset :: non_neg_integer(),
 	tx_end_offset :: non_neg_integer(),
 	block_start_offset :: non_neg_integer(),

--- a/apps/arweave/include/ar_repack.hrl
+++ b/apps/arweave/include/ar_repack.hrl
@@ -1,34 +1,16 @@
 -ifndef(AR_REPACK_HRL).
 -define(AR_REPACK_HRL, true).
 
--record(chunk_metadata, {
-	chunk_data_key = not_set,
-	tx_root = not_set,
-	data_root = not_set,
-	tx_path = not_set,
-	chunk_size = not_set
-}).
-
--record(chunk_offsets, {
-	absolute_offset = not_set,
-	bucket_end_offset = not_set,
-	padded_end_offset = not_set,
-	relative_offset = not_set
-}).
-
 -record(repack_chunk, {
 	state = needs_chunk :: 
 		needs_chunk | invalid | entropy_only | already_repacked | needs_data_path |
 		needs_repack | needs_entropy | needs_encipher | needs_write | error,
 	metadata = not_set :: not_set | not_found | #chunk_metadata{},
 	offsets = not_set :: not_set | not_found | #chunk_offsets{},
-	data_path = not_set :: not_set | not_found | binary(),
 	source_packing = not_set :: not_set | not_found | ar_packing:packing(),
 	target_packing = not_set :: not_set | not_found | ar_packing:packing(),
 	chunk = not_set :: not_set | not_found | binary(),
 	entropy = not_set :: not_set | binary()
 }).
-
--type repack_chunk() :: #repack_chunk{}.
 
 -endif.

--- a/apps/arweave/src/ar_poa.erl
+++ b/apps/arweave/src/ar_poa.erl
@@ -3,8 +3,8 @@
 -module(ar_poa).
 
 -export([get_data_path_validation_ruleset/2, get_data_path_validation_ruleset/3,
-		 validate_pre_fork_2_5/4, validate/1, chunk_proof/2, chunk_proof/5, validate_paths/1,
-		 get_padded_offset/1, get_padded_offset/2]).
+		 validate_pre_fork_2_5/4, validate/1, chunk_proof/2, chunk_proof/3, chunk_proof/5,
+		 validate_paths/1, get_padded_offset/1, get_padded_offset/2]).
 
 -include_lib("arweave/include/ar_poa.hrl").
 -include_lib("arweave/include/ar.hrl").

--- a/apps/arweave/src/ar_repack.erl
+++ b/apps/arweave/src/ar_repack.erl
@@ -713,22 +713,25 @@ read_chunk_and_data_path(RepackChunk, #state{} = State) ->
 	case ar_data_sync:get_chunk_data(ChunkDataKey, StoreID) of
 		not_found ->
 			log_warning(chunk_not_found_in_chunk_data_db, RepackChunk, State, []),
-			RepackChunk#repack_chunk{ data_path = not_found };
+			RepackChunk#repack_chunk{ 
+				metadata = Metadata#chunk_metadata{ data_path = not_found } };
 		{ok, V} ->
 			case binary_to_term(V) of
 				{Chunk, DataPath} ->
 					RepackChunk#repack_chunk{ 
-						data_path = DataPath,
+						metadata = Metadata#chunk_metadata{ data_path = DataPath },
 						chunk = Chunk
 					};
 				DataPath when MaybeChunk /= not_found ->
 					RepackChunk#repack_chunk{ 
-						data_path = DataPath,
+						metadata = Metadata#chunk_metadata{ data_path = DataPath },
 						chunk = MaybeChunk
 					};
 				_ ->
 					log_warning(chunk_not_found, RepackChunk, State, []),
-					RepackChunk#repack_chunk{ data_path = not_found }
+					RepackChunk#repack_chunk{ 
+						metadata = Metadata#chunk_metadata{ data_path = not_found }
+					}
 			end
 	end.
 

--- a/apps/arweave/src/ar_repack_io.erl
+++ b/apps/arweave/src/ar_repack_io.erl
@@ -227,8 +227,7 @@ wite_chunk(RepackChunk, TargetPacking, #state{} = State) ->
 	#repack_chunk{
 		offsets = Offsets,
 		metadata = Metadata,
-		chunk = Chunk,
-		data_path = DataPath
+		chunk = Chunk
 	} = RepackChunk,
 	#chunk_offsets{
 		absolute_offset = AbsoluteOffset,
@@ -240,7 +239,8 @@ wite_chunk(RepackChunk, TargetPacking, #state{} = State) ->
 		data_root = DataRoot,
 		tx_path = TXPath,
 		chunk_data_key = ChunkDataKey,
-		chunk_size = ChunkSize
+		chunk_size = ChunkSize,
+		data_path = DataPath
 	} = Metadata,
 	StartOffset = PaddedEndOffset - ?DATA_CHUNK_SIZE,
 	IsStorageSupported =


### PR DESCRIPTION
This is an incremental step towards replacing some of our long, opaque tuple arguments with records that can be used across modules