### PR TITLE
fix: when data_sync_record gets throttled, recover gracefully

### DIFF
--- a/apps/arweave/src/ar_data_discovery.erl
+++ b/apps/arweave/src/ar_data_discovery.erl
@@ -55,16 +55,10 @@ get_bucket_peers(Bucket) ->
 
 get_bucket_peers(Bucket, Cursor, Peers) ->
 	case ets:next(?MODULE, Cursor) of
-		'$end_of_table' ->
-			UniquePeers = sets:to_list(sets:from_list(Peers)),
-			PickedPeers = pick_peers(UniquePeers, ?QUERY_BEST_PEERS_COUNT),
-			PickedPeers;
 		{Bucket, _Share, Peer} = Key ->
 			get_bucket_peers(Bucket, Key, [Peer | Peers]);
-		_ ->
-			UniquePeers = sets:to_list(sets:from_list(Peers)),
-			PickedPeers = pick_peers(UniquePeers, ?QUERY_BEST_PEERS_COUNT),
-			PickedPeers
+		_ -> % matches `end_of_table` or an unexpected value
+			ar_util:unique(Peers)
 	end.
 
 %% @doc Return a list of peers where 80% of the peers are randomly chosen

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -1084,7 +1084,9 @@ handle_cast({collect_peer_intervals, Start, End}, State) ->
 					%% All checks have passed, find and enqueue intervals for one
 					%% sync bucket worth of chunks starting at offset Start
 					?LOG_DEBUG([{event, fetch_peer_intervals},
-							{function, collect_peer_intervals}, {s, Start}, {e, End2}]),
+							{function, collect_peer_intervals},
+							{store_id, StoreID},
+							{s, Start}, {e, End2}]),
 					ar_peer_intervals:fetch(Start, End2, StoreID)
 			end
 	end,

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -837,6 +837,9 @@ handle_get_jobs_response(Reply) ->
 
 handle_sync_record_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
 	ar_intervals:safe_from_etf(Body);
+handle_sync_record_response({ok, {{<<"429">>, _}, _, _, _, _}} = Reply) ->
+	?LOG_DEBUG([{event, too_many_requests}, {endpoint, data_sync_record}, {reply, Reply}]),
+	{error, too_many_requests};
 handle_sync_record_response(Reply) ->
 	{error, Reply}.
 
@@ -862,6 +865,8 @@ handle_sync_record_response({ok, {{<<"200">>, _}, _, Body, _, _}}, Start, Limit)
 		Error ->
 			Error
 	end;
+handle_sync_record_response({ok, {{<<"429">>, _}, _, _, _, _}}, _, _) ->
+	{error, too_many_requests};
 handle_sync_record_response(Reply, _, _) ->
 	{error, Reply}.
 

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -838,7 +838,6 @@ handle_get_jobs_response(Reply) ->
 handle_sync_record_response({ok, {{<<"200">>, _}, _, Body, _, _}}) ->
 	ar_intervals:safe_from_etf(Body);
 handle_sync_record_response({ok, {{<<"429">>, _}, _, _, _, _}} = Reply) ->
-	?LOG_DEBUG([{event, too_many_requests}, {endpoint, data_sync_record}, {reply, Reply}]),
 	{error, too_many_requests};
 handle_sync_record_response(Reply) ->
 	{error, Reply}.

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -1023,7 +1023,8 @@ may_be_empty_poa(#poa{} = PoA) ->
 fetch_poa_from_peers(_RecallByte, PackingDifficulty) when PackingDifficulty >= 1 ->
 	not_found;
 fetch_poa_from_peers(RecallByte, _PackingDifficulty) ->
-	Peers = ar_data_discovery:get_bucket_peers(RecallByte div ?NETWORK_DATA_BUCKET_SIZE),
+	BucketPeers = ar_data_discovery:get_bucket_peers(RecallByte div ?NETWORK_DATA_BUCKET_SIZE),
+	Peers = ar_data_discovery:pick_peers(BucketPeers, ?QUERY_BEST_PEERS_COUNT),
 	From = self(),
 	lists:foreach(
 		fun(Peer) ->

--- a/apps/arweave/src/ar_sup.erl
+++ b/apps/arweave/src/ar_sup.erl
@@ -34,6 +34,7 @@ init([]) ->
 	ets:new(ar_timer, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_peers, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_http, [set, public, named_table]),
+	ets:new(ar_rate_limiter, [set, public, named_table, {read_concurrency, true}]),
 	ets:new(ar_blacklist_middleware, [set, public, named_table]),
 	ets:new(blacklist, [set, public, named_table]),
 	ets:new(ignored_ids, [bag, public, named_table]),

--- a/apps/arweave/src/ar_util.erl
+++ b/apps/arweave/src/ar_util.erl
@@ -304,7 +304,7 @@ batch_pmap(Mapper, List, BatchSize, Timeout)
 			receive
 				{pmap_work, Ref, Mapped} -> Mapped
 			after Timeout ->
-				{error, timeout, Elem}
+				{error, batch_pmap_timeout, Elem}
 			end
 		end,
 		ListWithRefs


### PR DESCRIPTION
This PR does a few things:
- adds some extra headers when we have a 429. Headers aren't used yet, but I figure we can make use of them later if we want
- fixes a sort issue in `ar_data_discover:get_bucket_peers` - previously we did a conversion to set that would lose the sorting of the peer list. And since the list was sorted based on peers with the most advertised data, it's possible the jumbled list would have had nodes focusing too much effort on low-data peers.
- exposes `ar_rate_limiter:is_throttled` so a node can check if it is currently throttling itself when querying a given peer
introduces `ar_rate_limiter:set_cooldown` this is used when we get a 429 from a peer (i.e. could be a situation where the peer's rate limit is lower than our own, or perhaps we're just hitting it with too many concurrent requests). The cooldown period isn't enforced, but nodes can query it if they want
- filters the list of peers that we query data_sync_records from to skip those that are throttled or in cooldown
removes the exception from batch_pmap and instead flags the given job as having timed out

The sum total of these changes allows the node to be more selective about which peers it queries sync records from, and to recover more gracefully when one peer times out.

With these changes the node seems to query sync records far more regularly and with greater throughput than before - and the average request time is a couple seconds instead of ~1 minute (this is because we back off of peers that are being throttled)