### PR TITLE
fix: fix bottleneck in ar_global_sync_record

### DIFF
--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -297,6 +297,9 @@
 %% The directory for persisted metrics, NOT relative to the data dir.
 -define(METRICS_DIR, "metrics").
 
+%% The ID and module for the default storage module.
+-define(DEFAULT_MODULE, "default").
+
 %% Default TCP port.
 -define(DEFAULT_HTTP_IFACE_PORT, 1984).
 

--- a/apps/arweave/src/ar_chunk_copy.erl
+++ b/apps/arweave/src/ar_chunk_copy.erl
@@ -44,7 +44,7 @@ register_read_workers() ->
 	{ok, Config} = application:get_env(arweave, config),
 	StoreIDs = [
 		ar_storage_module:id(StorageModule) || StorageModule <- Config#config.storage_modules
-	] ++ ["default"],
+	] ++ [?DEFAULT_MODULE],
 	{Workers, WorkerMap} = 
 		lists:foldl(
 			fun(StoreID, {AccWorkers, AccWorkerMap}) ->
@@ -318,5 +318,5 @@ test_register_workers() ->
 		fun(StoreID) ->
 			?assertEqual(true, ready_for_work(StoreID))
 		end,
-		StoreIDs ++ ["default"]
+		StoreIDs ++ [?DEFAULT_MODULE]
 	).

--- a/apps/arweave/src/ar_device_lock.erl
+++ b/apps/arweave/src/ar_device_lock.erl
@@ -193,7 +193,7 @@ get_system_device(StorageModule) ->
 		_ -> Device
 	end.
 
-do_acquire_lock(Mode, "default", State) ->
+do_acquire_lock(Mode, ?DEFAULT_MODULE, State) ->
 	%% "default" storage module is a special case. It can only be in sync mode.
 	case Mode of
 		sync ->

--- a/apps/arweave/src/ar_disksup.erl
+++ b/apps/arweave/src/ar_disksup.erl
@@ -417,7 +417,7 @@ get_storage_modules_paths() ->
 		end,
 		Config#config.storage_modules
 	),
-	[{"default", DataDir} | SMDirs].
+	[{?DEFAULT_MODULE, DataDir} | SMDirs].
 
 ensure_storage_modules_paths() ->
 	StoragePaths = get_storage_modules_paths(),

--- a/apps/arweave/src/ar_global_sync_record.erl
+++ b/apps/arweave/src/ar_global_sync_record.erl
@@ -86,7 +86,7 @@ init([]) ->
 			end
 		end,
 		ar_intervals:new(),
