### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/apps/arweave/src/ar_info.erl
+++ b/apps/arweave/src/ar_info.erl
@@ -56,7 +56,7 @@ get_recent() ->
         <<"forks">> => get_recent_forks()
     }.
 
-%% @doc Return the the most recent blocks in reverse chronological order.
+%% @doc Return the most recent blocks in reverse chronological order.
 %% 
 %% There are a few list reversals that happen here:
 %% 1. get_block_anchors returns the blocks in reverse chronological order (latest block first)
@@ -79,7 +79,7 @@ get_recent_blocks() ->
     ),
     lists:reverse(Blocks).
 
-%% @doc Return the the most recent forks in reverse chronological order.
+%% @doc Return the most recent forks in reverse chronological order.
 get_recent_forks() ->
     CutOffTime = os:system_time(seconds) - ?RECENT_FORKS_AGE,
     case ar_chain_stats:get_forks(CutOffTime) of

--- a/apps/arweave/test/ar_tx_tests.erl
+++ b/apps/arweave/test/ar_tx_tests.erl
@@ -824,7 +824,7 @@ joins_network_successfully() ->
 	ar_test_node:mine(peer1),
 	assert_wait_until_height(peer1, ?MAX_TX_ANCHOR_DEPTH + 1),
 
-	%% lists:nth(?MAX_TX_ANCHOR_DEPTH - 1, BI) since we'll be at at ?MAX_TX_ANCHOR_DEPTH + 2.
+	%% lists:nth(?MAX_TX_ANCHOR_DEPTH - 1, BI) since we'll be at ?MAX_TX_ANCHOR_DEPTH + 2.
 	TX3 = ar_test_node:sign_tx(peer1, Key, #{ last_tx => element(1, lists:nth(?MAX_TX_ANCHOR_DEPTH - 1, BI)) }),
 	ar_test_node:assert_post_tx_to_peer(peer1, TX3),
 	ar_test_node:mine(peer1),

--- a/doc/path-manifest-schema.md
+++ b/doc/path-manifest-schema.md
@@ -6,7 +6,7 @@ Path manifests are JSON objects with the following keys.
 | ---------------- | ---------- | ------ | ----------- |
 | `manifest`       | ✓          | string | The manifest type identifier, this MUST be `arweave/paths`. |
 | `version`        | ✓          | string | The manifest specification version, currently "0.1.0". This will be updated with future updates according to [semver](https://semver.org). |
-| `index`          |            | object | The behavior gateways SHOULD follow when the manifest is accessed directly. When defined, `index` MUST contain a member describing the behavior to adopt. Currently, the only supported behavior is `path`. `index` MAY be be omitted, in which case gateways SHOULD serve a listing of all paths. |
+| `index`          |            | object | The behavior gateways SHOULD follow when the manifest is accessed directly. When defined, `index` MUST contain a member describing the behavior to adopt. Currently, the only supported behavior is `path`. `index` MAY be omitted, in which case gateways SHOULD serve a listing of all paths. |
 | `index.path`     |            | string | The default path to load. If defined, the field MUST reference a key in the `paths` object (it MUST NOT reference a transaction ID directly). |
 | `paths`          | ✓          | object | The path mapping between subpaths and the content they resolve to. The object keys represent the subpaths, and the values tell us which content to resolve to. |
 | `paths[path].id` | ✓          | string | The transaction ID to resolve to for the given path. |


### PR DESCRIPTION
remove redundant words in comment