### PR TITLE
Enable VDF tests on MacOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,14 @@ name: "Arweave MacOS Builder"
 on:
   workflow_dispatch:
   push:
-    branches: ["master"]
+    branches: ["**"]
+
+# We don't have a lot of workers right now, and some of the tests
+# will run on the same server. To avoid failure only one test at
+# a time is allowed.
+concurrency:
+  group: macos
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -19,96 +26,28 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-
-      # only arweave dependencies are being cached,
-      # those are not updated everyday and this is
-      # unecessary to fetch them everytime.
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            _build/default/lib/accept
-            _build/default/lib/b64fast
-            _build/default/lib/cowboy
-            _build/default/lib/cowlib
-            _build/default/lib/gun
-            _build/default/lib/jiffy
-            _build/default/lib/prometheus
-            _build/default/lib/prometheus_cowboy
-            _build/default/lib/prometheus_httpd
-            _build/default/lib/prometheus_process_collector
-            _build/default/lib/quantile_estimator
-            _build/default/lib/ranch
-            _build/default/lib/.rebar3
-            _build/default/lib/recon
-            _build/default/lib/rocksdb
-            _build/default/plugins/
-            _build/default/plugins/aleppo
-            _build/default/plugins/geas
-            _build/default/plugins/geas_rebar3
-            _build/default/plugins/hex_core
-            _build/default/plugins/katana_code
-            _build/default/plugins/pc
-            _build/default/plugins/.rebar3
-            _build/default/plugins/rebar3_archive_plugin
-            _build/default/plugins/rebar3_elvis_plugin
-            _build/default/plugins/rebar3_hex
-            _build/default/plugins/samovar
-            _build/default/plugins/verl
-            _build/default/plugins/zipper
-          key: macos-deps-cache-${{ hashFiles('rebar.lock') }}
-          restore-keys: |
-            macos-deps-cache-${{ hashFiles('rebar.lock') }}
-
+          
       - name: Get dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: ./ar-rebar3 default get-deps
 
-      - uses: actions/cache@v4
+      - name: Get dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          path: |
-            _build/default/lib/accept
-            _build/default/lib/b64fast
-            _build/default/lib/cowboy
-            _build/default/lib/cowlib
-            _build/default/lib/gun
-            _build/default/lib/jiffy
-            _build/default/lib/prometheus
-            _build/default/lib/prometheus_cowboy
-            _build/default/lib/prometheus_httpd
-            _build/default/lib/prometheus_process_collector
-            _build/default/lib/quantile_estimator
-            _build/default/lib/ranch
-            _build/default/lib/.rebar3
-            _build/default/lib/recon
-            _build/default/lib/rocksdb
-            _build/default/plugins/
-            _build/default/plugins/aleppo
-            _build/default/plugins/geas
-            _build/default/plugins/geas_rebar3
-            _build/default/plugins/hex_core
-            _build/default/plugins/katana_code
-            _build/default/plugins/pc
-            _build/default/plugins/.rebar3
-            _build/default/plugins/rebar3_archive_plugin
-            _build/default/plugins/rebar3_elvis_plugin
-            _build/default/plugins/rebar3_hex
-            _build/default/plugins/samovar
-            _build/default/plugins/verl
-            _build/default/plugins/zipper
-          key: macos-deps-cache-${{ hashFiles('rebar.lock') }}
+        run: ./ar-rebar3 test get-deps
 
       - name: Compile arweave release
         run: ./ar-rebar3 default release
 
-      # some artifacts are compiled and only available
+      - name: Build arweave test sources
+        run: ./ar-rebar3 test compile
+        
+     # some artifacts are compiled and only available
       # in arweave directy (libraries)
       - name: Prepare artifacts
         run: |
           chmod -R u+w ./_build
-          tar czfp _build.tar.gz ./_build ./bin/arweave
-          tar czfp apps.tar.gz ./apps
+          tar czfLp _build.tar.gz ./_build
+          tar czfLp apps.tar.gz ./apps
 
       # to avoid reusing artifacts from someone else
       # and generating issues, an unique artifact is
@@ -124,25 +63,68 @@ jobs:
             _build.tar.gz
             apps.tar.gz
 
-      # some artifacts are compiled and only available
-      # in arweave directy (libraries)
-      - name: Prepare artifacts
-        run: |
-          chmod -R u+w ./_build
-          tar czfp _build.tar.gz ./_build
-          tar czfp apps.tar.gz ./apps
+  canary:
+    needs: build
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
-      # to avoid reusing artifacts from someone else
-      # and generating issues, an unique artifact is
-      # produced using github checksum.
-      - name: upload artifacts
-        uses: actions/upload-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v4
         with:
           name: macos-build-${{ github.sha }}
-          if-no-files-found: error
-          include-hidden-files: true
+
+      - name: Extract artifact
+        run: |
+          tar zxfp _build.tar.gz
+          tar zxfp apps.tar.gz
+
+      - id: canary
+        name: ar_canary.erl
+        continue-on-error: true
+        run: bash scripts/github_workflow.sh "tests" "ar_canary"
+
+  tests:
+    needs: canary
+    runs-on: [self-hosted, macOS, ARM64]
+    strategy:
+      max-parallel: 3
+      matrix:
+        core_test_mod: [
+            ar_vdf_server_tests,
+            ar_mine_vdf_tests,
+            ar_vdf_tests
+          ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-build-${{ github.sha }}
+
+      - name: Extract artifact
+        run: |
+          tar zxfp _build.tar.gz
+          tar zxfp apps.tar.gz
+
+      - name: ${{ matrix.core_test_mod }}.erl
+        id: test
+        run: bash scripts/github_workflow.sh "tests" "${{ matrix.core_test_mod }}"
+
+      - name: upload artifacts in case of failure
+        uses: actions/upload-artifact@v4
+        if: always() && failure()
+        with:
+          name: "logs-${{ matrix.core_test_mod }}-${{ github.run_attempt }}-${{ job.status }}-${{ runner.name }}-${{ github.sha }}"
           retention-days: 7
           overwrite: true
+          include-hidden-files: true
           path: |
-            _build.tar.gz
-            apps.tar.gz
+            ./logs
+            *.out
+            *.dump

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,29 +119,6 @@ jobs:
             _build.tar.gz
             apps.tar.gz
 
-      # some artifacts are compiled and only available
-      # in arweave directy (libraries)
-      - name: Prepare artifacts
-        run: |
-          chmod -R u+w ./_build
-          tar czfp _build.tar.gz ./_build
-          tar czfp apps.tar.gz ./apps
-
-      # to avoid reusing artifacts from someone else
-      # and generating issues, an unique artifact is
-      # produced using github checksum.
-      - name: upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-${{ github.sha }}
-          if-no-files-found: error
-          include-hidden-files: true
-          retention-days: 7
-          overwrite: true
-          path: |
-            _build.tar.gz
-            apps.tar.gz
-
   ####################################################################
   # Canary testing, should fail.
   ####################################################################


### PR DESCRIPTION
This commit enables VDF tests for MacOS. because MacOS does not support containers at this time, some changes were required. Indeed, all runners are isolated using a dedicated user and environment, but rebar3 is using symlinks when dealing with dependencies. To avoid issues, links are deferenced. Artifacts will be bigger, but it is possible to run more than one worker at a time now, in a distributed environment.

Fixed duplicated code in standard tests.

see: https://github.com/ArweaveTeam/arweave-dev/issues/880