-		["default" | Config#config.storage_modules]
+		[?DEFAULT_MODULE | Config#config.storage_modules]
 	),
 	SyncBuckets = ar_sync_buckets:from_intervals(SyncRecord),
 	{SyncBuckets2, SerializedSyncBuckets} = ar_sync_buckets:serialize(SyncBuckets,
@@ -127,8 +127,9 @@ handle_cast(Cast, State) ->
 	?LOG_WARNING([{event, unhandled_cast}, {module, ?MODULE}, {cast, Cast}]),
 	{noreply, State}.
 
-handle_info({event, sync_record, {add_range, Start, End, ar_data_sync, StoreID}}, State) ->
-	case ar_storage_module:get_packing(StoreID) of
+handle_info({event, sync_record, {add_range, Start, End, ar_data_sync, Module}}, State) ->
+	Packing = ar_storage_module:get_packing(Module),
+	case Packing of
 		{replica_2_9, _} when ?BLOCK_2_9_SYNCING ->
 			%% Ignore replica.2.9 packing. This is a temporary solution until
 			%% we can support data syncing in batches corresponding to the

--- a/apps/arweave/src/ar_header_sync.erl
+++ b/apps/arweave/src/ar_header_sync.erl
@@ -270,7 +270,7 @@ handle_info({event, tx, {preparing_unblacklisting, TXID}}, State) ->
 handle_info({event, tx, _}, State) ->
 	{noreply, State};
 
-handle_info({event, disksup, {remaining_disk_space, "default", true, _Percentage, Bytes}},
+handle_info({event, disksup, {remaining_disk_space, ?DEFAULT_MODULE, true, _Percentage, Bytes}},
 		State) ->
 	{ok, Config} = application:get_env(arweave, config),
 	DiskPoolSize = Config#config.max_disk_pool_buffer_mb * 1024 * 1024,

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -282,7 +282,7 @@ open_files(StoreIDs) ->
 	lists:foreach(
 		fun(StoreID) ->
 			case StoreID of
-				"default" ->
+				?DEFAULT_MODULE ->
 					ok;
 				_ ->
 					ar_chunk_storage:open_files(StoreID)
@@ -321,14 +321,14 @@ chunks_read(miner, Worker, WhichChunk, Candidate, RecallRangeStart, ChunkOffsets
 chunks_read(standalone, Worker, WhichChunk, Candidate, RecallRangeStart, ChunkOffsets) ->
 	Worker ! {chunks_read, WhichChunk, Candidate, RecallRangeStart, ChunkOffsets}.
 
-get_packed_intervals(Start, End, MiningAddress, PackingDifficulty, "default", Intervals) ->
+get_packed_intervals(Start, End, MiningAddress, PackingDifficulty, ?DEFAULT_MODULE, Intervals) ->
 	ReplicaFormat = get_replica_format_from_packing_difficulty(PackingDifficulty),
 	Packing = ar_block:get_packing(PackingDifficulty, MiningAddress, ReplicaFormat),
-	case ar_sync_record:get_next_synced_interval(Start, End, Packing, ar_data_sync, "default") of
+	case ar_sync_record:get_next_synced_interval(Start, End, Packing, ar_data_sync, ?DEFAULT_MODULE) of
 		not_found ->
 			Intervals;
 		{Right, Left} ->
-			get_packed_intervals(Right, End, MiningAddress, PackingDifficulty, "default",
+			get_packed_intervals(Right, End, MiningAddress, PackingDifficulty, ?DEFAULT_MODULE,
 					ar_intervals:add(Intervals, Right, Left))
 	end;
 get_packed_intervals(_Start, _End, _MiningAddr, _PackingDifficulty, _StoreID, _Intervals) ->
@@ -415,7 +415,7 @@ read_range(Mode, WhichChunk, Candidate, RangeStart, StoreID) ->
 
 filter_by_packing([], _Intervals, _StoreID) ->
 	[];
-filter_by_packing([{EndOffset, Chunk} | ChunkOffsets], Intervals, "default" = StoreID) ->
+filter_by_packing([{EndOffset, Chunk} | ChunkOffsets], Intervals, ?DEFAULT_MODULE = StoreID) ->
 	case ar_intervals:is_inside(Intervals, EndOffset) of
 		false ->
 			filter_by_packing(ChunkOffsets, Intervals, StoreID);

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -163,7 +163,7 @@ init([]) ->
 	%% Trap exit to avoid corrupting any open files on quit.
 	process_flag(trap_exit, true),
 	ok = ar_events:subscribe(nonce_limiter),
-	ar_chunk_storage:open_files("default"),
+	ar_chunk_storage:open_files(?DEFAULT_MODULE),
 
 	Partitions = ar_mining_io:get_partitions(infinity),
 	Packing = ar_mining_io:get_packing(),

--- a/apps/arweave/src/ar_sync_record.erl
+++ b/apps/arweave/src/ar_sync_record.erl
@@ -43,6 +43,8 @@
 	state_db,
 	%% The identifier of the storage module.
 	store_id,
+	%% The storage module.
+	storage_module,
 	%% The partition covered by the storage module.
 	partition_number,
 	%% The size in bytes of the storage module; undefined for the "default" storage.
@@ -150,9 +152,9 @@ cut(Offset, ID, StoreID) ->
 %% byte that is the first byte of the weave, is_recorded(0, ID)
 %% returns false and is_recorded(1, ID) returns true.
 is_recorded(Offset, {ID, Packing}) ->
-	case is_recorded(Offset, Packing, ID, "default") of
+	case is_recorded(Offset, Packing, ID, ?DEFAULT_MODULE) of
 		true ->
-			{{true, Packing}, "default"};
+			{{true, Packing}, ?DEFAULT_MODULE};
 		false ->
 			StorageModules = [Module
 					|| {_, _, ModulePacking} = Module <- ar_storage_module:get_all(Offset),
@@ -160,12 +162,12 @@ is_recorded(Offset, {ID, Packing}) ->
 			is_recorded_any_by_type(Offset, ID, StorageModules)
 	end;
 is_recorded(Offset, ID) ->
-	case is_recorded(Offset, ID, "default") of
+	case is_recorded(Offset, ID, ?DEFAULT_MODULE) of
 		false ->
 			StorageModules = ar_storage_module:get_all(Offset),
 			is_recorded_any(Offset, ID, StorageModules);
 		Reply ->
-			{Reply, "default"}
+			{Reply, ?DEFAULT_MODULE}
 	end.
 
 %% @doc Return true or {true, Packing} if a chunk containing
@@ -272,13 +274,13 @@ get_intersection_size(End, Start, ID, StoreID) ->
 init(StoreID) ->
 	%% Trap exit to avoid corrupting any open files on quit.
 	process_flag(trap_exit, true),
+	StorageModule = ar_storage_module:get_by_id(StoreID),
 	{Dir, StorageModuleSize, StorageModuleIndex, PartitionNumber} =
-		case StoreID of
-			"default" ->
+		case StorageModule of
+			?DEFAULT_MODULE ->
 				{filename:join(?ROCKS_DB_DIR, "ar_sync_record_db"),
 					undefined, undefined, undefined};
-			_ ->
-				{Size, Index, _Packing} = ar_storage_module:get_by_id(StoreID),
+			{Size, Index, _Packing} ->
 				{filename:join(["storage_modules", StoreID, ?ROCKS_DB_DIR,
 						"ar_sync_record_db"]), Size, Index,
 							ar_node:get_partition_number(Size * Index)}
@@ -292,6 +294,7 @@ init(StoreID) ->
 	{ok, #state{
 		state_db = StateDB,
 		store_id = StoreID,
+		storage_module = StorageModule,
 		partition_number = PartitionNumber,
 		storage_module_size = StorageModuleSize,
 		storage_module_index = StorageModuleIndex,
@@ -421,7 +424,7 @@ name(StoreID) ->
 
 add2(End, Start, ID, State) ->
 	#state{ sync_record_by_id = SyncRecordByID, state_db = StateDB,
-			store_id = StoreID } = State,
+			store_id = StoreID, storage_module = Module } = State,
 	SyncRecord = maps:get(ID, SyncRecordByID, ar_intervals:new()),
 	SyncRecord2 = ar_intervals:add(SyncRecord, End, Start),
 	SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
@@ -431,7 +434,7 @@ add2(End, Start, ID, State) ->
 	{Reply, State3} = update_write_ahead_log({add, {End, Start, ID}}, StateDB, State2),
 	case Reply of
 		ok ->
-			emit_add_range(Start, End, ID, StoreID);
+			emit_add_range(Start, End, ID, Module);
 		_ ->
 			ok
 	end,
@@ -439,7 +442,7 @@ add2(End, Start, ID, State) ->
 
 add2(End, Start, Packing, ID, State) ->
 	#state{ sync_record_by_id = SyncRecordByID, sync_record_by_id_type = SyncRecordByIDType,
-			state_db = StateDB, store_id = StoreID } = State,
+			state_db = StateDB, store_id = StoreID, storage_module = Module } = State,
 	ByType = maps:get({ID, Packing}, SyncRecordByIDType, ar_intervals:new()),
 	ByType2 = ar_intervals:add(ByType, End, Start),
 	SyncRecordByIDType2 = maps:put({ID, Packing}, ByType2, SyncRecordByIDType),
@@ -455,7 +458,7 @@ add2(End, Start, Packing, ID, State) ->
 	{Reply, State3} = update_write_ahead_log({{add, Packing}, {End, Start, ID}}, StateDB, State2),
 	case Reply of
 		ok ->
-			emit_add_range(Start, End, ID, StoreID);
+			emit_add_range(Start, End, ID, Module);
 		_ ->
 			ok
 	end,
@@ -565,12 +568,14 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, StateDB, StoreID) ->
 	replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, WAL, StateDB, StoreID).
 
 replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, WAL, StateDB, StoreID) ->
-	replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, 1, WAL, StateDB, StoreID).
+	Module = ar_storage_module:get_by_id(StoreID),
+	replay_write_ahead_log(
+		SyncRecordByID, SyncRecordByIDType, 1, WAL, StateDB, StoreID, Module).
 
-replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, _StateDB, _StoreID)
+replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, _StateDB, _StoreID, _Module)
 		when N > WAL ->
 	{SyncRecordByID, SyncRecordByIDType, WAL};
-replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, StoreID) ->
+replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, StoreID, Module) ->
 	case ar_kv:get(StateDB, binary:encode_unsigned(N)) of
 		not_found ->
 			%% The VM crashed after recording the number.
@@ -582,10 +587,11 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, Stor
 					{End, Start, ID} = Params,
 					SyncRecord = maps:get(ID, SyncRecordByID, ar_intervals:new()),
 					SyncRecord2 = ar_intervals:add(SyncRecord, End, Start),
-					emit_add_range(Start, End, ID, StoreID),
+					emit_add_range(Start, End, ID, Module),
 					SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
 					replay_write_ahead_log(
-						SyncRecordByID2, SyncRecordByIDType, N + 1, WAL, StateDB, StoreID);
+						SyncRecordByID2, SyncRecordByIDType, N + 1, 
+						WAL, StateDB, StoreID, Module);
 				{add, Packing} ->
 					{End, Start, ID} = Params,
 					SyncRecord = maps:get(ID, SyncRecordByID, ar_intervals:new()),
@@ -593,15 +599,16 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, Stor
 					SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
 					ByType = maps:get({ID, Packing}, SyncRecordByIDType, ar_intervals:new()),
 					ByType2 = ar_intervals:add(ByType, End, Start),
