### PR TITLE
fix: cm fixes

### DIFF
--- a/.github/workflows/x-test-full.yml
+++ b/.github/workflows/x-test-full.yml
@@ -122,6 +122,7 @@ jobs:
             ar_packing_tests,
             ar_poa,
             ar_vdf_server_tests,
+            ar_vdf_external_update_tests,
             ar_post_block_tests,
             ar_reject_chunks_tests
           ]

--- a/.github/workflows/x-test-vdf.yml
+++ b/.github/workflows/x-test-vdf.yml
@@ -101,6 +101,7 @@ jobs:
             ar_vdf_tests,
             # long running
             ar_vdf_server_tests,
+            ar_vdf_external_update_tests,
           ]
     steps:
       - name: cleanup

--- a/apps/arweave/include/ar_config.hrl
+++ b/apps/arweave/include/ar_config.hrl
@@ -279,6 +279,8 @@
 	rocksdb_wal_sync_interval_s = ?DEFAULT_ROCKSDB_WAL_SYNC_INTERVAL_S,
 	%% openssl (will be removed), fused, hiopt_m4
 	vdf = openssl,
+	%% Turn on/off the rebasing check. Only disabled in tests.
+	allow_rebase = true,
 
 	% Shutdown procedures
 	shutdown_tcp_connection_timeout = ?SHUTDOWN_TCP_CONNECTION_TIMEOUT,

