### PR TITLE
Use workflows from current branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   # prepare ubuntu 22.04 release (jammy) on amd64 arch
   ubuntu-jammy-release:
-    uses: ArweaveTeam/arweave/.github/workflows/x-release-linux.yml@master
+    uses: ./.github/workflows/x-release-linux.yml
     secrets: inherit
     with:
       os_arch: amd64
@@ -35,7 +35,7 @@ jobs:
 
   # prepare ubuntu 24.04 release (noble) on amd64 arch
   ubuntu-noble-release:
-    uses: ArweaveTeam/arweave/.github/workflows/x-release-linux.yml@master
+    uses: ./.github/workflows/x-release-linux.yml
     secrets: inherit
     with:
       os_arch: amd64
@@ -45,7 +45,7 @@ jobs:
 
   # prepare rocky 9 release on amd64 arch
   rockylinux-9-release:
-    uses: ArweaveTeam/arweave/.github/workflows/x-release-linux.yml@master
+    uses: ./.github/workflows/x-release-linux.yml
     secrets: inherit
     with:
       os_arch: x86_64
@@ -55,7 +55,7 @@ jobs:
 
   # prepare macos release on arm64 arch
   macos-release:
-    uses: ArweaveTeam/arweave/.github/workflows/x-release-macos.yml@master
+    uses: ./.github/workflows/x-release-macos.yml
     secrets: inherit
     with:
       tag: ${{ github.ref_name || inputs.tag }}

--- a/.github/workflows/test-amd64-ubuntu-22.04.yml
+++ b/.github/workflows/test-amd64-ubuntu-22.04.yml
@@ -11,15 +11,15 @@ on:
 
 jobs:
   build:
-    uses: ArweaveTeam/arweave/.github/workflows/x-build.yml@master
+    uses: ./.github/workflows/x-build.yml
     secrets: inherit
 
   test-canary:
     needs: [build]
-    uses: ArweaveTeam/arweave/.github/workflows/x-test-canary.yml@master
+    uses: ./.github/workflows/x-test-canary.yml
     secrets: inherit
 
   test:
     needs: [test-canary]
-    uses: ArweaveTeam/arweave/.github/workflows/x-test-full.yml@master
+    uses: ./.github/workflows/x-test-full.yml
     secrets: inherit

--- a/.github/workflows/test-arm64-macos-15.yml
+++ b/.github/workflows/test-arm64-macos-15.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    uses: ArweaveTeam/arweave/.github/workflows/x-build.yml@master
+    uses: ./.github/workflows/x-build.yml
     secrets: inherit
     with:
       os_arch: arm64
@@ -20,7 +20,7 @@ jobs:
 
   test-canary:
     needs: [build]
-    uses: ArweaveTeam/arweave/.github/workflows/x-test-canary.yml@master
+    uses: ./.github/workflows/x-test-canary.yml
     secrets: inherit
     with:
       os_arch: arm64
@@ -29,7 +29,7 @@ jobs:
 
   test:
     needs: [test-canary]
-    uses: ArweaveTeam/arweave/.github/workflows/x-test-vdf.yml@master
+    uses: ./.github/workflows/x-test-vdf.yml
     secrets: inherit
     with:
       os_arch: arm64


### PR DESCRIPTION
Instead of using a specific repository/branch for each workflows, we should use the current branch in case someone is modifying it.

see: https://github.com/ArweaveTeam/arweave-dev/issues/945