-					emit_add_range(Start, End, ID, StoreID),
+					emit_add_range(Start, End, ID, Module),
 					SyncRecordByIDType2 = maps:put({ID, Packing}, ByType2, SyncRecordByIDType),
 					replay_write_ahead_log(
-						SyncRecordByID2, SyncRecordByIDType2, N + 1, WAL, StateDB, StoreID);
+						SyncRecordByID2, SyncRecordByIDType2, N + 1,
+						WAL, StateDB, StoreID, Module);
 				delete ->
 					{End, Start, ID} = Params,
 					SyncRecord = maps:get(ID, SyncRecordByID, ar_intervals:new()),
 					SyncRecord2 = ar_intervals:delete(SyncRecord, End, Start),
-					emit_remove_range(Start, End, StoreID),
+					emit_remove_range(Start, End, Module),
 					SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
 					SyncRecordByIDType2 =
 						maps:map(
@@ -614,12 +621,13 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, Stor
 							SyncRecordByIDType
 						),
 					replay_write_ahead_log(
-						SyncRecordByID2, SyncRecordByIDType2, N + 1, WAL, StateDB, StoreID);
+						SyncRecordByID2, SyncRecordByIDType2, N + 1,
+						WAL, StateDB, StoreID, Module);
 				cut ->
 					{Offset, ID} = Params,
 					SyncRecord = maps:get(ID, SyncRecordByID, ar_intervals:new()),
 					SyncRecord2 = ar_intervals:cut(SyncRecord, Offset),
-					emit_cut(Offset, StoreID),
+					emit_cut(Offset, Module),
 					SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
 					SyncRecordByIDType2 =
 						maps:map(
@@ -632,20 +640,21 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, Stor
 							SyncRecordByIDType
 						),
 					replay_write_ahead_log(
-						SyncRecordByID2, SyncRecordByIDType2, N + 1, WAL, StateDB, StoreID)
+						SyncRecordByID2, SyncRecordByIDType2, N + 1,
+						WAL, StateDB, StoreID, Module)
 			end
 	end.
 