--- a/apps/arweave/include/ar_mining_cache.hrl
+++ b/apps/arweave/include/ar_mining_cache.hrl
@@ -19,6 +19,7 @@
 
 
 -record(ar_mining_cache, {
+  name = not_set :: term(),
   mining_cache_sessions = #{} :: #{term() => #ar_mining_cache_session{}},
   mining_cache_sessions_queue = queue:new() :: queue:queue(),
   mining_cache_limit_bytes = 0 :: non_neg_integer()

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -19,6 +19,7 @@ validate_config(Config) ->
 	validate_storage_modules(Config) andalso
 	validate_repack_in_place(Config) andalso
 	validate_cm_pool(Config) andalso
+	validate_cm(Config) andalso
 	validate_unique_replication_type(Config) andalso
 	validate_verify(Config).
 
@@ -1212,6 +1213,17 @@ validate_cm_pool(Config) ->
 			true
 	end,
 	A andalso B andalso C.
+
+validate_cm(#config{ coordinated_mining = false }) ->
+	true;
+validate_cm(#config{ cm_api_secret = not_set }) ->
+	io:format("~nThe cm_api_secret must be set when coordinated_mining is set.~n~n"),
+	false;
+validate_cm(#config{ mine = false }) ->
+	io:format("~nThe mine flag must be set when coordinated_mining is set.~n~n"),
+	false;
+validate_cm(_Config) ->
+	true.
 
 validate_unique_replication_type(#config{ mine = false }) ->
 	true;

--- a/apps/arweave/src/ar_data_discovery.erl
+++ b/apps/arweave/src/ar_data_discovery.erl
@@ -110,6 +110,11 @@ handle_cast(update_network_data_map, #state{ peers_pending = N } = State)
 									SyncBuckets});
 						{error, request_type_not_found} ->
 							get_sync_buckets(Peer);
+						{error, Reason} ->
+							ar_http_iface_client:log_failed_request(Reason,
+								[{event, failed_to_fetch_sync_buckets},
+								{peer, ar_util:format_peer(Peer)},
+								{reason, io_lib:format("~p", [Reason])}]);
 						Error ->
 							?LOG_DEBUG([{event, failed_to_fetch_sync_buckets},
 								{peer, ar_util:format_peer(Peer)},

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -132,7 +132,8 @@ add_chunk_to_disk_pool(DataRoot, DataPath, Chunk, Offset, TXSize) ->
 		case {DataRootOffsetReply, DataRootInDiskPool} of
 			{not_found, []} ->
 				?LOG_WARNING([{event, failed_to_add_chunk_to_disk_pool},
-					{reason, data_root_not_found}, {offset, Offset}]),
+					{reason, data_root_not_found}, {offset, Offset},
+					{data_root, ar_util:encode(DataRoot)}]),
 				{error, data_root_not_found};
 			{not_found, [{_, {Size, Timestamp, TXIDSet}}]} ->
 				case Size + ChunkSize > DataRootLimit

--- a/apps/arweave/src/ar_data_sync_worker.erl
+++ b/apps/arweave/src/ar_data_sync_worker.erl
@@ -291,10 +291,10 @@ sync_range({Start, End, Peer, TargetStoreID, RetryCount} = Args, State) ->
 						{error, {ok, {{<<"404">>, _}, _, _, _, _}} = Reason} ->
 							{error, Reason};
 						{error, Reason} ->
-							?LOG_DEBUG([{event, failed_to_fetch_chunk},
-									{peer, ar_util:format_peer(Peer)},
-									{start_offset, Start2}, {end_offset, End},
-									{reason, io_lib:format("~p", [Reason])}]),
+							ar_http_iface_client:log_failed_request({error, Reason}, [{event, failed_to_fetch_chunk},
+								{peer, ar_util:format_peer(Peer)},
+								{start_offset, Start2}, {end_offset, End},
+								{reason, io_lib:format("~p", [Reason])}]),
 							{error, Reason}
 					end
 			end

--- a/apps/arweave/src/ar_entropy_storage.erl
+++ b/apps/arweave/src/ar_entropy_storage.erl
@@ -398,7 +398,7 @@ release_semaphore(Filepath) ->
 %%%===================================================================
 
 replica_2_9_test_() ->
-	{timeout, 20, fun test_replica_2_9/0}.
+	{timeout, 60, fun test_replica_2_9/0}.
 
 test_replica_2_9() ->
 	case ar_block:strict_data_split_threshold() of

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -1444,5 +1444,9 @@ log_failed_request(Reason, Log) ->
 	case Reason of
 		{error,{shutdown,econnrefused}} -> ok;
 		{error,{shutdown,timeout}} -> ok;
+		{error,timeout} -> ok;
+		{error,{shutdown,ehostunreach}} -> ok;
+		{error,{stream_error,closed}} -> ok;
+		{error,{stream_error,closing}} -> ok;
 		_ -> ?LOG_DEBUG(Log)
 	end.

--- a/apps/arweave/src/ar_mining_cache.erl
+++ b/apps/arweave/src/ar_mining_cache.erl
@@ -342,9 +342,7 @@ maybe_search_for_anomalies(SessionKey, #ar_mining_cache_session{
 			{event, mining_cache_anomaly}, {anomaly, reserved_size_non_zero},
 			{session_key, ar_nonce_limiter:encode_session_key(SessionKey)},
 			{actual_size, ReservedMiningCacheBytes}, {expected_size, 0}])
-	end,
-	?LOG_DEBUG([{event, mining_cache_anomaly}, {anomaly, mining_cache_anomaly_search_completed},
-		{session_key, ar_nonce_limiter:encode_session_key(SessionKey)}]);
+	end;
 maybe_search_for_anomalies(SessionKey, _InvalidSession) ->
 	?LOG_ERROR([{event, mining_cache_anomaly}, {anomaly, invalid_session_type},
 		{session_key, ar_nonce_limiter:encode_session_key(SessionKey)}]),

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -99,6 +99,7 @@ garbage_collect() ->
 %%%===================================================================
 
 init(Mode) ->
+	?LOG_INFO([{event, mining_io_init}, {mode, Mode}]),
 	gen_server:cast(self(), initialize_state),
 	{ok, #state{ mode = Mode }}.
 
@@ -213,10 +214,11 @@ start_io_threads(State) ->
     % Step 1: Group StoreIDs by their system device
 	case ar_device_lock:get_store_id_to_device_map() of
 		{error, Reason} ->
-			?LOG_ERROR([{event, error_initializing_state}, {module, ?MODULE},
+			?LOG_ERROR([{event, error_initializing_mining_io_state}, {module, ?MODULE},
 				{reason, io_lib:format("~p", [Reason])}]),
 			{error, Reason};
 		StoreIDToDevice ->
+			?LOG_INFO([{event, starting_mining_io_threads}, {store_id_to_device, StoreIDToDevice}]),
 			DeviceToStoreIDs = ar_util:invert_map(StoreIDToDevice),
 			% Step 2: Start IO threads for each device and populate map indices
 			State2 = maps:fold(

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -314,6 +314,10 @@ handle_info({event, nonce_limiter, {computed_output, Args}}, State) ->
 				SessionKey, StepNumber, Output, PartitionUpperBound, not_set, State)
 	end;
 
+handle_info({event, nonce_limiter, {valid, _}}, State) ->
+	%% Silently ignore validation messages
+	{noreply, State};
+
 handle_info({event, nonce_limiter, Message}, State) ->
 	?LOG_DEBUG([{event, mining_debug_skipping_nonce_limiter}, {message, Message}]),
 	{noreply, State};

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -583,10 +583,15 @@ generate_peer_report(Peer, Report) ->
 
 report_performance() ->
 	Report = generate_report(),
-	set_metrics(Report),
-	ReportString = format_report(Report),
-	ar:console("~s", [ReportString]),
-	log_report(ReportString).
+	case Report#report.partitions of
+		[] ->
+			ok;
+		_ ->
+			set_metrics(Report),
+			ReportString = format_report(Report),
+			ar:console("~s", [ReportString]),
+			log_report(ReportString)
+	end.
 
 log_report(ReportString) ->
 	Lines = string:tokens(lists:flatten(ReportString), "\n"),

--- a/apps/arweave/src/ar_mining_sup.erl
+++ b/apps/arweave/src/ar_mining_sup.erl
@@ -32,10 +32,9 @@ init([]) ->
 		end,
 		ar_mining_io:get_partitions(infinity)
 	),
-	Children = MiningWorkers ++ [
-		?CHILD(ar_mining_server, worker),
+	Children = [
+		?CHILD(ar_mining_stats, worker),
 		?CHILD(ar_mining_hash, worker),
-		?CHILD(ar_mining_io, worker),
-		?CHILD(ar_mining_stats, worker)
-	],
+		?CHILD(ar_mining_io, worker)
+	] ++ MiningWorkers ++ [?CHILD(ar_mining_server, worker)],
 	{ok, {{one_for_one, 5, 10}, Children}}.

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -135,7 +135,7 @@ garbage_collect(Worker) ->
 
 init({Partition, PackingDifficulty}) ->
 	Name = name(Partition, PackingDifficulty),
-	?LOG_DEBUG([{event, mining_debug_worker_started},
+	?LOG_INFO([{event, mining_worker_started},
 		{worker, Name}, {pid, self()}, {partition, Partition}]),
 	ChunkCache = ar_mining_cache:new(),
 	State0 = #state{

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -137,7 +137,7 @@ init({Partition, PackingDifficulty}) ->
 	Name = name(Partition, PackingDifficulty),
 	?LOG_INFO([{event, mining_worker_started},
 		{worker, Name}, {pid, self()}, {partition, Partition}]),
-	ChunkCache = ar_mining_cache:new(),
+	ChunkCache = ar_mining_cache:new(Name),
 	State0 = #state{
 		name = Name,
 		chunk_cache = ChunkCache,
@@ -489,8 +489,6 @@ handle_task({compute_h2_for_peer, Candidate, _ExtraArgs}, State) ->
 	case Range2Exists of
 		true ->
 			ar_mining_stats:h1_received_from_peer(Peer, length(H1List)),
-			log_debug(mining_debug_h1_received_from_peer, Candidate3, State, [
-				{h1_list_length, length(H1List)}]),
 
 			%% Add the candidate session to the cache. This is only needed during rare occasions
 			%% where a CM peer has added a new session a few seconds before this node does.

--- a/apps/arweave/src/ar_node.erl
+++ b/apps/arweave/src/ar_node.erl
@@ -63,14 +63,22 @@ get_block_index() ->
 %% @doc Return the current tip block. Assume the node has joined the network and
 %% initialized the state.
 get_current_block() ->
-	[{_, Current}] = ar_util:safe_ets_lookup(node_state, current),
-	ar_block_cache:get(block_cache, Current).
+	case ar_util:safe_ets_lookup(node_state, current) of
+		[{_, Current}] ->
+			ar_block_cache:get(block_cache, Current);
+		_ ->
+			not_joined
+	end.
 
 %% @doc Return the current network difficulty. Assume the node has joined the network and
 %% initialized the state.
 get_current_diff() ->
-	[{_, DiffPair}] = ar_util:safe_ets_lookup(node_state, diff_pair),
-	DiffPair.
+	case ar_util:safe_ets_lookup(node_state, diff_pair) of
+		[{_, DiffPair}] ->
+			DiffPair;
+		_ ->
+			not_joined
+	end.
 
 get_block_index_and_height() ->
 	Props =

--- a/apps/arweave/src/ar_node_utils.erl
+++ b/apps/arweave/src/ar_node_utils.erl
@@ -773,7 +773,7 @@ test_block_validation() ->
 			PartitionUpperBound2)).
 
 update_accounts_rejects_same_signature_in_double_signing_proof_test_() ->
-	{timeout, 10, fun test_update_accounts_rejects_same_signature_in_double_signing_proof/0}.
+	{timeout, 30, fun test_update_accounts_rejects_same_signature_in_double_signing_proof/0}.
 
 test_update_accounts_rejects_same_signature_in_double_signing_proof() ->
 	Accounts = #{},
@@ -796,7 +796,7 @@ test_update_accounts_rejects_same_signature_in_double_signing_proof() ->
 			update_accounts(B, PrevB, Accounts)).
 
 update_accounts_receives_released_reward_and_prover_reward_test_() ->
-	{timeout, 10, fun test_update_accounts_receives_released_reward_and_prover_reward/0}.
+	{timeout, 30, fun test_update_accounts_receives_released_reward_and_prover_reward/0}.
 
 % this function will prepend reward_history up to ?REWARD_HISTORY_BLOCKS
 % elements will keep pattern of changed values
@@ -844,7 +844,7 @@ test_update_accounts_receives_released_reward_and_prover_reward() ->
 	?assertEqual({1, <<>>, 1, false}, maps:get(BannedAddr, Accounts2)).
 
 update_accounts_does_not_let_banned_account_take_reward_test_() ->
-	{timeout, 10, fun test_update_accounts_does_not_let_banned_account_take_reward/0}.
+	{timeout, 30, fun test_update_accounts_does_not_let_banned_account_take_reward/0}.
 
 test_update_accounts_does_not_let_banned_account_take_reward() ->
 	?assert(?DOUBLE_SIGNING_REWARD_SAMPLE_SIZE == 2),

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -1459,7 +1459,7 @@ get_entropy_reset_point_test() ->
 	?assertEqual(ResetFreq * 4, get_entropy_reset_point(ResetFreq * 3, ResetFreq * 4 + 1)).
 
 reorg_after_join_test_() ->
-	{timeout, 120, fun test_reorg_after_join/0}.
+	{timeout, ?TEST_NODE_TIMEOUT, fun test_reorg_after_join/0}.
 
 test_reorg_after_join() ->
 	[B0] = ar_weave:init(),
@@ -1477,7 +1477,7 @@ test_reorg_after_join() ->
 	ar_test_node:wait_until_height(main, 2).
 
 reorg_after_join2_test_() ->
-	{timeout, 120, fun test_reorg_after_join2/0}.
+	{timeout, ?TEST_NODE_TIMEOUT, fun test_reorg_after_join2/0}.
 
 test_reorg_after_join2() ->
 	[B0] = ar_weave:init(),

--- a/apps/arweave/src/ar_nonce_limiter_server_worker.erl
+++ b/apps/arweave/src/ar_nonce_limiter_server_worker.erl
@@ -115,8 +115,7 @@ push_update(SessionKey, StepNumber, Output, Peer, Format, State) ->
 		not_found -> State;
 		_ ->
 			case ar_http_iface_client:push_nonce_limiter_update(Peer, Update, Format) of
-				ok ->
-					State;
+				ok -> State;
 				{ok, Response} ->
 					RequestedFormat = Response#nonce_limiter_update_response.format,
 					Postpone = Response#nonce_limiter_update_response.postpone,

--- a/apps/arweave/src/ar_peer_intervals.erl
+++ b/apps/arweave/src/ar_peer_intervals.erl
@@ -125,7 +125,7 @@ fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals) ->
 						%% Skipping peer because we hit a 429 and put it on cooldown.
 						ok;
 					{error, Reason} ->
-						?LOG_DEBUG([{event, failed_to_fetch_peer_intervals},
+						ar_http_iface_client:log_failed_request(Reason, [{event, failed_to_fetch_peer_intervals},
 							{parent, Parent},
 							{peer, ar_util:format_peer(Peer)},
 							{reason, io_lib:format("~p", [Reason])}]),
@@ -161,7 +161,7 @@ fetch_peer_intervals(Parent, Start, Peers, UnsyncedIntervals) ->
 				(ok, Acc) ->
 					Acc;
 				(Error, Acc) ->
-					?LOG_DEBUG([{event, failed_to_fetch_peer_intervals},
+					ar_http_iface_client:log_failed_request(Error, [{event, failed_to_fetch_peer_intervals},
 						{parent, Parent},
 						{peer, unknown},
 						{reason, io_lib:format("~p", [Error])}]),

--- a/apps/arweave/src/ar_poller_worker.erl
+++ b/apps/arweave/src/ar_poller_worker.erl
@@ -123,9 +123,10 @@ handle_cast({poll, Ref}, #state{ ref = Ref, peer = Peer,
 			gen_server:cast(ar_poller, {peer_out_of_sync, Peer}),
 			{noreply, State#state{ pause = true }};
 		{error, Reason} ->
-			?LOG_DEBUG([{event, failed_to_get_recent_hash_list_diff},
-					{peer, ar_util:format_peer(Peer)},
-					{reason, io_lib:format("~p", [Reason])}]),
+			ar_http_iface_client:log_failed_request(Reason,
+				[{event, failed_to_get_recent_hash_list_diff},
+				{peer, ar_util:format_peer(Peer)},
+				{reason, io_lib:format("~p", [Reason])}]),
 			{noreply, State#state{ pause = true }}
 	end;
 handle_cast({poll, _Ref}, State) ->

--- a/apps/arweave/src/ar_tx_poller.erl
+++ b/apps/arweave/src/ar_tx_poller.erl
@@ -127,7 +127,11 @@ check_for_received_txs(#state{ pending_txids = [] } = State) ->
 	case Reply of
 		{ok, TXIDs} ->
 			State#state{ pending_txids = TXIDs };
-		{error, _Error} ->
+		{error, Error} ->
+			?LOG_DEBUG([{event, failed_to_get_mempool_txids_from_peers},
+					{peers, [ar_util:format_peer(Peer) || Peer <- Peers]},
+					{error, io_lib:format("~p", [Error])}
+			]),
 			State
 	end.
 

--- a/apps/arweave/test/ar_config_tests.erl
+++ b/apps/arweave/test/ar_config_tests.erl
@@ -11,7 +11,8 @@ validate_test_() ->
 	[
 		{timeout, 60, fun test_validate_repack_in_place/0},
 		{timeout, 60, fun test_validate_cm_pool/0},
-		{timeout, 60, fun test_validate_storage_modules/0}
+		{timeout, 60, fun test_validate_storage_modules/0},
+		{timeout, 60, fun test_validate_cm/0}
 	].
 
 test_parse_config() ->
@@ -200,16 +201,24 @@ test_validate_repack_in_place() ->
 test_validate_cm_pool() ->
 	?assertEqual(false,
 		ar_config:validate_config(
-			#config{coordinated_mining = true, is_pool_server = true})),
+			#config{
+				coordinated_mining = true, is_pool_server = true,
+				mine = true, cm_api_secret = <<"secret">>})),
 	?assertEqual(true,
 		ar_config:validate_config(
-			#config{coordinated_mining = true, is_pool_server = false})),
+			#config{
+				coordinated_mining = true, is_pool_server = false,
+				mine = true, cm_api_secret = <<"secret">>})),
 	?assertEqual(true,
 		ar_config:validate_config(
-			#config{coordinated_mining = false, is_pool_server = true})),
+			#config{
+				coordinated_mining = false, is_pool_server = true,
+				mine = true, cm_api_secret = <<"secret">>})),
 	?assertEqual(true,
 		ar_config:validate_config(
-			#config{coordinated_mining = false, is_pool_server = false})),
+			#config{
+				coordinated_mining = false, is_pool_server = false,
+				mine = true, cm_api_secret = <<"secret">>})),
 	?assertEqual(false,
 		ar_config:validate_config(
 			#config{is_pool_server = true, is_pool_client = true, mine = true})),
@@ -235,6 +244,21 @@ test_validate_cm_pool() ->
 		ar_config:validate_config(
 			#config{is_pool_client = false, mine = false})).
 
+test_validate_cm() ->
+	?assertEqual(true,
+		ar_config:validate_config(
+			#config{coordinated_mining = true, mine = true, cm_api_secret = <<"secret">>})),
+	?assertEqual(true,
+		ar_config:validate_config(
+			#config{coordinated_mining = false, mine = false, cm_api_secret = not_set})),
+	?assertEqual(false,
+		ar_config:validate_config(
+			#config{coordinated_mining = true, mine = false, cm_api_secret = <<"secret">>})),
+	?assertEqual(false,
+		ar_config:validate_config(
+			#config{coordinated_mining = true, mine = true, cm_api_secret = not_set})).
+
+		
 test_validate_storage_modules() ->
 	Addr1 = crypto:strong_rand_bytes(32),
 	Addr2 = crypto:strong_rand_bytes(32),

--- a/apps/arweave/test/ar_http_iface_tests.erl
+++ b/apps/arweave/test/ar_http_iface_tests.erl
@@ -743,6 +743,16 @@ test_get_tx_status(_) ->
 	?assertMatch({ok, {{<<"202">>, _}, _, <<"Pending">>, _, _}}, FetchStatus()),
 	ar_test_node:mine(),
 	wait_until_height(main, Height + 1),
+	ar_util:do_until(
+		fun() ->
+			case FetchStatus() of
+				{ok, {{<<"200">>, _}, _, _, _, _}} -> true;
+				_ -> false
+			end	
+		end,
+		200,
+		5000
+	),
 	{ok, {{<<"200">>, _}, _, Body, _, _}} = FetchStatus(),
 	{Res} = ar_serialize:dejsonify(Body),
 	BI = ar_node:get_block_index(),

--- a/apps/arweave/test/ar_info_tests.erl
+++ b/apps/arweave/test/ar_info_tests.erl
@@ -229,13 +229,14 @@ test_recent_forks() ->
 	ar_test_node:wait_until_height(peer2, 6),
 
 	%% Reconnect the peers. This will orphan peer1's block
-	ar_test_node:connect_to_peer(peer1),
 	ar_test_node:connect_to_peer(peer2),
-	ar_test_node:connect_peers(peer1, peer2),
-
-	ar_test_node:wait_until_height(peer1, 6),
-	ar_test_node:wait_until_height(peer2, 6),
 	ar_test_node:wait_until_height(main, 6),
+
+	ar_test_node:connect_to_peer(peer1),
+	ar_test_node:wait_until_height(peer1, 6),
+
+	ar_test_node:connect_peers(peer1, peer2),
+	ar_test_node:wait_until_height(peer2, 6),
 
 	%% Disconnect peers, and have peer1 mine 2 block2, and peer2 mine 3
 	ar_test_node:disconnect_from(peer1),
@@ -261,13 +262,15 @@ test_recent_forks() ->
 	ar_test_node:wait_until_height(peer2, 9),
 
 	%% Reconnect the peers. This will create a second fork as peer1's blocks are orphaned
-	ar_test_node:connect_to_peer(peer1),
 	ar_test_node:connect_to_peer(peer2),
-	ar_test_node:connect_peers(peer1, peer2),
-
-	ar_test_node:wait_until_height(peer1, 9),
-	ar_test_node:wait_until_height(peer2, 9),
 	ar_test_node:wait_until_height(main, 9),
+
+	ar_test_node:connect_to_peer(peer1),
+	ar_test_node:wait_until_height(peer1, 9),
+
+	ar_test_node:connect_peers(peer1, peer2),
+	ar_test_node:wait_until_height(peer2, 9),
+
 
 	ar_test_node:disconnect_from(peer1),
 	ar_test_node:disconnect_from(peer2),

--- a/apps/arweave/test/ar_start_from_block_tests.erl
+++ b/apps/arweave/test/ar_start_from_block_tests.erl
@@ -6,7 +6,7 @@
 
 start_from_block_test_() ->
     [
-		{timeout, 240, fun test_start_from_block/0}
+		{timeout, ?TEST_NODE_TIMEOUT, fun test_start_from_block/0}
 	].
 
 test_start_from_block() ->

--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -240,7 +240,8 @@ update_config(Config) ->
 		local_peers = Config#config.local_peers,
 		mine = Config#config.mine,
 		storage_modules = Config#config.storage_modules,
-		repack_in_place_storage_modules = Config#config.repack_in_place_storage_modules
+		repack_in_place_storage_modules = Config#config.repack_in_place_storage_modules,
+		allow_rebase = Config#config.allow_rebase
 	},
 	ok = application:set_env(arweave, config, Config2),
 	?LOG_INFO("Updated Config:"),
@@ -333,7 +334,9 @@ base_cm_config(Peers) ->
 		coordinated_mining = true,
 		cm_api_secret = <<"test_coordinated_mining_secret">>,
 		cm_poll_interval = 2000,
-		disable_replica_2_9_device_limit = true
+		disable_replica_2_9_device_limit = true,
+		%% Disable rebasing by default to make the tests more reliable.
+		allow_rebase = false
 	}.
 
 mine() ->
@@ -621,6 +624,8 @@ start(B0, RewardAddr, Config, StorageModules) ->
 		header_sync_jobs = 2,
 		enable = [search_in_rocksdb_when_mining, serve_tx_data_without_limits,
 				double_check_nonce_limiter, serve_wallet_lists | Config#config.enable],
+		%% Disable rebasing by default to make the tests more reliable.
+		allow_rebase = false,
 		debug = true
 	}),
 	ar:start_dependencies(),

--- a/apps/arweave/test/ar_vdf_external_update_tests.erl
+++ b/apps/arweave/test/ar_vdf_external_update_tests.erl
@@ -1,0 +1,545 @@
+-module(ar_vdf_external_update_tests).
+
+-export([init/2]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include_lib("arweave/include/ar.hrl").
+-include_lib("arweave/include/ar_config.hrl").
+-include_lib("arweave/include/ar_mining.hrl").
+
+-import(ar_test_node, [assert_wait_until_height/2, post_block/2, send_new_block/2]).
+
+%% we have to wait to let the ar_events get processed whenever we apply a VDF step
+-define(WAIT_TIME, 1000).
+
+%% -------------------------------------------------------------------------------------------------
+%% Test Fixtures
+%% -------------------------------------------------------------------------------------------------
+
+setup_external_update() ->
+	{ok, Config} = application:get_env(arweave, config),
+	[B0] = ar_weave:init(),
+	%% Start the testnode with a configured VDF server so that it doesn't compute its own VDF -
+	%% this is necessary so that we can test the behavior of apply_external_update without any
+	%% auto-computed VDF steps getting in the way.
+	_ = ar_test_node:start(
+		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
+		Config#config{ 
+			nonce_limiter_server_trusted_peers = [
+				ar_util:format_peer(vdf_server_1()),
+				ar_util:format_peer(vdf_server_2()) 
+			],
+			mine = true
+		}
+	),
+	ets:new(computed_output, [named_table, ordered_set, public]),
+	ets:new(add_task, [named_table, bag, public]),
+	Pid = spawn(
+		fun() ->
+			ok = ar_events:subscribe(nonce_limiter),
+			computed_output()
+		end
+	),
+	{Pid, Config}.
+
+cleanup_external_update({Pid, Config}) ->
+	exit(Pid, kill),
+	ok = application:set_env(arweave, config, Config),
+	ets:delete(add_task),
+	ets:delete(computed_output).
+
+%% -------------------------------------------------------------------------------------------------
+%% Test Registration
+%% -------------------------------------------------------------------------------------------------
+
+external_update_test_() ->
+    {foreach,
+		fun setup_external_update/0,
+     	fun cleanup_external_update/1,
+		[
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_session_overlap/0, 120),
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_client_ahead/0, 120),
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_skip_ahead/0, 120),
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_2_servers_switching/0, 120),
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_backtrack/0, 120),
+			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+				fun test_2_servers_backtrack/0, 120)
+		]
+    }.
+
+mining_session_test_() ->
+    {foreach,
+		fun setup_external_update/0,
+     	fun cleanup_external_update/1,
+	[
+		ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
+			fun test_mining_session/0, 120)
+	]
+    }.
+
+%% -------------------------------------------------------------------------------------------------
+%% Tests
+%% -------------------------------------------------------------------------------------------------
+
+%%
+%% external_update_test_
+%%
+
+%% @doc The VDF session key is only updated when a block is procesed by the VDF server. Until that
+%% happens the serve will push all VDF steps under the same session key - even if those steps
+%% cross an entropy reset line. When a block comes in the server will update the session key
+%% *and* move all appropriate steps to that session. Prior to 2.7 this caused VDF clients to
+%% process some steps twice - once under the old session key, and once under the new session key.
+%% This test asserts that this behavior has been fixed and that VDF clients only process each
+%% step once.
+test_session_overlap() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey1, [], 8, true, SessionKey0),
+		"Partial session1, session not found"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
+		"Full session1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 9, true, SessionKey0),
+		"Partial session1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 10, true, SessionKey0),
+		"Partial session1, interval2"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 11, true, SessionKey0),
+		"Partial session1, interval2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey2, [], 12, true, SessionKey1),
+		"Partial session2, interval2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = true, step_number = 11 },
+		apply_external_update(SessionKey1, [8, 7, 6, 5], 9, false, SessionKey1),
+		"Full session1, all steps already seen"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey2, [11, 10], 12, false, SessionKey1),
+		"Full session2, some steps already seen"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual(
+		[<<"8">>, <<"7">>, <<"6">>, <<"5">>, <<"9">>, <<"10">>, <<"11">>, <<"12">>],
+	computed_steps()),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual(
+		[10, 10, 10, 10, 10, 20, 20, 20],
+		computed_upper_bounds()).
+
+
+%% @doc This test asserts that the client responds correctly when it is ahead of the VDF server.
+test_client_ahead() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
+		"Full session"),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 8 },
+		apply_external_update(SessionKey1, [], 7, true, SessionKey0),
+		"Partial session, client ahead"),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 8 },
+		apply_external_update(SessionKey1, [6, 5], 7, false, SessionKey0),
+		"Full session, client ahead"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual(
+		[<<"8">>, <<"7">>, <<"6">>, <<"5">>],
+		computed_steps()),
+	?assertEqual(
+		[10, 10, 10, 10],
+		computed_upper_bounds()).
+
+%% @doc
+%% Test case:
+%% 1. VDF server pushes a partial update that skips too far ahead of the client
+%% 2. Simulate the updates that the server would then push (i.e. full session updates of the current
+%%    session and maybe previous session)
+%%
+%% Assert that the client responds correctly and only processes each step once (even though it may
+%% see the same step several times as part of the full session updates).
+test_skip_ahead() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [5], 6, false, SessionKey0),
+		"Full session1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = true, step_number = 6 },
+		apply_external_update(SessionKey1, [], 8, true, SessionKey0),
+		"Partial session1, server ahead"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
+		"Full session1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey2, [], 12, true, SessionKey1),
+		"Partial session2, server ahead"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [8, 7, 6, 5], 9, false, SessionKey0),
+		"Full session1, all steps already seen"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey2, [11, 10], 12, false, SessionKey1),
+		"Full session2, some steps already seen"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual(
+		[<<"6">>, <<"5">>, <<"8">>, <<"7">>, <<"9">>, <<"12">>, <<"11">>, <<"10">>],
+		computed_steps()),
+	?assertEqual(
+		[10, 10, 10, 10, 10, 20, 20, 20],
+		computed_upper_bounds()).
+
+test_2_servers_switching() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [6, 5], 7, false, SessionKey0, vdf_server_1()),
+		"Full session1 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 8, true, SessionKey0, vdf_server_2()),
+		"Partial session1 from vdf_server_2"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 9, true, SessionKey0, vdf_server_2()),
+		"Partial session1 from vdf_server_2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey2, [], 11, true, SessionKey1, vdf_server_1()),
+		"Partial session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey2, [10], 11, false, SessionKey1, vdf_server_1()),
+		"Full session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 10, true, SessionKey0, vdf_server_2()),
+		"Partial session1 from vdf_server_2 (should not change current session)"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 11, true, SessionKey0, vdf_server_2()),
+		"Partial session1 from vdf_server_2 (should not change current session)"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 12, true, SessionKey0, vdf_server_2()),
+		"Partial session1 from vdf_server_2 (should not change current session)"),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			SessionKey2, [11, 10], 12, false, SessionKey1, vdf_server_2()),
+		"Full session2 from vdf_server_2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 12 },
+		apply_external_update(SessionKey2, [], 12, true, SessionKey1, vdf_server_1()),
+		"Partial (repeat) session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey2, [], 13, true, SessionKey1, vdf_server_1()),
+		"Partial (new) session2 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey2, [], 14, true, SessionKey1, vdf_server_2()),
+		"Partial (new) session2 from vdf_server_2"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual([
+		<<"7">>, <<"6">>, <<"5">>, <<"8">>, <<"9">>,
+		<<"11">>, <<"10">>, <<"10">>, <<"11">>, <<"12">>,
+		<<"12">>, <<"13">>, <<"14">>
+	], computed_steps()),
+	?assertEqual(
+		[10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20],
+		computed_upper_bounds()).
+
+test_backtrack() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [
+			16, 15,				%% interval 3
+			14, 13, 12, 11, 10, %% interval 2
+			9, 8, 7, 6, 5		%% interval 1
+		], 17, false, SessionKey0),
+		"Full session1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 18, true, SessionKey0),
+		"Partial session1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey2, [], 15, true, SessionKey1),
+		"Partial session2"),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 18 },
+		apply_external_update(
+			SessionKey1, [8, 7, 6, 5], 9, false, SessionKey0),
+		"Backtrack. Send full session1."),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			SessionKey2, [14, 13, 12, 11, 10], 15, false, SessionKey1),
+		"Backtrack. Send full session2"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual([
+		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
+        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
+        <<"5">>,<<"18">>,<<"15">>
+	], computed_steps()),
+	?assertEqual(
+		[20, 20, 20, 20, 20, 20, 20, 20, 10, 10, 10, 10, 10, 20, 30],
+		computed_upper_bounds()).
+
+test_2_servers_backtrack() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [
+			16, 15,				%% interval 3
+			14, 13, 12, 11, 10, %% interval 2
+			9, 8, 7, 6, 5		%% interval 1
+		], 17, false, SessionKey0, vdf_server_1()),
+		"Full session1 from vdf_server_1"),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [], 18, true, SessionKey0, vdf_server_1()),
+		"Partial session1 from vdf_server_1"),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey2, [], 15, true, SessionKey1, vdf_server_2()),
+		"Partial session2 from vdf_server_2"),
+	?assertEqual(
+		ok,
+		apply_external_update(
+			SessionKey2, [14, 13, 12, 11, 10], 15, false, SessionKey1, vdf_server_2()),
+		"Backtrack in session2 from vdf_server_2"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual([
+		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
+        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
+        <<"5">>,<<"18">>,<<"15">>
+	], computed_steps()),
+	?assertEqual(SessionKey0, get_current_session_key()),
+	?assertEqual(
+		[20, 20, 20, 20, 20, 20, 20, 20, 10, 10, 10, 10, 10, 20, 30],
+		computed_upper_bounds()).
+
+test_mining_session() ->
+	SessionKey0 = get_current_session_key(),
+	SessionKey1 = {<<"session1">>, 1, 1},
+	SessionKey2 = {<<"session2">>, 2, 1},
+	SessionKey3 = {<<"session3">>, 3, 1},
+	ar_test_node:mine(),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey0, [], 2, true, undefined),
+		"Partial session0, should mine"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
+	?assertEqual([2], mined_steps()),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey0, [3], 4, false, undefined),
+		"Full session0, should mine"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
+	?assertEqual([4, 3], mined_steps()),
+	?assertEqual(
+		#nonce_limiter_update_response{ step_number = 4 },
+		apply_external_update(SessionKey0, [], 4, true, undefined),
+		"Repeat step, should not mine"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
+	?assertEqual([], mined_steps()),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey1, [], 6, true, SessionKey0),
+		"Partial session1, should not mine"),
+	timer:sleep(?WAIT_TIME),
+	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
+	?assertEqual([], mined_steps()),
+	?assertEqual(
+		ok,
+		apply_external_update(SessionKey1, [5], 6, false, SessionKey0),
+		"Full session1, should mine"),
+	timer:sleep(?WAIT_TIME),
+	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
+	?assertEqual([6, 5], mined_steps()),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey3, [], 16, true, SessionKey2),
+		"Partial session3, should not mine"),
+	timer:sleep(?WAIT_TIME),
+	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
+	?assertEqual([], mined_steps()),
+	?assertEqual(
+		#nonce_limiter_update_response{ session_found = false },
+		apply_external_update(SessionKey3, [15], 16, true, SessionKey2),
+		"Full session3, should not mine"),
+	timer:sleep(?WAIT_TIME),
+	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
+	?assertEqual([], mined_steps()),
+	%% Current session is only updated when applying a new tip block, not when applying a VDF step
+	%% from a VDF server.
+	?assertEqual(SessionKey0, get_current_session_key()).
+
+%% -------------------------------------------------------------------------------------------------
+%% Helper Functions
+%% -------------------------------------------------------------------------------------------------
+
+init(Req, State) ->
+	SplitPath = ar_http_iface_server:split_path(cowboy_req:path(Req)),
+	handle(SplitPath, Req, State).
+
+handle([<<"vdf">>], Req, State) ->
+	{ok, Body, _} = ar_http_req:body(Req, ?MAX_BODY_SIZE),
+	case ar_serialize:binary_to_nonce_limiter_update(2, Body) of
+		{ok, Update} ->
+			handle_update(Update, Req, State);
+		{error, _} ->
+			Response = #nonce_limiter_update_response{ format = 2 },
+			Bin = ar_serialize:nonce_limiter_update_response_to_binary(Response),
+			{ok, cowboy_req:reply(202, #{}, Bin, Req), State}
+	end.
+
+handle_update(Update, Req, State) ->
+	{Seed, _, _} = Update#nonce_limiter_update.session_key,
+	IsPartial  = Update#nonce_limiter_update.is_partial,
+	Session = Update#nonce_limiter_update.session,
+	StepNumber = Session#vdf_session.step_number,
+	NSteps = length(Session#vdf_session.steps),
+	Checkpoints = maps:get(StepNumber, Session#vdf_session.step_checkpoints_map),
+
+	UpdateOutput = hd(Checkpoints),
+
+	SessionOutput = hd(Session#vdf_session.steps),
+
+	?assertNotEqual(Checkpoints, Session#vdf_session.steps),
+	%% #nonce_limiter_update.checkpoints should be the checkpoints of the last step so
+	%% the head of checkpoints should match the head of the session's steps
+	?assertEqual(UpdateOutput, SessionOutput),
+
+	case ets:lookup(computed_output, Seed) of
+		[{Seed, FirstStepNumber, LatestStepNumber}] ->
+			?assert(not IsPartial orelse StepNumber == LatestStepNumber + 1,
+				lists:flatten(io_lib:format(
+					"Partial VDF update did not increase by 1, "
+					"StepNumber: ~p, LatestStepNumber: ~p",
+					[StepNumber, LatestStepNumber]))),
+
+			ets:insert(computed_output, {Seed, FirstStepNumber, StepNumber}),
+			{ok, cowboy_req:reply(200, #{}, <<>>, Req), State};
+		_ ->
+			case IsPartial of
+				true ->
+					Response = #nonce_limiter_update_response{ session_found = false },
+					Bin = ar_serialize:nonce_limiter_update_response_to_binary(Response),
+					{ok, cowboy_req:reply(202, #{}, Bin, Req), State};
+				false ->
+					ets:insert(computed_output, {Seed, StepNumber - NSteps + 1, StepNumber}),
+					{ok, cowboy_req:reply(200, #{}, <<>>, Req), State}
+			end
+	end.
+
+vdf_server_1() ->
+	{127,0,0,1,2001}.
+
+vdf_server_2() ->
+	{127,0,0,1,2002}.
+
+computed_steps() ->
+    lists:reverse(ets:foldl(fun({_, Step, _}, Acc) -> [Step | Acc] end, [], computed_output)).
+
+computed_upper_bounds() ->
+    lists:reverse(ets:foldl(fun({_, _, UpperBound}, Acc) -> [UpperBound | Acc] end, [], computed_output)).
+
+mined_steps() ->
+	Steps = lists:reverse(ets:foldl(
+		fun({_Worker, _Task, Step}, Acc) -> [Step | Acc] end, [], add_task)),
+	ets:delete_all_objects(add_task),
+	Steps.
+
+computed_output() ->
+	receive
+		{event, nonce_limiter, {computed_output, Args}} ->
+			{_SessionKey, _StepNumber, Output, UpperBound} = Args,
+			Key = ets:info(computed_output, size) + 1, % Unique key based on current size, ensures ordering
+    		ets:insert(computed_output, {Key, Output, UpperBound}),
+			computed_output()
+	end.
+
+apply_external_update(SessionKey, ExistingSteps, StepNumber, IsPartial, PrevSessionKey) ->
+	apply_external_update(SessionKey, ExistingSteps, StepNumber, IsPartial, PrevSessionKey,
+		vdf_server_1()).
+apply_external_update(SessionKey, ExistingSteps, StepNumber, IsPartial, PrevSessionKey, Peer) ->
+	{Seed, Interval, _Difficulty} = SessionKey,
+	Steps = [list_to_binary(integer_to_list(Step)) || Step <- [StepNumber | ExistingSteps]],
+	Session = #vdf_session{
+		upper_bound = Interval * 10,
+		next_upper_bound = (Interval+1) * 10,
+		prev_session_key = PrevSessionKey,
+		step_number = StepNumber,
+		seed = Seed,
+		steps = Steps
+	},
+
+	Update = #nonce_limiter_update{
+		session_key = SessionKey,
+		is_partial = IsPartial,
+		session = Session
+	},
+	ar_nonce_limiter:apply_external_update(Update, Peer).
+
+get_current_session_key() ->
+	{CurrentSessionKey, _} = ar_nonce_limiter:get_current_session(),
+	CurrentSessionKey.
+
+mock_add_task() ->
+	{
+		ar_mining_worker, add_task,
+		fun(Worker, TaskType, Candidate) ->
+			ets:insert(add_task, {Worker, TaskType, Candidate#mining_candidate.step_number})
+		end
+	}.
+
+mock_reset_frequency() ->
+	{
+		ar_nonce_limiter, get_reset_frequency,
+		fun() ->
+			5
+		end
+	}.
+
+assert_sessions_equal(List, Set) ->
+	?assertEqual(lists:sort(List), lists:sort(sets:to_list(Set))).

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -6,14 +6,8 @@
 
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave/include/ar_config.hrl").
--include_lib("arweave/include/ar_consensus.hrl").
--include_lib("arweave/include/ar_mining.hrl").
--include_lib("arweave/include/ar_vdf.hrl").
 
 -import(ar_test_node, [assert_wait_until_height/2, post_block/2, send_new_block/2]).
-
-%% we have to wait to let the ar_events get processed whenever we apply a VDF step
--define(WAIT_TIME, 1000).
 
 %% -------------------------------------------------------------------------------------------------
 %% Test Fixtures
@@ -28,38 +22,6 @@ setup() ->
 cleanup({Config, PeerConfig}) ->
 	application:set_env(arweave, config, Config),
 	ar_test_node:remote_call(peer1, application, set_env, [arweave, config, PeerConfig]),
-	ets:delete(computed_output).
-
-setup_external_update() ->
-	{ok, Config} = application:get_env(arweave, config),
-	[B0] = ar_weave:init(),
-	%% Start the testnode with a configured VDF server so that it doesn't compute its own VDF -
-	%% this is necessary so that we can test the behavior of apply_external_update without any
-	%% auto-computed VDF steps getting in the way.
-	_ = ar_test_node:start(
-		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
-		Config#config{ 
-			nonce_limiter_server_trusted_peers = [
-				ar_util:format_peer(vdf_server_1()),
-				ar_util:format_peer(vdf_server_2()) 
-			],
-			mine = true
-		}
-	),
-	ets:new(computed_output, [named_table, ordered_set, public]),
-	ets:new(add_task, [named_table, bag, public]),
-	Pid = spawn(
-		fun() ->
-			ok = ar_events:subscribe(nonce_limiter),
-			computed_output()
-		end
-	),
-	{Pid, Config}.
-
-cleanup_external_update({Pid, Config}) ->
-	exit(Pid, kill),
-	ok = application:set_env(arweave, config, Config),
-	ets:delete(add_task),
 	ets:delete(computed_output).
 
 %% -------------------------------------------------------------------------------------------------
@@ -91,9 +53,9 @@ vdf_server_push_test_() ->
      	fun cleanup/1,
 		[
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_server_push_fast_block/0, ?TEST_SUITE_TIMEOUT),
+				fun test_vdf_server_push_fast_block/0, ?TEST_NODE_TIMEOUT),
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_server_push_slow_block/0, ?TEST_SUITE_TIMEOUT)
+				fun test_vdf_server_push_slow_block/0, ?TEST_NODE_TIMEOUT)
 		]
     }.
 
@@ -106,33 +68,13 @@ vdf_client_test_() ->
 		fun cleanup/1,
 		[
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_client_fast_block/0, 600),
+				fun test_vdf_client_fast_block/0, ?TEST_NODE_TIMEOUT),
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_client_fast_block_pull_interface/0, 600),
+				fun test_vdf_client_fast_block_pull_interface/0, ?TEST_NODE_TIMEOUT),
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_client_slow_block/0, 600),
+				fun test_vdf_client_slow_block/0, ?TEST_NODE_TIMEOUT),
 			ar_test_node:test_with_mocked_functions([mock_reset_frequency()],
-				fun test_vdf_client_slow_block_pull_interface/0, 600)
-		]
-    }.
-
-external_update_test_() ->
-    {foreach,
-		fun setup_external_update/0,
-     	fun cleanup_external_update/1,
-		[
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_session_overlap/0, 120),
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_client_ahead/0, 120),
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_skip_ahead/0, 120),
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_2_servers_switching/0, 120),
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_backtrack/0, 120),
-			ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-				fun test_2_servers_backtrack/0, 120)
+				fun test_vdf_client_slow_block_pull_interface/0, ?TEST_NODE_TIMEOUT)
 		]
     }.
 
