### PR TITLE
Fix absolute symlink issues on standalone runners

### DIFF
--- a/.github/workflows/x-build.yml
+++ b/.github/workflows/x-build.yml
@@ -136,12 +136,17 @@ jobs:
         run: ./ar-rebar3 test release
 
       # some artifacts are compiled and only available
-      # in arweave directory (libraries)
+      # in arweave directory (libraries).
       - name: Prepare artifacts
         run: |
           chmod -R u+w ./_build
-          tar czfp _build.tar.gz ./_build ./bin/arweave
-          tar czfp apps.tar.gz ./apps
+
+          # rebar is using a lot of absolute symlink,
+          # this can generate issue on standalone worker
+          # to avoid this problem, links must be
+          # deferenced with -h flag.
+          tar czfhp _build.tar.gz ./_build ./bin/arweave
+          tar czfhp apps.tar.gz ./apps
 
       # to avoid reusing artifacts from someone else
       # and generating issues, an unique artifact is


### PR DESCRIPTION
When building arweave with rebar3, rebar3 generates many absolute symlink. If the build has been done
on user-A, the link will point to user-A working
directory. Now, if a new job is started with the
same artifact, but on user-B, then, the symlinks
will still point to user-A working directory. In
this situation, user-B does not have access to the content of the directory, and then, it fails.

To avoid this issue, we can create a shared
directory for the artifacts (bad ideas),
dereferences all links one by one after an
extract (quite complex) or simply dereferences
the links while doing the tarball (easiest way).

The latest solution has been used.