-emit_add_range(Start, End, ar_data_sync, StoreID) ->
-	ar_events:send(sync_record, {add_range, Start, End, ar_data_sync, StoreID});
-emit_add_range(_Start, _End, _ID, _StoreID) ->
+emit_add_range(Start, End, ar_data_sync, Module) ->
+	ar_events:send(sync_record, {add_range, Start, End, ar_data_sync, Module});
+emit_add_range(_Start, _End, _ID, _Module) ->
 	ok.
 
-emit_remove_range(Start, End, StoreID) ->
-	ar_events:send(sync_record, {remove_range, Start, End, StoreID}).
+emit_remove_range(Start, End, Module) ->
+	ar_events:send(sync_record, {remove_range, Start, End, Module}).
 
-emit_cut(Offset, StoreID) ->
-	ar_events:send(sync_record, {cut, Offset, StoreID}).
+emit_cut(Offset, Module) ->
+	ar_events:send(sync_record, {cut, Offset, Module}).
 
 initialize_sync_record_by_id_ets(SyncRecordByID, StoreID) ->
 	Iterator = maps:iterator(SyncRecordByID),

--- a/apps/arweave/src/ar_sync_record_sup.erl
+++ b/apps/arweave/src/ar_sync_record_sup.erl
@@ -33,7 +33,7 @@ init([]) ->
 		Config#config.storage_modules
 	),
 	DefaultSyncRecordWorker = ?CHILD_WITH_ARGS(ar_sync_record, worker, ar_sync_record_default,
-		[ar_sync_record_default, "default"]),
+		[ar_sync_record_default, ?DEFAULT_MODULE]),
 	RepackInPlaceWorkers = lists:map(
 		fun({StorageModule, _Packing}) ->
 			StoreID = ar_storage_module:id(StorageModule),

--- a/apps/arweave/test/ar_header_sync_tests.erl
+++ b/apps/arweave/test/ar_header_sync_tests.erl
@@ -45,7 +45,7 @@ test_syncs_headers() ->
 	),
 	%% Throw the event to simulate running out of disk space.
 	ar_disksup:pause(),