@@ -144,16 +86,6 @@ serialize_test_() ->
 		{timeout, 120, fun test_serialize_response/0},
 		{timeout, 120, fun test_serialize_response_compatibility/0}
 	].
-
-mining_session_test_() ->
-    {foreach,
-		fun setup_external_update/0,
-     	fun cleanup_external_update/1,
-	[
-		ar_test_node:test_with_mocked_functions([mock_add_task(), mock_reset_frequency()],
-			fun test_mining_session/0, 120)
-	]
-    }.
 
 %% -------------------------------------------------------------------------------------------------
 %% Tests
@@ -200,8 +132,8 @@ test_vdf_server_push_fast_block() ->
 	Seed1 = B1#block.nonce_limiter_info#nonce_limiter_info.next_seed,
 	StepNumber1 = ar_block:vdf_step_number(B1),
 
-	[{Seed0, _, LatestStepNumber0}] = ets:lookup(computed_output, Seed0),
-	[{Seed1, FirstStepNumber1, _}] = ets:lookup(computed_output, Seed1),
+	[{Seed0, _, LatestStepNumber0}] = get_computed_output(Seed0),
+	[{Seed1, _FirstStepNumber1, _}] = get_computed_output(Seed1),
 	?assertEqual(2, ets:info(computed_output, size), "VDF server did not post 2 sessions"),
 	?assertEqual(StepNumber1, LatestStepNumber0,
 		"VDF server did not post the full Session0 when starting Session1"),
