### PR TITLE
Prepare release pipeline (first step)

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,7 +125,7 @@ jobs:
 
   e2e-tests:
     needs: build
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/gitstamp.yaml
+++ b/.github/workflows/gitstamp.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   gitstamp:
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     name: Timestamp commit with Gitstamp
     steps:
       - name: Clone repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, build-runner]
     steps:
       # we don't have a clean environment on MacOS (no vm, no containers)
       # we need to clean everything up before executing the workflow
@@ -65,7 +65,7 @@ jobs:
 
   canary:
     needs: build
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, build-runner]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -88,7 +88,7 @@ jobs:
 
   tests:
     needs: canary
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: [self-hosted, macOS, ARM64, build-runner]
     strategy:
       max-parallel: 3
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -124,7 +124,7 @@ jobs:
   ####################################################################
   canary:
     needs: build
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -162,7 +162,7 @@ jobs:
   ####################################################################
   eunit-tests-long-running:
     needs: canary
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     strategy:
       max-parallel: 4
       matrix:
@@ -227,7 +227,7 @@ jobs:
   ####################################################################
   eunit-tests-modules:
     needs: canary
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     strategy:
       max-parallel: 4
       matrix:
@@ -324,7 +324,7 @@ jobs:
   ####################################################################
   eunit-tests-suite:
     needs: canary
-    runs-on: [self-hosted, ubuntu, amd64]
+    runs-on: [self-hosted, ubuntu, amd64, build-runner]
     strategy:
       max-parallel: 4
       matrix:


### PR DESCRIPTION
To avoid breaking the pipelines, a small update is required to only use build-runners and not the one dedicated for the releases.