-	ar_events:send(disksup, {remaining_disk_space, "default", true, 0, 0}),
+	ar_events:send(disksup, {remaining_disk_space, ?DEFAULT_MODULE, true, 0, 0}),
 	NoSpaceHeight = ?MAX_TX_ANCHOR_DEPTH + 6,
 	NoSpaceTX = sign_v1_tx(main, Wallet,
 		#{ data => random_v1_data(10 * 1024), last_tx => ar_test_node:get_tx_anchor(peer1) }),

--- a/apps/arweave/test/ar_sync_record_tests.erl
+++ b/apps/arweave/test/ar_sync_record_tests.erl
@@ -32,12 +32,12 @@ test_sync_record() ->
 
 		?assertEqual([{1048576, 0}], ar_intervals:to_list(Global1)),
 		?assertEqual(not_found,
-			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 
 		%% Add a diskpool chunk
 		ar_sync_record:add(
-			DiskPoolStart+?DATA_CHUNK_SIZE, DiskPoolStart, ar_data_sync, "default"),
+			DiskPoolStart+?DATA_CHUNK_SIZE, DiskPoolStart, ar_data_sync, ?DEFAULT_MODULE),
 		timer:sleep(SleepTime),
 		{ok, Binary2} = ar_global_sync_record:get_serialized_sync_record(Options),
 		{ok, Global2} = ar_intervals:safe_from_etf(Binary2),
@@ -45,12 +45,12 @@ test_sync_record() ->
 		?assertEqual([{1048576, 0},{DiskPoolStart+?DATA_CHUNK_SIZE,DiskPoolStart}],
 			ar_intervals:to_list(Global2)),
 		?assertEqual({DiskPoolStart+?DATA_CHUNK_SIZE,DiskPoolStart},
-			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 
 		%% Remove the diskpool chunk
 		ar_sync_record:delete(
-			DiskPoolStart+?DATA_CHUNK_SIZE, DiskPoolStart, ar_data_sync, "default"),
+			DiskPoolStart+?DATA_CHUNK_SIZE, DiskPoolStart, ar_data_sync, ?DEFAULT_MODULE),
 		timer:sleep(SleepTime),
 		{ok, Binary3} = ar_global_sync_record:get_serialized_sync_record(Options),
 		{ok, Global3} = ar_intervals:safe_from_etf(Binary3),
@@ -77,7 +77,7 @@ test_sync_record() ->
 		?assertEqual([{1048576, 0},{PartitionStart+?DATA_CHUNK_SIZE,PartitionStart}],
 			ar_intervals:to_list(Global5)),
 		?assertEqual(not_found,
-			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 		?assertEqual({PartitionStart+?DATA_CHUNK_SIZE, PartitionStart},
 				ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, PartitionID)),
@@ -98,14 +98,14 @@ test_sync_record() ->
 				200,
 				1000),
 		?assertEqual(not_found,
-			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 		?assertEqual(not_found,
 				ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, PartitionID)),
 
 		%% Add chunk to both diskpool and storage module
 		ar_sync_record:add(
-			PartitionStart+?DATA_CHUNK_SIZE, PartitionStart, ar_data_sync, "default"),
+			PartitionStart+?DATA_CHUNK_SIZE, PartitionStart, ar_data_sync, ?DEFAULT_MODULE),
 		ar_sync_record:add(
 			PartitionStart+?DATA_CHUNK_SIZE, PartitionStart, ar_data_sync, PartitionID),
 		timer:sleep(SleepTime),
@@ -115,14 +115,14 @@ test_sync_record() ->
 		?assertEqual([{1048576, 0}, {PartitionStart+?DATA_CHUNK_SIZE,PartitionStart}],
 			ar_intervals:to_list(Global6)),
 		?assertEqual({PartitionStart+?DATA_CHUNK_SIZE,PartitionStart},
-			ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 		?assertEqual({PartitionStart+?DATA_CHUNK_SIZE, PartitionStart},
 			ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, PartitionID)),
 
 		%% Now remove it from just the diskpool
 		ar_sync_record:delete(
-			PartitionStart+?DATA_CHUNK_SIZE, PartitionStart, ar_data_sync, "default"),
+			PartitionStart+?DATA_CHUNK_SIZE, PartitionStart, ar_data_sync, ?DEFAULT_MODULE),
 		timer:sleep(SleepTime),
 		{ok, Binary7} = ar_global_sync_record:get_serialized_sync_record(Options),
 		{ok, Global7} = ar_intervals:safe_from_etf(Binary7),
@@ -130,7 +130,7 @@ test_sync_record() ->
 		?assertEqual([{1048576, 0}, {PartitionStart+?DATA_CHUNK_SIZE,PartitionStart}],
 			ar_intervals:to_list(Global7)),
 		?assertEqual(not_found,
-			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, "default")),
+			ar_sync_record:get_interval(DiskPoolStart+1, ar_data_sync, ?DEFAULT_MODULE)),
 		?assertEqual({1048576, 0}, ar_sync_record:get_interval(1, ar_data_sync, PartitionID)),
 		?assertEqual({PartitionStart+?DATA_CHUNK_SIZE, PartitionStart},
 			ar_sync_record:get_interval(PartitionStart+1, ar_data_sync, PartitionID)),


### PR DESCRIPTION
When a lot of chunks are being added to the global sync record (e.g. during a sync, pack, or repack), it needs to check for replica_2_9 chunks a lot. Previously each check used the ar_storage_module:get_by_id(StoreID) call which inclues a couple ets calls. At high volume this was a bottleneck which eventually caused the ar_global_sync_record message queue to back up and OOM.

Fix is to have the sync_record events include the StorageModule rather than the StoreID and so bypass the get_by_id call