### PR TITLE
Fix base64 encoding/decoding exception

### DIFF
--- a/apps/arweave/test/ar_base64_compatibility_tests.erl
+++ b/apps/arweave/test/ar_base64_compatibility_tests.erl
@@ -124,6 +124,8 @@ assert_encode(Input) ->
 			?assertException(error, badarg, ar_util:encode(Input));
 		{'EXIT', {badarith, _}} ->
 			?assertException(error, badarg, ar_util:encode(Input));
+		{'EXIT', {missing_padding, _}} ->
+			?assertException(error, badarg, ar_util:encode(Input));
 		Output ->
 			?assertEqual(Output, ar_util:encode(Input))
 	end.
@@ -135,6 +137,8 @@ assert_decode(Input) ->
 		{'EXIT', {function_clause, _}} ->
 			?assertException(error, badarg, ar_util:decode(Input));
 		{'EXIT', {badarith, _}} ->
+			?assertException(error, badarg, ar_util:decode(Input));
+		{'EXIT', {missing_padding, _}} ->
 			?assertException(error, badarg, ar_util:decode(Input));
 		Output ->
 			?assertEqual(Output, ar_util:decode(Input))


### PR DESCRIPTION
base64 encoding/decoding functions present in
Erlang/OTP have been upgraded 2 years ago to
add a new exception: missing_padding. This
exception was not catched by the test suite.