@@ -250,13 +182,13 @@ test_vdf_server_push_slow_block() ->
 	Seed1 = B1#block.nonce_limiter_info#nonce_limiter_info.next_seed,
 	StepNumber1 = ar_block:vdf_step_number(B1),
 
-	[{Seed0, _, LatestStepNumber0}] = ets:lookup(computed_output, Seed0),
-	[{Seed1, FirstStepNumber1, LatestStepNumber1}] = ets:lookup(computed_output, Seed1),
+	[{Seed0, _, LatestStepNumber0}] = get_computed_output(Seed0),
+	[{Seed1, FirstStepNumber1, LatestStepNumber1}] = get_computed_output(Seed1),
 	?assert(LatestStepNumber0 > FirstStepNumber1, "Session0 should have started later than Session1"),
 
 	timer:sleep(3000),
-	[{Seed0, _, NewLatestStepNumber0}] = ets:lookup(computed_output, Seed0),
-	[{Seed1, _, NewLatestStepNumber1}] = ets:lookup(computed_output, Seed1),
+	[{Seed0, _, NewLatestStepNumber0}] = get_computed_output(Seed0),
+	[{Seed1, _, NewLatestStepNumber1}] = get_computed_output(Seed1),
 	?assertEqual(LatestStepNumber0, NewLatestStepNumber0,
 		"Session0 should not have progressed"),
 	?assert(NewLatestStepNumber1 > LatestStepNumber1, "Session1 should have progressed"),
