### PR TITLE
Fix unhandled gun message

### DIFF
--- a/apps/arweave/src/ar_http.erl
+++ b/apps/arweave/src/ar_http.erl
@@ -189,6 +189,10 @@ handle_info({gun_error, PID, Reason},
 			{noreply, State#state{ status_by_pid = StatusByPID2, pid_by_peer = PIDByPeer2 }}
 	end;
 
+% missing pattern from gun 2.2+
+handle_info({gun_down, Pid, Protocol, Reason, Streams}, State) ->
+	handle_info({gun_down, Pid, Protocol, Reason, [], Streams}, State);
+
 handle_info({gun_down, PID, Protocol, Reason, _KilledStreams, _UnprocessedStreams},
 			#state{ pid_by_peer = PIDByPeer, status_by_pid = StatusByPID } = State) ->
 	case maps:get(PID, StatusByPID, not_found) of


### PR DESCRIPTION
Gun 2.2+ introduced a new message format, after
the update, logs now display those messages:

    [warning] ar_http:handle_info/2:241 event: unhandled_info, module:
      ar_http, message: {gun_down,<0.9569.2315>,http,normal,[]}
    [warning] ar_http:handle_info/2:241 event: unhandled_info, module:
      ar_http, message: {gun_down,<0.4587.2315>,http,normal,[]}
    [warning] ar_http:handle_info/2:241 event: unhandled_info, module:
      ar_http, message: {gun_down,<0.21784.2313>,http,closed,[]}

This commit fix the issue by forwarding the
pattern to the right one (only impacting
gun_down).