### PR TITLE
Fix Timeout Issue when peers clock are not sync

### DIFF
--- a/apps/arweave/src/ar_bench_2_9.erl
+++ b/apps/arweave/src/ar_bench_2_9.erl
@@ -27,7 +27,7 @@ run_benchmark_from_cli(Args) ->
 			{error, Reason} ->
 				io:format("Error: Could not ensure directory ~p exists. Reason: ~p~n", [Dir, Reason]),
 				show_help(),
-				erlang:halt(1)
+				init:stop(1)
 		end
 	end, Dirs),
 	run_benchmark({Format, Dirs, Threads, DataMiB}).
@@ -56,7 +56,7 @@ show_help() ->
 	io:format("     lower than specified to ensure balanced threads.~n"),
 	io:format("dir: directories to pack data to. If left off, benchmark will just simulate~n"),
 	io:format("     entropy generation without writing to disk.~n~n"),
-	erlang:halt().
+	init:stop(1).
 
 run_benchmark({Format, Dirs, Threads, DataMiB}) ->
 	application:set_env(arweave, config, #config{ 

--- a/apps/arweave/src/ar_bench_hash.erl
+++ b/apps/arweave/src/ar_bench_hash.erl
@@ -40,7 +40,7 @@ show_help() ->
 	io:format("  jit <0|1> (default: 1)~n"),
 	io:format("  large_pages <0|1> (default: 1)~n"),
 	io:format("  hw_aes <0|1> (default: 1)~n"),
-	erlang:halt().
+	init:stop(1).
 
 run_benchmark(RandomXState) ->
 	run_benchmark(RandomXState, ar_mine_randomx:jit(),

--- a/apps/arweave/src/ar_bench_packing.erl
+++ b/apps/arweave/src/ar_bench_packing.erl
@@ -59,7 +59,7 @@ show_help() ->
 	io:format("  pdiff <number> (default: 1)~n"),
 	io:format("  rounds <number> (default: 10)~n"),
 	lists:foreach(fun(Test) -> io:format("  ~p~n", [Test]) end, maps:keys(?VALID_TESTS)),
-	erlang:halt().
+	init:stop(1).
 
 run_benchmark(Test, JIT, LargePages, HardwareAES, PackingDifficulty, Rounds) ->
 	timer:sleep(3000),

--- a/apps/arweave/src/ar_data_doctor.erl
+++ b/apps/arweave/src/ar_data_doctor.erl
@@ -11,7 +11,7 @@ main() ->
 	main([]).
 main([]) ->
 	help(),
-	erlang:halt(1);
+	init:stop(1);
 main(Args) ->
     logger:set_handler_config(default, level, error),
     Command = hd(Args),
@@ -29,10 +29,10 @@ main(Args) ->
     end,
     case Success of
         true ->
-            erlang:halt(0);
+            init:stop(0);
         _ ->
             help(),
-            erlang:halt(1)
+            init:stop(1)
     end. 
 
 help() ->

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -857,7 +857,7 @@ handle_cast({join, RecentBI}, State) ->
 					"in the most recent blocks. If you have just started a new weave using "
 					"the init option, restart from the local state "
 					"or specify some peers.~n~n"),
-			erlang:halt();
+			init:stop(1);
 		{_, {_H, Offset, _TXRoot}} ->
 			PreviousWeaveSize = element(2, hd(CurrentBI)),
 			{ok, OrphanedDataRoots} = remove_orphaned_data(State, Offset, PreviousWeaveSize),
@@ -896,7 +896,7 @@ handle_cast({cut, Start}, #sync_data_state{ store_id = StoreID,
 							"`enable remove_orphaned_storage_module_data`.~n",
 							[StoreID, Start]),
 					timer:sleep(2000),
-					erlang:halt();
+					init:stop(1);
 				true ->
 					ok = delete_chunk_metadata_range(Start, End, State),
 					ok = ar_chunk_storage:cut(Start, StoreID),

--- a/apps/arweave/src/ar_header_sync.erl
+++ b/apps/arweave/src/ar_header_sync.erl
@@ -108,7 +108,7 @@ handle_cast({join, Height, RecentBI, Blocks}, State) ->
 						"new one in the most recent blocks. If you have just started a new "
 						"weave using the init option, restart from the local state "
 						"or specify some peers.~n~n"),
-					erlang:halt();
+					init:stop(1);
 			{_, {IntersectionHeight, _}} ->
 				S = State2#state{
 						sync_record = ar_intervals:cut(SyncRecord, IntersectionHeight),

--- a/apps/arweave/src/ar_join.erl
+++ b/apps/arweave/src/ar_join.erl
@@ -60,7 +60,7 @@ start2([]) ->
 	ar:console("~nTrusted peers are not available.~n", []),
 	?LOG_WARNING([{event, not_joining}, {reason, trusted_peers_not_available}]),
 	timer:sleep(1000),
-	erlang:halt();
+	init:stop(1);
 start2(Peers) ->
 	ar:console("Joining the Arweave network...~n"),
 	[{H, _, _} | _] = BI = get_block_index(Peers, ?REJOIN_RETRIES),
