### PR TITLE
Upgrade Jiffy to its latest version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
-	{jiffy, {git, "https://github.com/ArweaveTeam/jiffy.git", {ref, "f25a120f02951b9fd618d1f8f6343fdb8dbe133f"}}},
+	{jiffy, {git, "https://github.com/ArweaveTeam/jiffy.git", {ref, "073da726e07bafb5d140020a9e8765c703da3ef7"}}},
 	{ranch, "1.8.1"},
 	{gun, "2.2.0"},
 	{cowboy, "2.12.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
  {<<"gun">>,{pkg,<<"gun">>,<<"2.2.0">>},0},
  {<<"jiffy">>,
   {git,"https://github.com/ArweaveTeam/jiffy.git",
-       {ref,"f25a120f02951b9fd618d1f8f6343fdb8dbe133f"}},
+       {ref,"073da726e07bafb5d140020a9e8765c703da3ef7"}},
   0},
  {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.11.0">>},0},
  {<<"prometheus_cowboy">>,{pkg,<<"prometheus_cowboy">>,<<"0.1.8">>},0},


### PR DESCRIPTION
While compiling previous version, it fails on MacOS 26+. Instead of patching our fork of jiffy, this PR is upgrading it. Indeed, the latest version of jiffy seems to works correctly on MacOS 26+.