### PR TITLE
Fix a missing function call on help message

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -371,8 +371,8 @@ show_help() ->
 				"flags are disallowed. See the node output for details."},
 			{"verify_samples (num)", io_lib:format("Number of chunks to sample and unpack "
 				"during 'verify'. Default is ~B.", [?SAMPLE_CHUNK_COUNT])},
-			{"shutdown_tcp_connection_timeout", "shutdown tcp connection timeout in seconds.",
-				"Default is ~Bs.", [?SHUTDOWN_TCP_CONNECTION_TIMEOUT]}
+			{"shutdown_tcp_connection_timeout", io_lib:format("shutdown tcp connection timeout in seconds.",
+				"Default is ~Bs.", [?SHUTDOWN_TCP_CONNECTION_TIMEOUT])}
 		]
 	),
 	erlang:halt().


### PR DESCRIPTION
A call to io_lib:format/3 was missing, leading to an error message when executing the code.