@@ -295,6 +227,7 @@ test_vdf_client_fast_block() ->
 			]
 		}),
 	%% Start main as a VDF server
+	ar_test_node:stop(),
 	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ 
@@ -464,333 +397,6 @@ test_vdf_client_slow_block_pull_interface() ->
 	%% VDF server is ahead of the block in the VDF chain.
 	send_new_block(ar_test_node:peer_ip(peer1), B1),
 	BI = assert_wait_until_height(peer1, 1).
-
-%%
-%% external_update_test_
-%%
-
-%% @doc The VDF session key is only updated when a block is procesed by the VDF server. Until that
-%% happens the serve will push all VDF steps under the same session key - even if those steps
-%% cross an entropy reset line. When a block comes in the server will update the session key
-%% *and* move all appropriate steps to that session. Prior to 2.7 this caused VDF clients to
-%% process some steps twice - once under the old session key, and once under the new session key.
-%% This test asserts that this behavior has been fixed and that VDF clients only process each
-%% step once.
-test_session_overlap() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey1, [], 8, true, SessionKey0),
-		"Partial session1, session not found"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
-		"Full session1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 9, true, SessionKey0),
-		"Partial session1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 10, true, SessionKey0),
-		"Partial session1, interval2"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 11, true, SessionKey0),
-		"Partial session1, interval2"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey2, [], 12, true, SessionKey1),
-		"Partial session2, interval2"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = true, step_number = 11 },
-		apply_external_update(SessionKey1, [8, 7, 6, 5], 9, false, SessionKey1),
-		"Full session1, all steps already seen"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey2, [11, 10], 12, false, SessionKey1),
-		"Full session2, some steps already seen"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual(
-		[<<"8">>, <<"7">>, <<"6">>, <<"5">>, <<"9">>, <<"10">>, <<"11">>, <<"12">>],
-	computed_steps()),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual(
-		[10, 10, 10, 10, 10, 20, 20, 20],
-		computed_upper_bounds()).
-
-
-%% @doc This test asserts that the client responds correctly when it is ahead of the VDF server.
-test_client_ahead() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
-		"Full session"),
-	?assertEqual(
-		#nonce_limiter_update_response{ step_number = 8 },
-		apply_external_update(SessionKey1, [], 7, true, SessionKey0),
-		"Partial session, client ahead"),
-	?assertEqual(
-		#nonce_limiter_update_response{ step_number = 8 },
-		apply_external_update(SessionKey1, [6, 5], 7, false, SessionKey0),
-		"Full session, client ahead"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual(
-		[<<"8">>, <<"7">>, <<"6">>, <<"5">>],
-		computed_steps()),
-	?assertEqual(
-		[10, 10, 10, 10],
-		computed_upper_bounds()).
-
-%% @doc
-%% Test case:
-%% 1. VDF server pushes a partial update that skips too far ahead of the client
-%% 2. Simulate the updates that the server would then push (i.e. full session updates of the current
-%%    session and maybe previous session)
-%%
-%% Assert that the client responds correctly and only processes each step once (even though it may
-%% see the same step several times as part of the full session updates).
-test_skip_ahead() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [5], 6, false, SessionKey0),
-		"Full session1"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = true, step_number = 6 },
-		apply_external_update(SessionKey1, [], 8, true, SessionKey0),
-		"Partial session1, server ahead"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [7, 6, 5], 8, false, SessionKey0),
-		"Full session1"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey2, [], 12, true, SessionKey1),
-		"Partial session2, server ahead"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [8, 7, 6, 5], 9, false, SessionKey0),
-		"Full session1, all steps already seen"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey2, [11, 10], 12, false, SessionKey1),
-		"Full session2, some steps already seen"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual(
-		[<<"6">>, <<"5">>, <<"8">>, <<"7">>, <<"9">>, <<"12">>, <<"11">>, <<"10">>],
-		computed_steps()),
-	?assertEqual(
-		[10, 10, 10, 10, 10, 20, 20, 20],
-		computed_upper_bounds()).
-
-test_2_servers_switching() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [6, 5], 7, false, SessionKey0, vdf_server_1()),
-		"Full session1 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 8, true, SessionKey0, vdf_server_2()),
-		"Partial session1 from vdf_server_2"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 9, true, SessionKey0, vdf_server_2()),
-		"Partial session1 from vdf_server_2"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey2, [], 11, true, SessionKey1, vdf_server_1()),
-		"Partial session2 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey2, [10], 11, false, SessionKey1, vdf_server_1()),
-		"Full session2 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 10, true, SessionKey0, vdf_server_2()),
-		"Partial session1 from vdf_server_2 (should not change current session)"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 11, true, SessionKey0, vdf_server_2()),
-		"Partial session1 from vdf_server_2 (should not change current session)"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 12, true, SessionKey0, vdf_server_2()),
-		"Partial session1 from vdf_server_2 (should not change current session)"),
-	?assertEqual(
-		ok,
-		apply_external_update(
-			SessionKey2, [11, 10], 12, false, SessionKey1, vdf_server_2()),
-		"Full session2 from vdf_server_2"),
-	?assertEqual(
-		#nonce_limiter_update_response{ step_number = 12 },
-		apply_external_update(SessionKey2, [], 12, true, SessionKey1, vdf_server_1()),
-		"Partial (repeat) session2 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey2, [], 13, true, SessionKey1, vdf_server_1()),
-		"Partial (new) session2 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey2, [], 14, true, SessionKey1, vdf_server_2()),
-		"Partial (new) session2 from vdf_server_2"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual([
-		<<"7">>, <<"6">>, <<"5">>, <<"8">>, <<"9">>,
-		<<"11">>, <<"10">>, <<"10">>, <<"11">>, <<"12">>,
-		<<"12">>, <<"13">>, <<"14">>
-	], computed_steps()),
-	?assertEqual(
-		[10, 10, 10, 10, 10, 20, 20, 20, 20, 20, 20, 20, 20],
-		computed_upper_bounds()).
-
-test_backtrack() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [
-			16, 15,				%% interval 3
-			14, 13, 12, 11, 10, %% interval 2
-			9, 8, 7, 6, 5		%% interval 1
-		], 17, false, SessionKey0),
-		"Full session1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 18, true, SessionKey0),
-		"Partial session1"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey2, [], 15, true, SessionKey1),
-		"Partial session2"),
-	?assertEqual(
-		#nonce_limiter_update_response{ step_number = 18 },
-		apply_external_update(
-			SessionKey1, [8, 7, 6, 5], 9, false, SessionKey0),
-		"Backtrack. Send full session1."),
-	?assertEqual(
-		ok,
-		apply_external_update(
-			SessionKey2, [14, 13, 12, 11, 10], 15, false, SessionKey1),
-		"Backtrack. Send full session2"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual([
-		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
-        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
-        <<"5">>,<<"18">>,<<"15">>
-	], computed_steps()),
-	?assertEqual(
-		[20, 20, 20, 20, 20, 20, 20, 20, 10, 10, 10, 10, 10, 20, 30],
-		computed_upper_bounds()).
-
-test_2_servers_backtrack() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [
-			16, 15,				%% interval 3
-			14, 13, 12, 11, 10, %% interval 2
-			9, 8, 7, 6, 5		%% interval 1
-		], 17, false, SessionKey0, vdf_server_1()),
-		"Full session1 from vdf_server_1"),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [], 18, true, SessionKey0, vdf_server_1()),
-		"Partial session1 from vdf_server_1"),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey2, [], 15, true, SessionKey1, vdf_server_2()),
-		"Partial session2 from vdf_server_2"),
-	?assertEqual(
-		ok,
-		apply_external_update(
-			SessionKey2, [14, 13, 12, 11, 10], 15, false, SessionKey1, vdf_server_2()),
-		"Backtrack in session2 from vdf_server_2"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual([
-		<<"17">>,<<"16">>,<<"15">>,<<"14">>,<<"13">>,<<"12">>,
-        <<"11">>,<<"10">>,<<"9">>,<<"8">>,<<"7">>,<<"6">>,
-        <<"5">>,<<"18">>,<<"15">>
-	], computed_steps()),
-	?assertEqual(SessionKey0, get_current_session_key()),
-	?assertEqual(
-		[20, 20, 20, 20, 20, 20, 20, 20, 10, 10, 10, 10, 10, 20, 30],
-		computed_upper_bounds()).
-
-test_mining_session() ->
-	SessionKey0 = get_current_session_key(),
-	SessionKey1 = {<<"session1">>, 1, 1},
-	SessionKey2 = {<<"session2">>, 2, 1},
-	SessionKey3 = {<<"session3">>, 3, 1},
-	ar_test_node:mine(),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey0, [], 2, true, undefined),
-		"Partial session0, should mine"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
-	?assertEqual([2], mined_steps()),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey0, [3], 4, false, undefined),
-		"Full session0, should mine"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
-	?assertEqual([4, 3], mined_steps()),
-	?assertEqual(
-		#nonce_limiter_update_response{ step_number = 4 },
-		apply_external_update(SessionKey0, [], 4, true, undefined),
-		"Repeat step, should not mine"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
-	?assertEqual([], mined_steps()),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey1, [], 6, true, SessionKey0),
-		"Partial session1, should not mine"),
-	timer:sleep(?WAIT_TIME),
-	?assertEqual([SessionKey0], sets:to_list(ar_mining_server:active_sessions())),
-	?assertEqual([], mined_steps()),
-	?assertEqual(
-		ok,
-		apply_external_update(SessionKey1, [5], 6, false, SessionKey0),
-		"Full session1, should mine"),
-	timer:sleep(?WAIT_TIME),
-	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
-	?assertEqual([6, 5], mined_steps()),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey3, [], 16, true, SessionKey2),
-		"Partial session3, should not mine"),
-	timer:sleep(?WAIT_TIME),
-	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
-	?assertEqual([], mined_steps()),
-	?assertEqual(
-		#nonce_limiter_update_response{ session_found = false },
-		apply_external_update(SessionKey3, [15], 16, true, SessionKey2),
-		"Full session3, should not mine"),
-	timer:sleep(?WAIT_TIME),
-	assert_sessions_equal([SessionKey0, SessionKey1], ar_mining_server:active_sessions()),
-	?assertEqual([], mined_steps()),
-	%% Current session is only updated when applying a new tip block, not when applying a VDF step
-	%% from a VDF server.
-	?assertEqual(SessionKey0, get_current_session_key()).
 
 %%
 %% serialize_test_
@@ -980,7 +586,3 @@ mock_reset_frequency() ->
 			5
 		end
 	}.
-	
-
-assert_sessions_equal(List, Set) ->
-	?assertEqual(lists:sort(List), lists:sort(sets:to_list(Set))).


### PR DESCRIPTION
prevent `session_not_found` when mining CM, warn about missing `mine` flag

a missing `mine` flag on the exit node would cause it to reject valid solutions