### PR TITLE
Improve service state

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -1298,6 +1298,10 @@ shutdown([NodeName]) ->
 	rpc:cast(NodeName, init, stop, []).
 
 prep_stop(State) ->
+	% the service will be stopped, ar_shutdown_manager
+	% must be noticed and its state modified.
+	_ = ar_shutdown_manager:shutdown(),
+
 	% When arweave is stopped, the first step is to stop
 	% accepting connections from other peers, and then
 	% start the shutdown procedure.

--- a/apps/arweave/src/ar_block_pre_validator.erl
+++ b/apps/arweave/src/ar_block_pre_validator.erl
@@ -199,7 +199,8 @@ handle_info(Info, State) ->
 	?LOG_ERROR([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_chain_stats.erl
+++ b/apps/arweave/src/ar_chain_stats.erl
@@ -65,7 +65,8 @@ handle_cast(_Msg, State) ->
 handle_info(_Info, State) ->
 	{noreply, State}.
 
-terminate(_Reason, _state) ->
+terminate(Reason, _state) ->
+	?LOG_INFO([{module, ?MODULE}, {pid, self()}, {callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -487,8 +487,9 @@ handle_info(Info, State) ->
 	?LOG_ERROR([{event, unhandled_info}, {info, io_lib:format("~p", [Info])}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
 	sync_and_close_files(),
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_coordination.erl
+++ b/apps/arweave/src/ar_coordination.erl
@@ -361,7 +361,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_data_discovery.erl
+++ b/apps/arweave/src/ar_data_discovery.erl
@@ -82,7 +82,8 @@ init([]) ->
 		?DATA_DISCOVERY_COLLECT_PEERS_FREQUENCY_MS,
 		?MODULE,
 		collect_peers,
-		[]
+		[],
+		#{ skip_on_shutdown => false }
 	),
 	gen_server:cast(?MODULE, update_network_data_map),
 	ok = ar_events:subscribe(peer),
@@ -179,7 +180,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -731,7 +731,8 @@ init({?DEFAULT_MODULE = StoreID, _}) ->
 		?RECORD_DISK_POOL_CHUNKS_COUNT_FREQUENCY_MS,
 		ar_data_sync,
 		record_disk_pool_chunks_count,
-		[]
+		[],
+		#{ skip_on_shutdown => false }
 	),
 
 	StateMap = read_data_sync_state(),
@@ -770,7 +771,8 @@ init({?DEFAULT_MODULE = StoreID, _}) ->
 		?REMOVE_EXPIRED_DATA_ROOTS_FREQUENCY_MS,
 		?MODULE,
 		remove_expired_disk_pool_data_roots,
-		[]
+		[],
+		#{ skip_on_shutdown => false }
 	),
 	lists:foreach(
 		fun(_DiskPoolJobNumber) ->
@@ -798,7 +800,8 @@ init({?DEFAULT_MODULE = StoreID, _}) ->
 		200,
 		?MODULE,
 		record_chunk_cache_size_metric,
-		[]
+		[],
+		#{ skip_on_shutdown => false }
 	),
 	gen_server:cast(self(), process_store_chunk_queue),
 	{ok, State2};
@@ -1541,9 +1544,9 @@ handle_info(Message,  #sync_data_state{ store_id = StoreID } = State) ->
 	{noreply, State}.
 
 terminate(Reason, #sync_data_state{ store_id = StoreID } = State) ->
+	store_sync_state(State),
 	?LOG_INFO([{event, terminate}, {store_id, StoreID},
 			{reason, io_lib:format("~p", [Reason])}]),
-	store_sync_state(State),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_device_lock.erl
+++ b/apps/arweave/src/ar_device_lock.erl
@@ -5,7 +5,7 @@
 -export([get_store_id_to_device_map/0, is_ready/0, acquire_lock/3, release_lock/2,
 	set_device_lock_metric/3]).
 
--export([start_link/0, init/1, handle_call/3, handle_info/2, handle_cast/2]).
+-export([start_link/0, init/1, handle_call/3, handle_info/2, handle_cast/2, terminate/2]).
 
 -include("../include/ar.hrl").
 -include("../include/ar_config.hrl").
@@ -152,6 +152,10 @@ handle_cast(Request, State) ->
 handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
+
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
+	ok.
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_disk_cache.erl
+++ b/apps/arweave/src/ar_disk_cache.erl
@@ -262,7 +262,8 @@ handle_info(Message, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%--------------------------------------------------------------------

--- a/apps/arweave/src/ar_events.erl
+++ b/apps/arweave/src/ar_events.erl
@@ -176,7 +176,8 @@ handle_info(Info, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%--------------------------------------------------------------------

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -37,7 +37,9 @@ execute(Req, #{ handler := ar_http_iface_handler }) ->
 	end),
 	{ok, TimeoutRef} = ar_timer:send_after(
 		?HANDLER_TIMEOUT,
-		{timeout, HandlerPid, Req}
+		self(),
+		{timeout, HandlerPid, Req},
+		#{ skip_on_shutdown => false }
 	),
 	loop(TimeoutRef);
 execute(Req, Env) ->

--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -7,7 +7,7 @@
 
 -export([start_link/0]).
 -export([init/1]).
--export([handle_call/3, handle_cast/2, handle_info/2]).
+-export([handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -export([split_path/1, label_http_path/1, label_req/1]).
 
 -include_lib("arweave/include/ar.hrl").
@@ -79,6 +79,10 @@ handle_info(Msg = {'EXIT', _From, Reason}, _State) ->
 handle_info(Msg, State) ->
 	?LOG_WARNING([{process, ?MODULE}, {received, Msg}]),
 	{noreply, State}.
+
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
+	ok.
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_ignore_registry.erl
+++ b/apps/arweave/src/ar_ignore_registry.erl
@@ -27,7 +27,13 @@ add_ref(ID, Ref) ->
 
 add_ref(ID, Ref, Timeout) ->
 	ets:insert(ignored_ids, {ID, {ref, Ref}}),
-	{ok, _} = ar_timer:apply_after(Timeout, ar_ignore_registry, remove_ref, [ID, Ref]).
+	{ok, _} = ar_timer:apply_after(
+		Timeout,
+		ar_ignore_registry,
+		remove_ref,
+		[ID, Ref],
+		#{ skip_on_shutdown => false }
+	).
 
 %% @doc Remove a referenced ID record from the registry.
 remove_ref(ID, Ref) ->
@@ -38,7 +44,13 @@ remove_ref(ID, Ref) ->
 add_temporary(ID, Timeout) ->
 	Ref = make_ref(),
 	ets:insert(ignored_ids, {ID, {temporary, Ref}}),
-	{ok, _} = ar_timer:apply_after(Timeout, ar_ignore_registry, remove_temporary, [ID, Ref]).
+	{ok, _} = ar_timer:apply_after(
+		Timeout,
+		ar_ignore_registry,
+		remove_temporary,
+		[ID, Ref],
+		#{ skip_on_shutdown => false }
+	).
 
 %% @doc Remove the temporary record from the registry.
 remove_temporary(ID, Ref) ->

--- a/apps/arweave/src/ar_kv.erl
+++ b/apps/arweave/src/ar_kv.erl
@@ -355,17 +355,14 @@ handle_info(Message, State) ->
 
 
 terminate(Reason, _State) ->
-	?LOG_INFO([{event, terminate}, {module, ?MODULE}, {reason, Reason}]),
 	Result = with_each_db(fun(DbRec) ->
 		?LOG_INFO([{event, terminate_db}, {module, ?MODULE}, {db, DbRec#db.name}]),
 		_ = db_flush(DbRec),
 		_ = wal_sync(DbRec),
 		_ = close(DbRec)
 	end),
-	?LOG_INFO([{event, terminate_complete}, {module, ?MODULE}]),
+	?LOG_INFO([{event, terminate_complete}, {module, ?MODULE}, {reason, Reason}]),
 	Result.
-
-
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_mining_hash.erl
+++ b/apps/arweave/src/ar_mining_hash.erl
@@ -105,7 +105,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -199,7 +199,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -333,7 +333,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -283,7 +283,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -278,7 +278,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -746,8 +746,9 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, #state{ worker = W }) ->
+terminate(Reason, #state{ worker = W }) ->
 	W ! stop,
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_nonce_limiter_client.erl
+++ b/apps/arweave/src/ar_nonce_limiter_client.erl
@@ -196,7 +196,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_nonce_limiter_server.erl
+++ b/apps/arweave/src/ar_nonce_limiter_server.erl
@@ -110,7 +110,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_nonce_limiter_server_worker.erl
+++ b/apps/arweave/src/ar_nonce_limiter_server_worker.erl
@@ -83,7 +83,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_p3.erl
+++ b/apps/arweave/src/ar_p3.erl
@@ -101,6 +101,7 @@ handle_info({event, node_state, _}, State) ->
 	{noreply, State}.
 
 terminate(Reason, State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_p3_db.erl
+++ b/apps/arweave/src/ar_p3_db.erl
@@ -140,7 +140,8 @@ handle_cast(stop, State) ->
 handle_info(_Message, State) ->
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_packing_server.erl
+++ b/apps/arweave/src/ar_packing_server.erl
@@ -303,7 +303,13 @@ init([]) ->
 		end,
 	ar:console("~nSetting the packing chunk cache size limit to ~B chunks.~n", [MaxSize]),
 	ets:insert(?MODULE, {buffer_size_limit, MaxSize}),
-	{ok, _} = ar_timer:apply_interval(200, ?MODULE, record_buffer_size_metric, []),
+	{ok, _} = ar_timer:apply_interval(
+		200,
+		?MODULE,
+		record_buffer_size_metric,
+		[],
+		#{ skip_on_shutdown => false }
+	),
 	{ok, #state{
 		workers = Workers, num_workers = NumWorkers }}.
 
@@ -372,7 +378,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_peers.erl
+++ b/apps/arweave/src/ar_peers.erl
@@ -385,11 +385,12 @@ init([]) ->
 			load_peers(),
 			gen_server:cast(?MODULE, rank_peers),
 			gen_server:cast(?MODULE, ping_peers),
-			{ok, _} = ar_timer:apply_interval(
+			_ = ar_timer:apply_interval(
 				?GET_MORE_PEERS_FREQUENCY_MS,
 				?MODULE,
 				discover_peers,
-				[]
+				[],
+				#{ skip_on_shutdown => true }
 			);
 		_ ->
 			ok
@@ -472,8 +473,9 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
-	store_peers().
+terminate(Reason, _State) ->
+	store_peers(),
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]).
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_poller.erl
+++ b/apps/arweave/src/ar_poller.erl
@@ -167,7 +167,8 @@ handle_info(Info, State) ->
 	?LOG_ERROR([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_poller_worker.erl
+++ b/apps/arweave/src/ar_poller_worker.erl
@@ -164,7 +164,8 @@ handle_info(Info, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_pool.erl
+++ b/apps/arweave/src/ar_pool.erl
@@ -267,7 +267,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_pool_cm_job_poller.erl
+++ b/apps/arweave/src/ar_pool_cm_job_poller.erl
@@ -64,7 +64,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([ {module, ?MODULE}, {pid, self()}, {callback, terminate}, {reason, Reason} ]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_pool_job_poller.erl
+++ b/apps/arweave/src/ar_pool_job_poller.erl
@@ -72,7 +72,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([ {module, ?MODULE}, {pid, self()}, {callback, terminate}, {reason, Reason} ]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_process_sampler.erl
+++ b/apps/arweave/src/ar_process_sampler.erl
@@ -20,7 +20,12 @@ start_link() ->
 
 %% gen_server callbacks
 init([]) ->
-	{ok, _} = ar_timer:send_interval(?SAMPLE_PROCESSES_INTERVAL, sample_processes),
+	{ok, _} = ar_timer:send_interval(
+		?SAMPLE_PROCESSES_INTERVAL,
+		self(),
+		sample_processes,
+		#{ skip_on_shutdown => false }
+	),
 	ar_util:cast_after(?SAMPLE_SCHEDULERS_INTERVAL, ?MODULE, sample_schedulers),
 	{ok, #state{}}.
 
@@ -90,7 +95,8 @@ handle_info(sample_processes, State) ->
 handle_info(_Info, State) ->
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %% Internal functions

--- a/apps/arweave/src/ar_rate_limiter.erl
+++ b/apps/arweave/src/ar_rate_limiter.erl
@@ -118,7 +118,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_repack.erl
+++ b/apps/arweave/src/ar_repack.erl
@@ -360,6 +360,7 @@ handle_info(Request, #state{} = State) ->
 terminate(Reason, #state{} = State) ->
 	log_debug(terminate, State, [{reason, ar_util:safe_format(Reason)}]),
 	store_cursor(State),
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_semaphore.erl
+++ b/apps/arweave/src/ar_semaphore.erl
@@ -2,7 +2,8 @@
 -behaviour(gen_server).
 
 -export([start_link/2, acquire/2, stop/1]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+-include_lib("kernel/include/logger.hrl").
 
 %%%===================================================================
 %%% Public interface.
@@ -68,6 +69,10 @@ handle_info({'DOWN', _,  process, Pid, _}, {Capacity, WaitingPids, Queue}) ->
 		error ->
 			{noreply, {Capacity, WaitingPids, Queue}}
 	end.
+
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
+	ok.
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -1078,8 +1078,8 @@ handle_info(Message, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {message, Message}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
-	ok.
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]).
 
 %%%===================================================================
 %%% Private functions.

--- a/apps/arweave/src/ar_sup.erl
+++ b/apps/arweave/src/ar_sup.erl
@@ -30,6 +30,7 @@ start_link() ->
 
 init([]) ->
 	%% These ETS tables should belong to the supervisor.
+	ets:new(ar_shutdown_manager, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_timer, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_peers, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_http, [set, public, named_table]),

--- a/apps/arweave/src/ar_sync_record.erl
+++ b/apps/arweave/src/ar_sync_record.erl
@@ -116,7 +116,7 @@ add_async(Event, End, Start, ID, StoreID) ->
 add_async(Event, End, Start, Packing, ID, StoreID) ->
 	GenServerID = name(StoreID),
 	gen_server:cast(GenServerID, {add_async, Event, End, Start, Packing, ID}).
-	
+
 %% @doc Remove the given interval from the record
 %% with the given ID. Store the changes on disk before
 %% returning ok.
@@ -372,7 +372,8 @@ handle_cast(store_state, State) ->
 		?STORE_SYNC_RECORD_FREQUENCY_MS,
 		gen_server,
 		cast,
-		[self(), store_state]
+		[self(), store_state],
+		#{ skip_on_shutdown => false }
 	),
 	{noreply, State2};
 
@@ -594,7 +595,7 @@ replay_write_ahead_log(SyncRecordByID, SyncRecordByIDType, N, WAL, StateDB, Stor
 					emit_add_range(Start, End, ID, Module),
 					SyncRecordByID2 = maps:put(ID, SyncRecord2, SyncRecordByID),
 					replay_write_ahead_log(
-						SyncRecordByID2, SyncRecordByIDType, N + 1, 
+						SyncRecordByID2, SyncRecordByIDType, N + 1,
 						WAL, StateDB, StoreID, Module);
 				{add, Packing} ->
 					{End, Start, ID} = Params,

--- a/apps/arweave/src/ar_timer.erl
+++ b/apps/arweave/src/ar_timer.erl
@@ -10,33 +10,123 @@
 %%% Arweave. Those timers must be managed, in particular during
 %%% shutdown, when no new connections or other actions are required.
 %%%
+%%% Not all timers need to use this module, only the ones needing
+%%% to use a timer to connect to remote peers.
+%%%
 %%% Only intervals are currently managed, other functions are simple
 %%% wrappers.
+%%%
+%%% This module is tightly coupled with `ar_shutdown_manager' and
+%%% uses `ar_shutdown_manager:apply/4' to know if the application is
+%%% in running mode or if the application is being stopped.
+%%%
+%%% @see ar_shutdown_manager
+%%% @see ar_shutdown_manager:apply/4
+%%%
+%%% == Examples ==
+%%%
+%%% When the application is running normally, this module behave
+%%% exactly like the functions exported by timers:
+%%%
+%%% ```
+%%% {ok, Ref1} =
+%%%   ar_timer:apply_after(
+%%%   	10_000,
+%%%   	io,
+%%%   	format,
+%%%   	["hello"],
+%%%   	#{}
+%%% ).
+%%% '''
+%%%
+%%% If the application is stopped, for example when executing the
+%%% `./bin/stop' script or `erlang:halt/1' or `init:stop/1' functions,
+%%% then those functions will return `shutdown'. This is the default
+%%% behavior when no specific options is passed in the last argument.
+%%%
+%%% ```
+%%% shutdown =
+%%%   ar_timer:apply_after(
+%%%     10_000,
+%%%     io,
+%%%     format,
+%%%     ["hello"],
+%%%     #{}
+%%% ).
+%%% '''
+%%%
+%%% This behavior can be disabled by setting the key `skip_on_shutdown'
+%%% to false when needed. In this case, these functions will simply
+%%% act as wrappers around `timers' module functions.
+%%%
+%%% ```
+%%% {ok, Ref1} =
+%%%   ar_timer:apply_after(
+%%%     10_000,
+%%%     io,
+%%%     format,
+%%%     ["hello"],
+%%%     #{ skip_on_shutdown => false }
+%%%   ).
+%%% '''
 %%%
 %%% @end
 %%%===================================================================
 -module(ar_timer).
 -export([
 	apply_after/4,
+	apply_after/5,
 	apply_interval/4,
+	apply_interval/5,
 	cancel/1,
 	insert_timer/2,
 	list_timers/0,
 	terminate_timers/0,
 	send_after/2,
 	send_after/3,
+	send_after/4,
 	send_interval/2,
-	send_interval/3
+	send_interval/3,
+	send_interval/4
 ]).
 -include_lib("kernel/include/logger.hrl").
+-type ar_timer_opts() :: #{ skip_on_shutdown => boolean() }.
 
 %%--------------------------------------------------------------------
 %% @doc wrapper around timer:apply_after/4.
+%% @see timer:apply_after/5
+%% @end
+%%--------------------------------------------------------------------
+-spec apply_after(Time, Module, Function, Arguments) -> Return when
+	Time :: pos_integer(),
+	Module :: atom(),
+	Function :: atom(),
+	Arguments :: [term()],
+	Return :: shutdown | {ok, reference()}.
+
+apply_after(Time, Module, Function, Arguments) ->
+	apply_after(Time, Module, Function, Arguments, #{}).
+
+%%--------------------------------------------------------------------
+%% @doc wrapper around timer:apply_after/4.
+%%
 %% @see timer:apply_after/4
 %% @end
 %%--------------------------------------------------------------------
-apply_after(Time, Module, Function, Arguments) ->
-	case timer:apply_after(Time, Module, Function, Arguments) of
+-spec apply_after(Time, Module, Function, Arguments, Opts) -> Return when
+	Time :: pos_integer(),
+	Module :: atom(),
+	Function :: atom(),
+	Arguments :: [term()],
+	Opts :: ar_timer_opts(),
+	Return :: shutdown
+		| {ok, reference()}.
+
+apply_after(Time, Module, Function, Arguments, Opts) ->
+	M = timer,
+	F = apply_after,
+	A = [Time, Module, Function, Arguments],
+	case ar_shutdown_manager:apply(M, F, A, Opts) of
 		{ok, TimerRef} -> {ok, TimerRef};
 		Elsewise -> Elsewise
 	end.
@@ -46,8 +136,35 @@ apply_after(Time, Module, Function, Arguments) ->
 %% @see timer:apply_interval/4
 %% @end
 %%--------------------------------------------------------------------
+-spec apply_interval(Time, Module, Function, Arguments) -> Return when
+	Time :: pos_integer(),
+	Module :: atom(),
+	Function :: atom(),
+	Arguments :: [term()],
+	Return :: shutdown
+		| {ok, reference()}.
+
 apply_interval(Time, Module, Function, Arguments) ->
-	case timer:apply_interval(Time, Module, Function, Arguments) of
+	apply_interval(Time, Module, Function, Arguments, #{}).
+
+%%--------------------------------------------------------------------
+%% @doc wrapper around timer:apply_interval/4
+%% @end
+%%--------------------------------------------------------------------
+-spec apply_interval(Time, Module, Function, Arguments, Opts) -> Return when
+	Time :: pos_integer(),
+	Module :: atom(),
+	Function :: atom(),
+	Arguments :: [term()],
+	Opts :: ar_timer_opts(),
+	Return :: shutdown
+		| {ok, reference()}.
+
+apply_interval(Time, Module, Function, Arguments, Opts) ->
+	M = timer,
+	F = apply_interval,
+	A = [Time, Module, Function, Arguments],
+	case ar_shutdown_manager:apply(M, F, A, Opts) of
 		{ok, TimerRef} ->
 			insert_timer(TimerRef, #{
 				pid => self(),
@@ -66,16 +183,45 @@ apply_interval(Time, Module, Function, Arguments) ->
 %% @see send_after/3
 %% @end
 %%--------------------------------------------------------------------
+-spec send_after(Time, Message) -> Return when
+	Time :: pos_integer(),
+	Message :: term(),
+	Return :: shutdown | {ok, reference()}.
+
 send_after(Time, Message) ->
 	send_after(Time, self(), Message).
+
+%%--------------------------------------------------------------------
+%% @doc wrapper around timer:send_after/3.
+%% @see send_after/4
+%% @end
+%%--------------------------------------------------------------------
+-spec send_after(Time, Pid, Message) -> Return when
+	Time :: pos_integer(),
+	Pid :: pid() | atom(),
+	Message :: term(),
+	Return :: shutdown | {ok, reference()}.
+
+send_after(Time, Pid, Message) ->
+	send_after(Time, Pid, Message, #{}).
 
 %%--------------------------------------------------------------------
 %% @doc wrapper around timer:send_after/3.
 %% @see timer:send_after/3
 %% @end
 %%--------------------------------------------------------------------
-send_after(Time, Pid, Message) ->
-	case timer:send_after(Time, Pid, Message) of
+-spec send_after(Time, Pid, Message, Opts) -> Return when
+	Time :: pos_integer(),
+	Pid :: pid() | atom(),
+	Message :: term(),
+	Opts :: ar_timer_opts(),
+	Return :: shutdown | {ok, reference()}.
+
+send_after(Time, Pid, Message, Opts) ->
+	M = timer,
+	F = send_after,
+	A = [Time, Pid, Message],
+	case ar_shutdown_manager:apply(M, F, A, Opts) of
 		{ok, TimerRef} -> {ok, TimerRef};
 		Elsewise -> Elsewise
 	end.
@@ -85,16 +231,45 @@ send_after(Time, Pid, Message) ->
 %% @see send_interval/3
 %% @end
 %%--------------------------------------------------------------------
+-spec send_interval(Time, Message) -> Return when
+	Time :: pos_integer(),
+	Message :: term(),
+	Return :: shutdown | {ok, reference()}.
+
 send_interval(Time, Message) ->
 	send_interval(Time, self(), Message).
+
+%%--------------------------------------------------------------------
+%% @doc wrapper around timer:interval/3.
+%% @see send_interval/4
+%% @end
+%%--------------------------------------------------------------------
+-spec send_interval(Time, Pid, Message) -> Return when
+	Time :: pos_integer(),
+	Pid :: atom() | pid(),
+	Message :: term(),
+	Return :: shutdown | {ok, reference()}.
+
+send_interval(Time, Pid, Message) ->
+	send_interval(Time, Pid, Message, #{}).
 
 %%--------------------------------------------------------------------
 %% @doc wrapper around timer:interval/3.
 %% @see timer:send_interval/3
 %% @end
 %%--------------------------------------------------------------------
-send_interval(Time, Pid, Message) ->
-	case timer:send_interval(Time, Pid, Message) of
+-spec send_interval(Time, Pid, Message, Opts) -> Return when
+	Time :: pos_integer(),
+	Pid :: atom() | pid(),
+	Message :: term(),
+	Opts :: ar_timer_opts(),
+	Return :: shutdown | {ok, reference()}.
+
+send_interval(Time, Pid, Message, Opts) ->
+	M = timer,
+	F = send_interval,
+	A = [Time, Pid, Message],
+	case ar_shutdown_manager:apply(M, F, A, Opts) of
 		{ok, TimerRef} ->
 			insert_timer(TimerRef, #{
 				pid => self(),

--- a/apps/arweave/src/ar_tx_db.erl
+++ b/apps/arweave/src/ar_tx_db.erl
@@ -13,7 +13,13 @@
 %% write-once values.
 put_error_codes(TXID, ErrorCodes) ->
 	ets:insert(?MODULE, {TXID, ErrorCodes}),
-	{ok, _} = ar_timer:apply_after(1800*1000, ?MODULE, clear_error_codes, [TXID]),
+	{ok, _} = ar_timer:apply_after(
+		1800*1000,
+		?MODULE,
+		clear_error_codes,
+		[TXID],
+		#{ skip_on_shutdown => false }
+	),
 	ok.
 
 %% @doc Retreive a term from the meta db.

--- a/apps/arweave/src/ar_tx_emitter.erl
+++ b/apps/arweave/src/ar_tx_emitter.erl
@@ -139,7 +139,8 @@ handle_info(Info, State) ->
 	?LOG_ERROR([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%%===================================================================

--- a/apps/arweave/src/ar_tx_poller.erl
+++ b/apps/arweave/src/ar_tx_poller.erl
@@ -105,7 +105,7 @@ handle_info(Info, State) ->
 	{noreply, State}.
 
 terminate(Reason, _State) ->
-	?LOG_WARNING("Unexpected terminate: ~p", [Reason]),
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%% Internal functions.

--- a/apps/arweave/src/ar_verify_chunks.erl
+++ b/apps/arweave/src/ar_verify_chunks.erl
@@ -111,7 +111,8 @@ handle_info(Info, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 is_ready(EndOffset) ->

--- a/apps/arweave/src/ar_verify_chunks_reporter.erl
+++ b/apps/arweave/src/ar_verify_chunks_reporter.erl
@@ -73,7 +73,8 @@ handle_info(Info, State) ->
 	?LOG_WARNING([{event, unhandled_info}, {module, ?MODULE}, {info, Info}]),
 	{noreply, State}.
 
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 print_verify_reports(Reports) when map_size(Reports) == 0 ->

--- a/apps/arweave/src/ar_watchdog.erl
+++ b/apps/arweave/src/ar_watchdog.erl
@@ -200,5 +200,6 @@ handle_info(Info, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.

--- a/apps/arweave/src/ar_webhook.erl
+++ b/apps/arweave/src/ar_webhook.erl
@@ -276,7 +276,8 @@ handle_info(Info, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
-terminate(_Reason, _State) ->
+terminate(Reason, _State) ->
+	?LOG_INFO([{module, ?MODULE},{pid, self()},{callback, terminate},{reason, Reason}]),
 	ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
ar_shutdown_manager can now set the state of the system as running
or shutdown. When the system is in shutdown state, part of the
application should not be used, for example, no new connections
from the peer can be created, and no new timer interval can be
created.

ar_timer module should be used only on modules
trying to fetch data from remote peers. Indeed, some side
effects don't have an impact on the blocking during shutdown,
it seems the connections from the node to another peers are
blocking due to the shutdown.

ar_timer functions have been improved as well to support
extra-options, and define if the timer should be executed
or not during shutdown time with the flag skip_on_shutdown.

Improved logging when a process is shutting down. useful
to see where the application is blocking.

see: https://github.com/ArweaveTeam/arweave-dev/issues/915