### PR TITLE
New release should always be a prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ on:
         required: false
         default: true
         type: boolean
+      prerelease:
+        required: false
+        default: true
+        type: boolean
+      draft:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # prepare ubuntu 22.04 release (jammy) on amd64 arch
@@ -176,3 +184,5 @@ jobs:
             _releases/SHA256
             LICENSE.md
           make_latest: ${{ inputs.make_latest || true }}
+          prerelease: ${{ inputs.prerelease || true }}
+          draft: ${{ inputs.draft || false }}


### PR DESCRIPTION
This commit modifies the state of a new
release, it should not be a draft but should
be set as pre-release.

see: https://github.com/ArweaveTeam/arweave-dev/issues/935