### PR TITLE
Fix Github Workflow dual build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,6 @@ on:
   workflow_dispatch:
   push:
     branches: ["**"]
-  pull_request_target:
-    branches:
-      - 'master'
-      - 'release/**'
-      - 'releases/**'
 
 jobs:
   build:


### PR DESCRIPTION
Few months ago we wanted to allow external users
and developers to open PRs and test them. It
seems doing that created a dual build that can
be annoying when debugging. This is a known "issue" on Github side (https://github.com/orgs/community/discussions/26872)