### PR TITLE
Fix race condition where we may not detect double-signing

### DIFF
--- a/apps/arweave/src/ar_block.erl
+++ b/apps/arweave/src/ar_block.erl
@@ -6,7 +6,7 @@
 		compute_h0/2, compute_h0/5, compute_h0/6,
 		compute_h1/3, compute_h2/3, compute_solution_h/2,
 		indep_hash/1, indep_hash/2, indep_hash2/2, get_block_signature_preimage/4,
-		generate_signed_hash/1, verify_signature/3,
+		generate_signed_hash/1, verify_signature/3, get_reward_key/2,
 		generate_block_data_segment/1, generate_block_data_segment/2,
 		generate_block_data_segment_base/1, get_recall_range/3, verify_tx_root/1,
 		hash_wallet_list/1, generate_hash_list_for_block/2,
@@ -467,6 +467,20 @@ verify_signature(BlockPreimage, PrevCDiff,
 	end;
 verify_signature(_BlockPreimage, _PrevCDiff, _B) ->
 	false.
+
+%% @doc Return the key suitable for ar_wallet:sign/3 from the given public key.
+get_reward_key(Pub, Height) ->
+	case Height >= ar_fork:height_2_9() of
+		false ->
+			{?DEFAULT_KEY_TYPE, Pub};
+		true ->
+			case byte_size(Pub) of
+				?ECDSA_PUB_KEY_SIZE ->
+					{?ECDSA_KEY_TYPE, Pub};
+				_ ->
+					{?RSA_KEY_TYPE, Pub}
+			end
+	end.
 
 %% @doc Generate a block data segment for a pre-2.6 block. It is combined with a nonce
 %% when computing a solution candidate.

--- a/apps/arweave/src/ar_events_sup.erl
+++ b/apps/arweave/src/ar_events_sup.erl
@@ -37,7 +37,7 @@ init([]) ->
 		%% Events: new, ready_for_mining, orphaned, emitting_scheduled,
 		%% preparing_unblacklisting, ready_for_unblacklisting, registered_offset.
 		?CHILD(ar_events, tx, worker),
-		%% Events: discovered, rejected, new, double_signing, mined_block_received.
+		%% Events: discovered, rejected, new, mined_block_received.
 		?CHILD(ar_events, block, worker),
 		%% Events: unpacked, packed.
 		?CHILD(ar_events, chunk, worker),

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -250,23 +250,10 @@ may_be_apply_double_signing_proof(B, PrevB, Accounts) ->
 			may_be_apply_double_signing_proof2(B, PrevB, Accounts)
 	end.
 
-get_reward_key(Pub, Height) ->
-	case Height >= ar_fork:height_2_9() of
-		false ->
-			{?DEFAULT_KEY_TYPE, Pub};
-		true ->
-			case byte_size(Pub) of
-				?ECDSA_PUB_KEY_SIZE ->
-					{?ECDSA_KEY_TYPE, Pub};
-				_ ->
-					{?RSA_KEY_TYPE, Pub}
-			end
-	end.
-
 may_be_apply_double_signing_proof2(B, PrevB, Accounts) ->
 	{Pub, _Signature1, _CDiff1, _PrevCDiff1, _Preimage1, _Signature2, _CDiff2, _PrevCDiff2,
 			_Preimage2} = B#block.double_signing_proof,
-	Key = get_reward_key(Pub, B#block.height),
+	Key = ar_block:get_reward_key(Pub, B#block.height),
 	case B#block.reward_key == Key of
 		true ->
 			{error, invalid_double_signing_proof_same_address};
@@ -292,7 +279,7 @@ may_be_apply_double_signing_proof3(B, PrevB, Accounts) ->
 			Preimage2} = B#block.double_signing_proof,
 	SignaturePreimage1 = ar_block:get_block_signature_preimage(CDiff1, PrevCDiff1,
 			Preimage1, Height),
-	Key = get_reward_key(Pub, B#block.height),
+	Key = ar_block:get_reward_key(Pub, B#block.height),
 	Addr = ar_wallet:to_address(Key),
 	case ar_wallet:verify(Key, SignaturePreimage1, Signature1) of
 		false ->

--- a/apps/arweave/test/ar_post_block_tests.erl
+++ b/apps/arweave/test/ar_post_block_tests.erl
@@ -573,7 +573,6 @@ test_reject_block_invalid_double_signing_proof(KeyType) ->
 	B7_2 = sign_block(B7#block{ tags = [<<"new_tag">>] }, B6, Key),
 	post_block(B6, valid),
 	post_block(B7, valid),
-	timer:sleep(1000),
 	post_block(B7_2, valid),
 	%% Wait until the node records conflicting proofs.
 	true = ar_util:do_until(


### PR DESCRIPTION
Also, add some redundant correctness checks when including a double-signing proof into a block.