@@ -78,7 +78,7 @@ start2(Peers) ->
 			file:write_file(File, term_to_binary({B, Peers, BI})),
 			ar:console("Inconsistent head block and block index. Error dump: ~s.", [File]),
 			timer:sleep(2000),
-			erlang:halt()
+			init:stop(1)
 	end.
 
 get_block_index(Peers, Retries) ->
@@ -100,7 +100,7 @@ get_block_index(Peers, Retries) ->
 					),
 					?LOG_ERROR([{event, failed_to_fetch_block_index}]),
 					timer:sleep(1000),
-					erlang:halt()
+					init:stop(1)
 			end;
 		BI ->
 			BI
@@ -189,7 +189,7 @@ get_block(Peers, H, Retries) ->
 						{block, ar_util:encode(H)}
 					]),
 					timer:sleep(1000),
-					erlang:halt()
+					init:stop(1)
 			end
 	end.
 
@@ -222,7 +222,7 @@ get_block(Peers, BShadow, [TXID | TXIDs], TXs, Retries) ->
 						{block, ar_util:encode(TXID)}
 					]),
 					timer:sleep(1000),
-					erlang:halt()
+					init:stop(1)
 			end
 	end.
 
@@ -320,7 +320,7 @@ get_block_trail_loop(WorkerQ, PeerQ, Retries, Trail, FetchState) ->
 								"consider trying some other trusted peers.", []),
 							?LOG_ERROR([{event, failed_to_join}]),
 							timer:sleep(1000),
-							erlang:halt();
+							init:stop(1);
 						_ ->
 							case queue:member(Peer, PeerQ) of
 								false ->
@@ -395,7 +395,7 @@ get_block_trail_loop(WorkerQ, PeerQ, Retries, Trail, FetchState) ->
 								"consider trying some other trusted peers.", []),
 							?LOG_ERROR([{event, failed_to_join}]),
 							timer:sleep(1000),
-							erlang:halt();
+							init:stop(1);
 						_ ->
 							case queue:member(Peer, PeerQ) of
 								false ->
@@ -462,7 +462,7 @@ maybe_set_reward_history(Blocks, Peers) ->
 					[ar_util:encode((hd(Blocks))#block.indep_hash)]),
 			?LOG_WARNING([{event, failed_to_fetch_reward_history}]),
 			timer:sleep(1000),
-			erlang:halt()
+			init:stop(1)
 	end.
 
 maybe_set_block_time_history([#block{ height = Height } | _] = Blocks, Peers) ->
@@ -477,7 +477,7 @@ maybe_set_block_time_history([#block{ height = Height } | _] = Blocks, Peers) ->
 							"any of the peers. Consider changing the peers.~n",
 							[ar_util:encode((hd(Blocks))#block.indep_hash)]),
 					timer:sleep(1000),
-					erlang:halt()
+					init:stop(1)
 			end;
 		false ->
 			Blocks

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -903,7 +903,7 @@ apply_chain(#nonce_limiter_info{ global_step_number = StepNumber },
 			" to apply quickly; step number: ~B, previous step number: ~B.",
 			[StepNumber, PrevStepNumber]),
 	timer:sleep(1000),
-	erlang:halt();
+	init:stop(1);
 %% @doc Apply the pre-validated / trusted nonce_limiter_info. Since the info is trusted
 %% we don't validate it here.
 apply_chain(Info, PrevInfo) ->

--- a/apps/arweave/src/ar_util.erl
+++ b/apps/arweave/src/ar_util.erl
@@ -532,6 +532,6 @@ assert_file_exists_and_readable(FilePath) ->
 			ok;
 		{error, _} ->
 			io:format("~nThe filepath ~p doesn't exist or isn't readable.~n~n", [FilePath]),
-			erlang:halt(1)
+			init:stop(1)
 	end.
 

--- a/apps/arweave/src/ar_wallets.erl
+++ b/apps/arweave/src/ar_wallets.erl
@@ -177,7 +177,7 @@ handle_cast({init, Blocks, [{from_state, SearchDepth}]}, _) ->
 			ar:console("~n~n\tThe local state is missing an account tree, consider joining "
 					"the network via the trusted peers.~n"),
 			timer:sleep(1000),
-			erlang:halt();
+			init:stop(1);
 		{Skipped, Tree} ->
 			Blocks2 = lists:nthtail(Skipped, Blocks),
 			initialize_state(Blocks2, Tree)


### PR DESCRIPTION
erlang:halt/0 or erlang:halt/1 should not be used, or only if something really bad happens. usually,
when an erlang application must be stopped, even
more when it's a release, init:halt/0 or init:halt/1 should be used instead. init:halt functions will
take care to close everything before the shutdown. Using erlang:halt functions are doing the opposite, and generate a core dump, without cleaning anything, it could also explain why many time the peers are in bad state after a shutdown.

If only a few part of the trusted peers have a bad clock, it should not be a problem. The previous
method was to stop arweave when one peers had
some trouble, if more than 10 nodes are configured (for example peers.arweave.xyz), then it should not be a problem.

see: https://github.com/ArweaveTeam/arweave-dev/issues/907