### PR TITLE
Change log error to log warning in ar_shutdown module

### DIFF
--- a/apps/arweave/src/ar_shutdown_manager.erl
+++ b/apps/arweave/src/ar_shutdown_manager.erl
@@ -105,7 +105,7 @@ apply(Module, Function, Arguments, Opts) ->
 		running ->
 			erlang:apply(Module, Function, Arguments);
 		shutdown ->
-			?LOG_ERROR([
+			?LOG_WARNING([
 				{state, shutdown},
 				{module, Module},
 				{function, Function},


### PR DESCRIPTION
Most of errors from ar_shutdown should be in warning, those are not "critical" because they are only
executed during shutdown.