### PR TITLE
Modify Arweave network parameters name

### DIFF
--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -162,6 +162,7 @@
 -define(DEFAULT_COWBOY_HTTP_REQUEST_TIMEOUT, 5000).
 -define(DEFAULT_COWBOY_TCP_BACKLOG, 1024).
 -define(DEFAULT_COWBOY_TCP_DELAY_SEND, false).
+-define(DEFAULT_COWBOY_TCP_IDLE_TIMEOUT_SECOND, 10).
 -define(DEFAULT_COWBOY_TCP_KEEPALIVE, true).
 -define(DEFAULT_COWBOY_TCP_LINGER, false).
 -define(DEFAULT_COWBOY_TCP_LINGER_TIMEOUT, 0).
@@ -256,7 +257,7 @@
 	block_throttle_by_solution_interval = ?DEFAULT_BLOCK_THROTTLE_BY_SOLUTION_INTERVAL_MS,
 	tls_cert_file = not_set, %% required to enable TLS
 	tls_key_file = not_set,  %% required to enable TLS
-	http_api_transport_idle_timeout = 10000,
+	http_api_transport_idle_timeout = ?DEFAULT_COWBOY_TCP_IDLE_TIMEOUT_SECOND*1000,
 	p3 = #p3_config{},
 	coordinated_mining = false,
 	cm_api_secret = not_set,

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -616,7 +616,7 @@ parse_options([{<<"p3">>, {P3Config}} | Rest], Config) ->
 			P3Config}
 	end;
 
-parse_options([{<<"http_api_transport_idle_timeout_seconds">>, D} | Rest], Config) when is_integer(D) ->
+parse_options([{<<"http_api.tcp.idle_timeout_seconds">>, D} | Rest], Config) when is_integer(D) ->
 	parse_options(Rest, Config#config{ http_api_transport_idle_timeout = D * 1000 });
 
 parse_options([{<<"coordinated_mining">>, true} | Rest], Config) ->
@@ -715,13 +715,13 @@ parse_options([{<<"data_sync_request_packed_chunks">>, InvalidValue} | _Rest], _
 	{error, {bad_type, data_sync_request_packed_chunks, boolean}, InvalidValue};
 
 %% shutdown procedure
-parse_options([{<<"shutdown_tcp_connection_timeout">>, Delay} | Rest], Config)
+parse_options([{<<"network.tcp.shutdown.connection_timeout">>, Delay} | Rest], Config)
 	when is_integer(Delay) andalso Delay > 0 ->
 		NewConfig = Config#config{ shutdown_tcp_connection_timeout = Delay },
 		parse_options(Rest, NewConfig);
-parse_options([{<<"shutdown_tcp_connection_timeout">>, InvalidValue} | _Rest], _Config) ->
+parse_options([{<<"network.tcp.shutdown.connection_timeout">>, InvalidValue} | _Rest], _Config) ->
 	{error, {bad_type, shutdown_tcp_connection_timeout, integer}, InvalidValue};
-parse_options([{<<"shutdown_tcp_mode">>, Mode}|Rest], Config) ->
+parse_options([{<<"network.tcp.shutdown.mode">>, Mode}|Rest], Config) ->
 	case Mode of
 		<<"shutdown">> ->
 			NewConfig = Config#config{ shutdown_tcp_mode = shutdown },
@@ -734,7 +734,7 @@ parse_options([{<<"shutdown_tcp_mode">>, Mode}|Rest], Config) ->
 	end;
 
 %% Global socket configuration
-parse_options([{<<"socket.backend">>, Backend}|Rest], Config) ->
+parse_options([{<<"network.socket.backend">>, Backend}|Rest], Config) ->
 	case Backend of
 		<<"inet">> ->
 			parse_options(Rest, Config#config{ 'socket.backend' = inet });


### PR DESCRIPTION
Grouping arweave network parameters by category, using `.` as separator, a cleaner approach reflecting also `sysctl` configuration convention. In preparation for the next release 2.9.5 or major release. Here the final parameters keys with their default values:

| Version | Parameters                                | Default Value |
|---------|-------------------------------------------|---------------|
| `2.9.5` | `http_api.http.active_n`                  | `100`
| `2.9.5` | `http_api.http.inactivity_timeout`        | `60000`
| `2.9.5` | `http_api.http.linger_timeout`            | `0`
| `2.9.5` | `http_api.http.linger`                    | `false`
| `2.9.5` | `http_api.http.request_timeout`           | `5000`
| `2.9.5` | `http_api.tcp.backlog`                    | `1024`
| `2.9.5` | `http_api.tcp.delay_send`                 | `false`
| `2.9.5` | `http_api.tcp.idle_timeout_seconds`       | `10`
| `2.9.5` | `http_api.tcp.keepalive`                  | `true`
| `2.9.5` | `http_api.tcp.listener_shutdown`          | `5000`
| `2.9.5` | `http_api.tcp.nodelay`                    | `true`
| `2.9.5` | `http_api.tcp.num_acceptors`              | `10`
| `2.9.5` | `http_api.tcp.send_timeout_close`         | `true`
| `2.9.5` | `http_api.tcp.send_timeout`               | `15000`
| `2.9.5` | `http_client.http.closing_timeout`        | `15000`
| `2.9.5` | `http_client.http.keepalive`              | `60000`
| `2.9.5` | `http_client.tcp.delay_send`              | `false`
| `2.9.5` | `http_client.tcp.keepalive`               | `true`
| `2.9.5` | `http_client.tcp.linger_timeout`          | `0`
| `2.9.5` | `http_client.tcp.linger`                  | `false`
| `2.9.5` | `http_client.tcp.nodelay`                 | `true`
| `2.9.5` | `http_client.tcp.send_timeout_close`      | `true`
| `2.9.5` | `http_client.tcp.send_timeout`            | `15000`
| `2.9.5` | `network.socket.backend`                  | `inet`
| `2.9.5` | `network.tcp.shutdown.connection_timeout` | `30`
| `2.9.5` | `network.tcp.shutdown.mode`               | `shutdown`