### PR TITLE
Fix build runners naming

### DIFF
--- a/.github/workflows/x-build.yml
+++ b/.github/workflows/x-build.yml
@@ -28,7 +28,7 @@ jobs:
   build-template:
     runs-on:
       - self-hosted
-      - builder-runner
+      - build-runner
       - ${{ inputs.os_arch }}
       - ${{ inputs.os_name }}
       - ${{ inputs.os_release }}

--- a/.github/workflows/x-test-canary.yml
+++ b/.github/workflows/x-test-canary.yml
@@ -30,7 +30,7 @@ jobs:
   canary:
     runs-on:
       - self-hosted
-      - builder-runner
+      - build-runner
       - ${{ inputs.os_arch }}
       - ${{ inputs.os_name }}
       - ${{ inputs.os_release }}

--- a/.github/workflows/x-test-full.yml
+++ b/.github/workflows/x-test-full.yml
@@ -30,7 +30,7 @@ jobs:
   eunit-tests-suite:
     runs-on:
       - self-hosted
-      - builder-runner
+      - build-runner
       - ${{ inputs.os_arch }}
       - ${{ inputs.os_name }}
       - ${{ inputs.os_release }}

--- a/.github/workflows/x-test-vdf.yml
+++ b/.github/workflows/x-test-vdf.yml
@@ -27,7 +27,7 @@ jobs:
   eunit-tests-suite:
     runs-on:
       - self-hosted
-      - builder-runner
+      - build-runner
       - ${{ inputs.os_arch }}
       - ${{ inputs.os_name }}
       - ${{ inputs.os_release }}


### PR DESCRIPTION
This commit fix a typo on the runners used to
build and test arweave.