### PR TITLE
Bump the release number for the future release

### DIFF
--- a/apps/arweave/include/ar.hrl
+++ b/apps/arweave/include/ar.hrl
@@ -33,7 +33,7 @@
 -define(CLIENT_VERSION, 5).
 
 %% The current build number -- incremented for every release.
--define(RELEASE_NUMBER, 85).
+-define(RELEASE_NUMBER, 86).
 
 -define(DEFAULT_REQUEST_HEADERS,
 	[


### PR DESCRIPTION
Bumping the release number early allows test nodes to distinguish updated nodes from not updated notes and helps us avoid the bug where the code relies on the outdated release number (e.g., when querying freshly introduced endpoints)