### PR TITLE
Create an Interface to Arweave Application Environment

### DIFF
--- a/apps/arweave/e2e/ar_e2e.erl
+++ b/apps/arweave/e2e/ar_e2e.erl
@@ -135,7 +135,7 @@ start_source_node(Node, PackingType, WalletFixture, ModuleSize) ->
 	RewardAddr = ar_wallet:to_address(Wallet),
 	[B0] = ar_weave:init([{RewardAddr, ?AR(200), <<>>}], 0, ar_block:partition_size()),
 
-	{ok, Config} = ar_test_node:remote_call(Node, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(Node, arweave_config, get_env, []),
 	
 	?assertEqual(ar_test_node:peer_name(Node),
 		ar_test_node:start_other_node(Node, B0, Config#config{

--- a/apps/arweave/include/ar_blacklist_middleware.hrl
+++ b/apps/arweave/include/ar_blacklist_middleware.hrl
@@ -7,7 +7,7 @@
 end).
 
 -define(RPM_BY_PATH(Path, LimitByIP), fun() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	?RPM_BY_PATH(Path, LimitByIP, Config#config.requests_per_minute_limit)()
 end).
 

--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -1181,7 +1181,7 @@ start(Config) ->
 			init:stop(1)
 	end,
 	Config2 = ar_config:set_dependent_flags(Config),
-	ok = application:set_env(arweave, config, Config2),
+	ok = arweave_config:set_env(Config2),
 	filelib:ensure_dir(Config2#config.log_dir ++ "/"),
 	warn_if_single_scheduler(),
 	case Config2#config.nonce_limiter_server_trusted_peers of
@@ -1195,7 +1195,7 @@ start(Config) ->
 
 
 start(normal, _Args) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	%% Set erlang socket backend
 	persistent_term:put({kernel, inet_backend}, Config#config.'socket.backend'),
 	%% Configure logger
@@ -1222,7 +1222,7 @@ set_mining_address(#config{ mining_addr = not_set } = C) ->
 			Addr = ar_wallet:to_address(W),
 			ar:console("~nSetting the mining address to ~s.~n", [ar_util:encode(Addr)]),
 			C2 = C#config{ mining_addr = Addr },
-			application:set_env(arweave, config, C2),
+			arweave_config:set_env(C2),
 			set_mining_address(C2)
 	end;
 set_mining_address(#config{ mine = false }) ->
@@ -1265,7 +1265,7 @@ create_wallet(DataDir, KeyType) ->
 		false ->
 			create_wallet_fail(KeyType);
 		true ->
-			ok = application:set_env(arweave, config, #config{ data_dir = DataDir }),
+			ok = arweave_config:set_env(#config{ data_dir = DataDir }),
 			case ar_wallet:new_keyfile(KeyType) of
 				{error, Reason} ->
 					ar:console("Failed to create a wallet, reason: ~p.~n~n",
@@ -1299,7 +1299,7 @@ benchmark_packing(Args) ->
 benchmark_vdf() ->
 	benchmark_vdf([]).
 benchmark_vdf(Args) ->
-	ok = application:set_env(arweave, config, #config{}),
+	ok = arweave_config:set_env(#config{}),
 	ar_bench_vdf:run_benchmark_from_cli(Args),
 	init:stop(1).
 
@@ -1340,7 +1340,7 @@ stop_dependencies() ->
 	lists:foreach(fun(Dep) -> application:stop(Dep) end, Deps).
 
 start_dependencies() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{ok, _} = application:ensure_all_started(arweave, permanent),
 	ar_config:log_config(Config).
 

--- a/apps/arweave/src/ar_bench_2_9.erl
+++ b/apps/arweave/src/ar_bench_2_9.erl
@@ -59,8 +59,9 @@ show_help() ->
 	init:stop(1).
 
 run_benchmark({Format, Dirs, Threads, DataMiB}) ->
-	application:set_env(arweave, config, #config{ 
-		disable = [], enable  = [randomx_large_pages] }),
+	arweave_config:set_env(#config{ 
+		disable = [], enable  = [randomx_large_pages]
+	}),
 
 	ThreadDirPairs = assign_threads_to_dirs(Threads, Dirs),
 

--- a/apps/arweave/src/ar_bench_vdf.erl
+++ b/apps/arweave/src/ar_bench_vdf.erl
@@ -36,13 +36,13 @@ run_benchmark(Mode, Difficulty, Verify) ->
 			%% Run as part of startup, use whatever is set in the config
 			ok;
 		openssl ->
-			ok = application:set_env(arweave, config, #config{ vdf = openssl });
+			ok = arweave_config:set_env(#config{ vdf = openssl });
 		fused ->
-			ok = application:set_env(arweave, config, #config{ vdf = fused });
+			ok = arweave_config:set_env(#config{ vdf = fused });
 		hiopt_m4 ->
-			ok = application:set_env(arweave, config, #config{ vdf = hiopt_m4 });
+			ok = arweave_config:set_env(#config{ vdf = hiopt_m4 });
 		default ->
-			ok = application:set_env(arweave, config, #config{})
+			ok = arweave_config:set_env(#config{})
 	end,
 	Input = crypto:strong_rand_bytes(32),
 	{Time, {ok, Output, Checkpoints}} = timer:tc(fun() -> 

--- a/apps/arweave/src/ar_blacklist_middleware.erl
+++ b/apps/arweave/src/ar_blacklist_middleware.erl
@@ -13,7 +13,7 @@
 
 execute(Req, Env) ->
 	IPAddr = requesting_ip_addr(Req),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(blacklist, Config#config.disable) of
 		true ->
 			{ok, Req, Env};
@@ -148,6 +148,6 @@ peer_to_ip_addr({A, B, C, D, _}) -> {A, B, C, D}.
 
 get_key_limit(IPAddr, Req) ->
 	Path = ar_http_iface_server:split_path(cowboy_req:path(Req)),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Map = maps:get(IPAddr, Config#config.requests_per_minute_limit_by_ip, #{}),
 	?RPM_BY_PATH(Path, Map)().

--- a/apps/arweave/src/ar_block_pre_validator.erl
+++ b/apps/arweave/src/ar_block_pre_validator.erl
@@ -69,7 +69,7 @@ pre_validate(B, Peer, ReceiveTimestamp) ->
 init([]) ->
 	gen_server:cast(?MODULE, pre_validate),
 	ok = ar_events:subscribe(block),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ThrottleBySolutionInterval = Config#config.block_throttle_by_solution_interval,
 	ThrottleByIPInterval = Config#config.block_throttle_by_ip_interval,
 	{ok, #state{ throttle_by_ip_interval = ThrottleByIPInterval,
@@ -476,7 +476,7 @@ pre_validate_existing_solution_hash(B, PrevB, Peer) ->
 			pre_validate_nonce_limiter_global_step_number(B, PrevB, false, Peer);
 		{invalid, ExtraData2} ->
 			Code = maps:get(code, ExtraData2, check_resigned_solution_hash),
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			case lists:member(extended_block_validation_trace, Config#config.enable) of
 				true ->
 					post_block_reject_warn_and_error_dump(B, Code, Peer, ExtraData2);
@@ -825,7 +825,7 @@ post_block_reject_warn_and_error_dump(B, Step, Peer) ->
 	post_block_reject_warn_and_error_dump(B, Step, Peer, #{}).
 
 post_block_reject_warn_and_error_dump(B, Step, Peer, ExtraData) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ID = binary_to_list(ar_util:encode(crypto:strong_rand_bytes(16))),
 	File = filename:join(Config#config.data_dir, "invalid_block_dump_" ++ ID),
 	file:write_file(File, term_to_binary({B, ExtraData})),

--- a/apps/arweave/src/ar_bridge.erl
+++ b/apps/arweave/src/ar_bridge.erl
@@ -122,7 +122,7 @@ handle_info({event, block, {new, B, _}}, State) ->
 			%% The cache should have been just pruned and this block is old.
 			{noreply, State};
 		_ ->
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			TrustedPeers = ar_peers:get_trusted_peers(),
 			SpecialPeers = Config#config.block_gossip_peers,
 			Peers = ((SpecialPeers ++ ar_peers:get_peers(current)) -- TrustedPeers) ++ TrustedPeers,
@@ -252,7 +252,7 @@ send_to_worker(Peer, {JSON, B}, W) ->
 	end.
 
 send_and_log(Peer, H, Height, Format, Bin, RecallByte) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Reply =
 		case Format of
 			json ->

--- a/apps/arweave/src/ar_chunk_copy.erl
+++ b/apps/arweave/src/ar_chunk_copy.erl
@@ -41,7 +41,7 @@ register_workers() ->
 	Workers ++ [ChunkCopy].
 
 register_read_workers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StoreIDs = [
 		ar_storage_module:id(StorageModule) || StorageModule <- Config#config.storage_modules
 	] ++ [?DEFAULT_MODULE],
@@ -311,7 +311,7 @@ test_process_queue() ->
 		queue:to_list(Worker3#worker_tasks.task_queue)).
 
 test_register_workers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StoreIDs = [
 		ar_storage_module:id(StorageModule) || StorageModule <- Config#config.storage_modules],
 	lists:foreach(

--- a/apps/arweave/src/ar_chunk_storage.erl
+++ b/apps/arweave/src/ar_chunk_storage.erl
@@ -49,7 +49,7 @@ name(StoreID) ->
 	list_to_atom("ar_chunk_storage_" ++ ar_storage_module:label(StoreID)).
 
 register_workers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ConfiguredWorkers = lists:map(
 		fun(StorageModule) ->
 			StoreID = ar_storage_module:id(StorageModule),
@@ -258,7 +258,7 @@ delete(PaddedOffset, StoreID) ->
 
 %% @doc Run defragmentation of chunk files if enabled
 run_defragmentation() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.run_defragmentation of
 		false ->
 			ok;
@@ -350,7 +350,7 @@ read_offset(PaddedOffset, StoreID) ->
 init(?DEFAULT_MODULE = StoreID) ->
 	%% Trap exit to avoid corrupting any open files on quit..
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	Dir = get_storage_module_path(DataDir, StoreID),
 	ok = filelib:ensure_dir(Dir ++ "/"),
@@ -370,7 +370,7 @@ init(?DEFAULT_MODULE = StoreID) ->
 init(StoreID) ->
 	%% Trap exit to avoid corrupting any open files on quit..
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	Dir = get_storage_module_path(DataDir, StoreID),
 	ok = filelib:ensure_dir(Dir ++ "/"),
@@ -497,11 +497,11 @@ terminate(Reason, _State) ->
 %%%===================================================================
 
 get_chunk_group_size() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.chunk_storage_file_size.
 
 get_filepath(Name, StoreID) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	ChunkDir = get_chunk_storage_path(DataDir, StoreID),
 	filename:join([ChunkDir, Name]).
@@ -874,7 +874,7 @@ defrag_files([Filepath | Rest]) ->
 	defrag_files(Rest).
 
 update_sizes_file([], Sizes) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	SizesFile = filename:join(Config#config.data_dir, "chunks_sizes"),
 	case file:open(SizesFile, [write, raw]) of
 		{error, Reason} ->

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -30,7 +30,7 @@ set_dependent_flags(Config) ->
 	Config2.
 
 use_remote_vdf_server() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.nonce_limiter_server_trusted_peers of
 		[] ->
 			false;
@@ -39,11 +39,11 @@ use_remote_vdf_server() ->
 	end.
 
 pull_from_remote_vdf_server() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	not lists:member(vdf_server_pull, Config#config.disable).
 
 compute_own_vdf() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.nonce_limiter_server_trusted_peers of
 		[] ->
 			%% Not a VDF client - compute VDF unless explicitly disabled.
@@ -54,7 +54,7 @@ compute_own_vdf() ->
 	end.
 
 is_vdf_server() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.nonce_limiter_client_peers of
 		[] ->
 			lists:member(public_vdf_server, Config#config.enable);
@@ -63,7 +63,7 @@ is_vdf_server() ->
 	end.
 
 is_public_vdf_server() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	lists:member(public_vdf_server, Config#config.enable).
 
 parse(Config) when is_binary(Config) ->

--- a/apps/arweave/src/ar_coordination.erl
+++ b/apps/arweave/src/ar_coordination.erl
@@ -104,14 +104,14 @@ garbage_collect() ->
 
 %% Return true if we are an exit peer in the coordinated mining setup.
 is_exit_peer() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.coordinated_mining == true andalso
 			Config#config.cm_exit_peer == not_set.
 
 %% Return true if we are a CM miner in the coordinated mining setup.
 %% A CM miner may be but does not have to be an exit node.
 is_coordinated_miner() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.coordinated_mining == true.
 
 %% @doc Return a list of unique partitions including local partitions and all of
@@ -162,7 +162,7 @@ get_cluster_partitions_list() ->
 %%%===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 
 	ar_util:cast_after(?BATCH_POLL_INTERVAL_MS, ?MODULE, check_batches),
 	State = #state{
@@ -278,7 +278,7 @@ handle_cast({computed_h2_for_peer, Candidate}, State) ->
 	{noreply, State};
 
 handle_cast(refetch_peer_partitions, State) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Peers = Config#config.cm_peers,
 	Peers2 =
 		case Config#config.cm_exit_peer == not_set

--- a/apps/arweave/src/ar_data_sync_worker.erl
+++ b/apps/arweave/src/ar_data_sync_worker.erl
@@ -37,7 +37,7 @@ start_link(Name, Mode) ->
 
 init({Name, Mode}) ->
 	?LOG_INFO([{event, init}, {module, ?MODULE}, {name, Name}]),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	%% In case there has been a restart we need to tell
 	%% ar_data_sync_worker_master to erase pending worker tasks.
 	%% We only want to do this for sync workers, not read workers.

--- a/apps/arweave/src/ar_data_sync_worker_master.erl
+++ b/apps/arweave/src/ar_data_sync_worker_master.erl
@@ -61,7 +61,7 @@ register_workers() ->
 
 
 register_sync_workers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{Workers, WorkerNames} = lists:foldl(
 		fun(Number, {AccWorkers, AccWorkerNames}) ->
 			Name = list_to_atom("ar_data_sync_worker_" ++ integer_to_list(Number)),
@@ -75,7 +75,7 @@ register_sync_workers() ->
 
 %% @doc Returns true if syncing is enabled (i.e. sync_jobs > 0).
 is_syncing_enabled() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.sync_jobs > 0.
 
 %% @doc Returns true if we can accept new tasks. Will always return false if syncing is
@@ -637,9 +637,9 @@ test_max_peer_queue() ->
 	?assertEqual(20, max_peer_queue(#performance{ current_rating = 1 }, 100, 10)).
 
 test_cut_peer_queue() ->
-	{ok, OriginalConfig} = application:get_env(arweave, config),
+	{ok, OriginalConfig} = arweave_config:get_env(),
 	try
-		ok = application:set_env(arweave, config, OriginalConfig#config{
+		ok = arweave_config:set_env(OriginalConfig#config{
 			sync_jobs = 10
 		}),
 
@@ -672,7 +672,7 @@ test_cut_peer_queue() ->
 		assert_peer_tasks(TaskQueue, 0, 8, PeerTasks4),
 		?assertEqual(100, State4#state.queued_task_count)
 	after
-		application:set_env(arweave, config, OriginalConfig)
+		arweave_config:set_env(OriginalConfig)
 	end.
 
 test_update_active() ->

--- a/apps/arweave/src/ar_device_lock.erl
+++ b/apps/arweave/src/ar_device_lock.erl
@@ -103,7 +103,7 @@ start_link() ->
 
 init([]) ->
 	gen_server:cast(self(), initialize_state),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 
 	State = #state{
 		num_replica_2_9_workers = Config#config.replica_2_9_workers,
@@ -170,7 +170,7 @@ terminate(Reason, _State) ->
 %%%===================================================================
 
 initialize_state(State) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StorageModules = Config#config.storage_modules,
 	RepackInPlaceModules = [element(1, El)
 			|| El <- Config#config.repack_in_place_storage_modules],
@@ -196,7 +196,7 @@ initialize_state(State) ->
 	State2.
 
 get_system_device(StorageModule) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StoreID = ar_storage_module:id(StorageModule),
 	Path = ar_chunk_storage:get_chunk_storage_path(Config#config.data_dir, StoreID),
 	Device = ar_util:get_system_device(Path),

--- a/apps/arweave/src/ar_disk_cache.erl
+++ b/apps/arweave/src/ar_disk_cache.erl
@@ -34,7 +34,7 @@ lookup_block_filename(H) when is_binary(H)->
 	PathBlock =
 		case get(ar_disk_cache_path) of
 			undefined ->
-				{ok, Config} = application:get_env(arweave, config),
+				{ok, Config} = arweave_config:get_env(),
 				Path = filename:join(Config#config.data_dir, ?DISK_CACHE_DIR),
 				put(ar_disk_cache_path, Path),
 				filename:join(Path, ?DISK_CACHE_BLOCK_DIR);
@@ -60,7 +60,7 @@ lookup_block_filename(H) when is_binary(H)->
 lookup_tx_filename(Hash) when is_binary(Hash) ->
 	PathTX = case get(ar_disk_cache_path) of
 		undefined ->
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			Path = filename:join(Config#config.data_dir, ?DISK_CACHE_DIR),
 			put(ar_disk_cache_path, Path),
 			filename:join(Path, ?DISK_CACHE_TX_DIR);
@@ -142,7 +142,7 @@ start_link() ->
 init([]) ->
 	%% Trap exit to avoid corrupting any open files on quit.
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Path = filename:join(Config#config.data_dir, ?DISK_CACHE_DIR),
 	BlockPath = filename:join(Path, ?DISK_CACHE_BLOCK_DIR),
 	TXPath = filename:join(Path, ?DISK_CACHE_TX_DIR),
@@ -282,12 +282,12 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 
 get_block_path() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Path = filename:join(Config#config.data_dir, ?DISK_CACHE_DIR),
 	filename:join(Path, ?DISK_CACHE_BLOCK_DIR).
 
 get_tx_path() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Path = filename:join(Config#config.data_dir, ?DISK_CACHE_DIR),
 	filename:join(Path, ?DISK_CACHE_TX_DIR).
 

--- a/apps/arweave/src/ar_disksup.erl
+++ b/apps/arweave/src/ar_disksup.erl
@@ -48,7 +48,7 @@ start_link() ->
 	gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 get_disk_space_check_frequency() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.disk_space_check_frequency.
 
 get_disk_data() ->
@@ -419,7 +419,7 @@ skip_to_eol([_ | T]) ->
 	skip_to_eol(T).
 
 get_storage_modules_paths() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	SMDirs = lists:map(
 		fun(StorageModule) ->

--- a/apps/arweave/src/ar_doctor_bench.erl
+++ b/apps/arweave/src/ar_doctor_bench.erl
@@ -47,7 +47,7 @@ bench_read(Args) ->
 		data_dir = DataDir,
 		storage_modules = StorageModules,
 		mining_addr = Address},
-	application:set_env(arweave, config, Config),
+	arweave_config:set_env(Config),
 
 	ar_kv_sup:start_link(),
 	ar_storage_sup:start_link(),

--- a/apps/arweave/src/ar_doctor_dump.erl
+++ b/apps/arweave/src/ar_doctor_dump.erl
@@ -24,7 +24,7 @@ dump([IncludeTXs, H, MinHeight, DataDir, OutputDir]) ->
 	ok = filelib:ensure_dir(filename:join([OutputDir, "txs", "dummy"])),
 
 	Config = #config{data_dir = DataDir},
-	application:set_env(arweave, config, Config),
+	arweave_config:set_env(Config),
 	ar_kv_sup:start_link(),
 	ar_storage_sup:start_link(),
 

--- a/apps/arweave/src/ar_doctor_inspect.erl
+++ b/apps/arweave/src/ar_doctor_inspect.erl
@@ -21,7 +21,7 @@ main(Args) ->
 			true;
 		["chunks", Dir, StartStr, EndStr | AddrListStr] when length(AddrListStr) >= 1 ->
 			Addresses = [ar_util:decode(AddrStr) || AddrStr <- AddrListStr],
-			application:set_env(arweave, config, #config{
+			arweave_config:set_env(#config{
 				disable = [], enable  = [randomx_large_pages]
 			}),
 			ar_metrics:register(),
@@ -225,7 +225,7 @@ bitmap(DataDir, StorageModuleConfig) ->
 	Config = #config{
 		data_dir = DataDir,
 		storage_modules = [StorageModule]},
-	application:set_env(arweave, config, Config),
+	arweave_config:set_env(Config),
 
 	StoreID = ar_storage_module:id(StorageModule),
 	

--- a/apps/arweave/src/ar_entropy_gen.erl
+++ b/apps/arweave/src/ar_entropy_gen.erl
@@ -44,7 +44,7 @@ name(StoreID) ->
 	list_to_atom("ar_entropy_gen_" ++ ar_storage_module:label(StoreID)).
 
 register_workers(Module) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ConfiguredWorkers = lists:filtermap(
 		fun(StorageModule) ->
 				StoreID = ar_storage_module:id(StorageModule),

--- a/apps/arweave/src/ar_entropy_storage.erl
+++ b/apps/arweave/src/ar_entropy_storage.erl
@@ -414,7 +414,7 @@ test_replica_2_9() ->
 			{ar_block:partition_size(), 0, Packing},
 			{ar_block:partition_size(), 1, Packing}
 	],
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
 		ar_test_node:start(#{ reward_addr => RewardAddr, storage_modules => StorageModules }),
 		StoreID1 = ar_storage_module:id(lists:nth(1, StorageModules)),
@@ -475,7 +475,7 @@ test_replica_2_9() ->
 		assert_get(P5, 16 * ?DATA_CHUNK_SIZE, StoreID2),
 		?assertNotEqual(Entropy4, Entropy5)
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end.
 
 assert_get(Expected, Offset, StoreID) ->

--- a/apps/arweave/src/ar_global_sync_record.erl
+++ b/apps/arweave/src/ar_global_sync_record.erl
@@ -71,7 +71,7 @@ get_serialized_sync_buckets() ->
 
 init([]) ->
 	ok = ar_events:subscribe(sync_record),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	SyncRecord = lists:foldl(
 		fun(Module, Acc) ->
 			case Module of

--- a/apps/arweave/src/ar_header_sync.erl
+++ b/apps/arweave/src/ar_header_sync.erl
@@ -62,7 +62,7 @@ init([]) ->
 	%% Trap exit to avoid corrupting any open files on quit..
 	process_flag(trap_exit, true),
 	[ok, ok] = ar_events:subscribe([tx, disksup]),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ok = ar_kv:open(filename:join(?ROCKS_DB_DIR, "ar_header_sync_db"), ?MODULE),
 	{SyncRecord, Height, CurrentBI} =
 		case ar_storage:read_term(header_sync_state) of
@@ -272,7 +272,7 @@ handle_info({event, tx, _}, State) ->
 
 handle_info({event, disksup, {remaining_disk_space, ?DEFAULT_MODULE, true, _Percentage, Bytes}},
 		State) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DiskPoolSize = Config#config.max_disk_pool_buffer_mb * 1024 * 1024,
 	DiskCacheSize = Config#config.disk_cache_size * 1048576,
 	BufferSize = 10_000_000_000,

--- a/apps/arweave/src/ar_http.erl
+++ b/apps/arweave/src/ar_http.erl
@@ -47,7 +47,7 @@ req(Args) ->
 req2(#{ peer := {_, _} } = Args) ->
 	req(Args, false);
 req2(#{ peer := Peer } = Args) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.port == element(5, Peer) of
 		true ->
 			%% Do not block requests to self.
@@ -262,7 +262,7 @@ terminate(Reason, #state{ status_by_pid = StatusByPID }) ->
 %%% ==================================================================
 
 open_connection(#{ peer := Peer } = Args) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{IPOrHost, Port} = get_ip_port(Peer),
 	ConnectTimeout = maps:get(connect_timeout, Args,
 			maps:get(timeout, Args, ?HTTP_REQUEST_CONNECT_TIMEOUT)),
@@ -420,7 +420,7 @@ await_response( #{ pid := PID, stream_ref := Ref, timeout := Timeout
 	end.
 
 log(Type, Event, #{method := Method, peer := Peer, path := Path}, Reason) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(http_logging, Config#config.enable) of
 		true when Type == warn ->
 			?LOG_WARNING([

--- a/apps/arweave/src/ar_http_iface_client.erl
+++ b/apps/arweave/src/ar_http_iface_client.erl
@@ -1414,16 +1414,16 @@ handle_cm_noop_response(Response) ->
 	{error, Response}.
 
 p2p_headers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	[{<<"x-p2p-port">>, integer_to_binary(Config#config.port)},
 			{<<"x-release">>, integer_to_binary(?RELEASE_NUMBER)}].
 
 cm_p2p_headers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	add_header(<<"x-cm-api-secret">>, Config#config.cm_api_secret, p2p_headers()).
 
 pool_client_headers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Headers = add_header(<<"x-pool-api-key">>, Config#config.pool_api_key, p2p_headers()),
 	case Config#config.pool_worker_name of
 		not_set ->

--- a/apps/arweave/src/ar_http_iface_middleware.erl
+++ b/apps/arweave/src/ar_http_iface_middleware.erl
@@ -91,7 +91,7 @@ handle(Req, Pid) ->
 handle(Peer, Req, Pid) ->
 	Method = cowboy_req:method(Req),
 	SplitPath = ar_http_iface_server:split_path(cowboy_req:path(Req)),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(http_logging, Config#config.enable) of
 		true ->
 			?LOG_INFO([
@@ -283,7 +283,7 @@ handle(<<"GET">>, [<<"unconfirmed_tx2">>, Hash], Req, _Pid) ->
 %% served as HTML.
 %% GET request to endpoint /tx/{hash}/data.html
 handle(<<"GET">>, [<<"tx">>, Hash, << "data.", _/binary >>], Req, _Pid) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(serve_html_data, Config#config.disable) of
 		true ->
 			{421, #{}, <<"Serving HTML data is disabled on this node.">>, Req};
@@ -1909,7 +1909,7 @@ handle_post_tx({Req, Pid, Encoding}) ->
 		false ->
 			not_joined(Req);
 		true ->
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			case ar_semaphore:acquire(post_tx, Config#config.post_tx_timeout * 1000) of
 				{error, timeout} ->
 					{503, #{}, <<>>, Req};
@@ -2065,7 +2065,7 @@ handle_get_chunk(OffsetBinary, Req, Encoding) ->
 								ok = ar_semaphore:acquire(get_chunk, ?DEFAULT_CALL_TIMEOUT),
 								{Packing, ok};
 							{{true, _}, _StoreID} ->
-								{ok, Config} = application:get_env(arweave, config),
+								{ok, Config} = arweave_config:get_env(),
 								case lists:member(pack_served_chunks, Config#config.enable) of
 									false ->
 										{none, {reply, {404, #{}, <<>>, Req}}};
@@ -2296,12 +2296,12 @@ handle_post_chunk(validate_proof, Proof, Req) ->
 	end.
 
 check_internal_api_secret(Req) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	check_api_secret(
 		<<"x-internal-api-secret">>, Config#config.internal_api_secret, <<"Internal API">>, Req).
 
 check_cm_api_secret(Req) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	check_api_secret(<<"x-cm-api-secret">>, Config#config.cm_api_secret, <<"CM API">>, Req).
 
 check_api_secret(Header, Secret, APIName, Req) ->
@@ -2541,7 +2541,7 @@ check_block_receive_timestamp(H) ->
 	end.
 
 handle_post_partial_solution(Req, Pid) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	CMExitNode = ar_coordination:is_exit_peer() andalso ar_pool:is_client(),
 	case {Config#config.is_pool_server, CMExitNode} of
 		{false, false} ->
@@ -2592,7 +2592,7 @@ handle_post_partial_solution_cm_exit_peer_pool_client(Req, Pid) ->
 	end.
 
 handle_get_jobs(PrevOutput, Req) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	CMExitNode = ar_coordination:is_exit_peer() andalso ar_pool:is_client(),
 	case {Config#config.is_pool_server, CMExitNode} of
 		{false, false} ->
@@ -2786,7 +2786,7 @@ process_request(get_block, [Type, ID, <<"wallet_list">>], Req) ->
 		unavailable ->
 			{404, #{}, <<"Not Found.">>, Req};
 		B ->
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			case {B#block.height >= ar_fork:height_2_2(),
 					lists:member(serve_wallet_lists, Config#config.enable)} of
 				{true, false} ->
@@ -2821,7 +2821,7 @@ process_request(get_block, [Type, ID, <<"wallet_list">>], Req) ->
 %% field :: nonce | previous_block | timestamp | last_retarget | diff | height | hash |
 %%			indep_hash | txs | hash_list | wallet_list | reward_addr | tags | reward_pool
 process_request(get_block, [Type, ID, Field], Req) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(subfield_queries, Config#config.enable) of
 		true ->
 			case find_block(Type, ID) of
@@ -3160,7 +3160,7 @@ handle_post_vdf3(Req, Pid, Peer) ->
 	end.
 
 handle_get_vdf(Req, Call, Format) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(public_vdf_server, Config#config.enable) of
 		true ->
 			handle_get_vdf2(Req, Call, Format);

--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -45,7 +45,7 @@ init(_) ->
 	% if something goes wrong, the connections must
 	% be cleaned before leaving.
 	erlang:process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case start_http_iface_listener(Config) of
 		{ok, Pid} -> {ok, Pid};
 		Elsewise -> {error, Elsewise}

--- a/apps/arweave/src/ar_join.erl
+++ b/apps/arweave/src/ar_join.erl
@@ -71,7 +71,7 @@ start2(Peers) ->
 		ExpectedBIMerkleH ->
 			do_join(Peers, B, BI);
 		_ ->
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			ID = binary_to_list(ar_util:encode(crypto:strong_rand_bytes(16))),
 			File = filename:join(Config#config.data_dir,
 					"inconsistent_joining_data_dump_" ++ ID),
@@ -229,7 +229,7 @@ get_block(Peers, BShadow, [TXID | TXIDs], TXs, Retries) ->
 %% @doc Perform the joining process.
 do_join(Peers, B, BI) ->
 	ar:console("Downloading the block trail.~n", []),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	WorkerQ = queue:from_list([spawn(fun() -> worker() end)
 			|| _ <- lists:seq(1, Config#config.join_workers)]),
 	PeerQ = queue:from_list(Peers),

--- a/apps/arweave/src/ar_kv.erl
+++ b/apps/arweave/src/ar_kv.erl
@@ -267,7 +267,7 @@ count(Name) ->
 
 init([]) ->
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	S0 = #state{
 		db_flush_timer = #timer{interval_ms = Config#config.rocksdb_flush_interval_s * 1000},
 		wal_sync_timer = #timer{interval_ms = Config#config.rocksdb_wal_sync_interval_s * 1000}
@@ -602,13 +602,13 @@ with_each_db(Callback) ->
 
 
 get_data_dir() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.data_dir.
 
 
 
 get_base_log_dir() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.log_dir.
 
 

--- a/apps/arweave/src/ar_mine_randomx.erl
+++ b/apps/arweave/src/ar_mine_randomx.erl
@@ -177,7 +177,7 @@ packing_rounds({spora_2_6, _Addr}) ->
 	?RANDOMX_PACKING_ROUNDS_2_6.
 
 jit() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(randomx_jit, Config#config.disable) of
 		true ->
 			0;
@@ -186,7 +186,7 @@ jit() ->
 	end.
 
 large_pages() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(randomx_large_pages, Config#config.enable) of
 		true ->
 			1;
@@ -195,7 +195,7 @@ large_pages() ->
 	end.
 
 hardware_aes() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(randomx_hardware_aes, Config#config.disable) of
 		true ->
 			0;

--- a/apps/arweave/src/ar_mining_hash.erl
+++ b/apps/arweave/src/ar_mining_hash.erl
@@ -44,7 +44,7 @@ garbage_collect() ->
 %%%===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	State = lists:foldl(
 		fun(_, Acc) -> start_hashing_thread(Acc) end,
 		#state{},

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -52,7 +52,7 @@ is_recall_range_readable(Candidate, RecallRangeStart) ->
 			{is_recall_range_readable, Candidate, RecallRangeStart}, 60000).
 
 get_packing() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	%% ar_config:validate_storage_modules/1 ensures that we only mine against a single
 	%% packing format. So we can grab it any partition.
 	case Config#config.storage_modules of
@@ -63,7 +63,7 @@ get_packing() ->
 get_partitions(PartitionUpperBound) when PartitionUpperBound =< 0 ->
 	[];
 get_partitions(PartitionUpperBound) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Max = ar_node:get_max_partition_number(PartitionUpperBound),
 	AllPartitions = lists:foldl(
 		fun	(Module, Acc) ->

--- a/apps/arweave/src/ar_mining_server.erl
+++ b/apps/arweave/src/ar_mining_server.erl
@@ -479,7 +479,7 @@ calculate_cache_limits(NumActivePartitions, PackingDifficulty) ->
 		(?IDEAL_STEPS_PER_PARTITION * IdealRangesPerStep * RecallRangeSize * NumActivePartitions)
 	),
 
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	OverallCacheLimitBytes = case Config#config.mining_cache_size_mb of
 		undefined ->
 			MinimumCacheLimitBytes;
@@ -975,7 +975,7 @@ post_solution(error, _State) ->
 	?LOG_WARNING([{event, found_solution_but_could_not_build_a_block}]),
 	error;
 post_solution(Solution, State) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	post_solution(Config#config.cm_exit_peer, Solution, State).
 
 post_solution(not_set, Solution, #state{ is_pool_client = true }) ->
@@ -1177,7 +1177,7 @@ read_poa(RecallByte, ChunkOrSubChunk, Packing, Nonce) ->
 	end.
 
 dump_invalid_solution_data(Data) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ID = binary_to_list(ar_util:encode(crypto:strong_rand_bytes(16))),
 	File = filename:join(Config#config.data_dir, "invalid_solution_data_dump_" ++ ID),
 	file:write_file(File, term_to_binary(Data)).
@@ -1351,11 +1351,11 @@ pause() ->
 	gen_server:cast(?MODULE, pause).
 
 setup() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config.
 
 cleanup(Config) ->
-	application:set_env(arweave, config, Config).
+	arweave_config:set_env(Config).
 
 calculate_cache_limits_test_() ->
 	{setup, fun setup/0, fun cleanup/1,
@@ -1367,8 +1367,8 @@ calculate_cache_limits_test_() ->
 	}.
 
 test_calculate_cache_limits_default() ->
-	{ok, Config} = application:get_env(arweave, config),
-	application:set_env(arweave, config, Config#config{
+	{ok, Config} = arweave_config:get_env(),
+	arweave_config:set_env(Config#config{
 		mining_cache_size_mb = undefined
 	}),
 	?assertEqual(
@@ -1481,8 +1481,8 @@ test_calculate_cache_limits_default() ->
 	).
 
 test_calculate_cache_limits_custom_low() ->
-	{ok, Config} = application:get_env(arweave, config),
-	application:set_env(arweave, config, Config#config{
+	{ok, Config} = arweave_config:get_env(),
+	arweave_config:set_env(Config#config{
 		mining_cache_size_mb = 1
 	}),
 	?assertEqual(
@@ -1535,8 +1535,8 @@ test_calculate_cache_limits_custom_low() ->
 	).
 
 test_calculate_cache_limits_custom_high() ->
-	{ok, Config} = application:get_env(arweave, config),
-	application:set_env(arweave, config, Config#config{
+	{ok, Config} = arweave_config:get_env(),
+	arweave_config:set_env(Config#config{
 		mining_cache_size_mb = 500_000
 	}),
 	?assertEqual(

--- a/apps/arweave/src/ar_mining_stats.erl
+++ b/apps/arweave/src/ar_mining_stats.erl
@@ -442,7 +442,7 @@ optimal_partition_hash_hps(PoA1Multiplier, VDFSpeed, PartitionDataSize, TotalDat
 	H1Optimal + H2Optimal.
 
 generate_report() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Height = ar_node:get_height(),
 	Packing = ar_mining_io:get_packing(),
 	Partitions = ar_mining_io:get_partitions(),
@@ -971,10 +971,11 @@ test_vdf_stats() ->
 	?assertEqual(undefined, vdf_speed(1000)).
 
 test_data_size_stats() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
-		application:set_env(arweave, config,
-			Config#config{ mining_addr = <<"MINING">> }),
+		arweave_config:set_env(Config#config{
+			mining_addr = <<"MINING">>
+		}),
 
 		WeaveSize = floor(2 * ar_block:partition_size()),
 		ets:insert(node_state, [{weave_size, WeaveSize}]),
@@ -984,11 +985,11 @@ test_data_size_stats() ->
 		do_test_data_size_stats(Config, {composite, <<"MINING">>, 1}, {composite, <<"PACKING">>, 1}),
 		do_test_data_size_stats(Config, {composite, <<"MINING">>, 2}, {composite, <<"PACKING">>, 2})
 	after
-		application:set_env(arweave, config, Config)
+		arweave_config:set_env(Config)
 	end.
 
 do_test_data_size_stats(Config, Mining, Packing) ->
-	application:set_env(arweave, config, Config#config{ 
+	arweave_config:set_env(Config#config{ 
 		storage_modules = [
 			{floor(0.1 * ar_block:partition_size()), 10, unpacked},
 			{floor(0.1 * ar_block:partition_size()), 10, Mining},
@@ -1311,7 +1312,7 @@ test_report_poa1_multiple_2() ->
 	test_report({composite, <<"MINING">>, 2}, {composite, <<"PACKING">>, 2}, 2).
 
 test_report(Mining, Packing, PoA1Multiplier) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	MiningAddress = case Mining of
 		{spora_2_6, Addr} ->
 			Addr;
@@ -1353,11 +1354,10 @@ test_report(Mining, Packing, PoA1Multiplier) ->
 	],
 	
 	try	
-		application:set_env(arweave, config,
-			Config#config{
-				storage_modules = StorageModules,
-				mining_addr = MiningAddress
-			}),
+		arweave_config:set_env(Config#config{
+			storage_modules = StorageModules,
+			mining_addr = MiningAddress
+		}),
 		ar_mining_stats:pause_performance_reports(120000),
 		reset_all_stats(),
 		Partitions = [
@@ -1525,5 +1525,5 @@ test_report(Mining, Packing, PoA1Multiplier) ->
 		},
 		Report2)
 	after
-		application:set_env(arweave, config, Config)
+		arweave_config:set_env(Config)
 	end.

--- a/apps/arweave/src/ar_mining_worker.erl
+++ b/apps/arweave/src/ar_mining_worker.erl
@@ -377,7 +377,7 @@ handle_task({computed_h1, Candidate, _ExtraArgs}, State) ->
 				%% This node does not store chunk2. If we're part of a coordinated
 				%% mining set, we can try one of our peers, but this node is done with
 				%% this VDF step.
-				{ok, Config} = application:get_env(arweave, config),
+				{ok, Config} = arweave_config:get_env(),
 				case Config#config.coordinated_mining of
 					false -> ok;
 					true ->

--- a/apps/arweave/src/ar_node_sup.erl
+++ b/apps/arweave/src/ar_node_sup.erl
@@ -90,7 +90,7 @@ ar_blacklist_middleware_spec() ->
 %% configuration.
 %%--------------------------------------------------------------------
 ar_semaphores_spec() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Semaphores = Config#config.semaphores,
 	[ ar_semaphore_spec(Name, N) || {Name, N} <- maps:to_list(Semaphores) ].
 

--- a/apps/arweave/src/ar_nonce_limiter.erl
+++ b/apps/arweave/src/ar_nonce_limiter.erl
@@ -186,7 +186,7 @@ validate_last_step_checkpoints(#block{
 			PrevOutput2 = ar_nonce_limiter:maybe_add_entropy(
 				PrevOutput, PrevBStepNumber, StepNumber, Seed),
 			PrevStepNumber = StepNumber - 1,
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			ThreadCount = Config#config.max_nonce_limiter_last_step_validation_thread_count,
 			case verify_no_reset(PrevStepNumber, PrevOutput2, 1,
 					lists:reverse(LastStepCheckpoints), ThreadCount, VDFDifficulty) of
@@ -326,7 +326,7 @@ request_validation(H, #nonce_limiter_info{ output = Output,
 					end,
 					spawn(fun() ->
 						StartStepNumber2 = StartStepNumber + NumAlreadyComputed,
-						{ok, Config} = application:get_env(arweave, config),
+						{ok, Config} = arweave_config:get_env(),
 						ThreadCount = Config#config.max_nonce_limiter_validation_thread_count,
 						Result =
 							case is_integer(EntropyResetPoint) andalso
@@ -805,7 +805,7 @@ send_output(SessionKey, Session) ->
 	ar_events:send(nonce_limiter, {computed_output, {SessionKey, StepNumber, Output, UpperBound}}).
 
 dump_error(Data) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ErrorID = binary_to_list(ar_util:encode(crypto:strong_rand_bytes(8))),
 	ErrorDumpFile = filename:join(Config#config.data_dir, "error_dump_" ++ ErrorID),
 	file:write_file(ErrorDumpFile, term_to_binary(Data)),
@@ -1359,7 +1359,7 @@ send_events_for_external_update(SessionKey, Session) ->
 		Session#vdf_session{ step_number = StepNumber-1, steps = RemainingSteps }).
 
 debug_double_check(Label, Result, Func, Args) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(double_check_nonce_limiter, Config#config.enable) of
 		false ->
 			Result;

--- a/apps/arweave/src/ar_nonce_limiter_client.erl
+++ b/apps/arweave/src/ar_nonce_limiter_client.erl
@@ -59,7 +59,7 @@ init([]) ->
 		true ->
 			gen_server:cast(?MODULE, pull)
 	end,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{ok, #state{ remote_servers = queue:from_list(Config#config.nonce_limiter_server_trusted_peers) }}.
 
 handle_call(Request, _From, State) ->

--- a/apps/arweave/src/ar_nonce_limiter_sup.erl
+++ b/apps/arweave/src/ar_nonce_limiter_sup.erl
@@ -21,7 +21,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ServerWorkers = lists:map(
 		fun(Peer) ->
 			Name = list_to_atom("ar_nonce_limiter_server_worker_"

--- a/apps/arweave/src/ar_p3.erl
+++ b/apps/arweave/src/ar_p3.erl
@@ -51,7 +51,7 @@ get_rates_json() ->
 %%%===================================================================
 init([]) ->
 	ok = ar_events:subscribe(node_state),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ar_p3_config:validate_config(Config).
 
 handle_call({allow_request, Req}, _From, State) ->

--- a/apps/arweave/src/ar_packing_server.erl
+++ b/apps/arweave/src/ar_packing_server.erl
@@ -270,7 +270,7 @@ pack_replica_2_9_chunk(RewardAddr, AbsoluteEndOffset, Chunk) ->
 %%%===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 
 	ar:console("~nInitialising RandomX datasets. Keys: ~p, ~p. "
 			"The process may take several minutes.~n",

--- a/apps/arweave/src/ar_peer_intervals.erl
+++ b/apps/arweave/src/ar_peer_intervals.erl
@@ -50,7 +50,7 @@ fetch(Start, End, StoreID) ->
 			UnsyncedIntervals = get_unsynced_intervals(Start, End2, StoreID),
 
 			Bucket = Start div ?NETWORK_DATA_BUCKET_SIZE,
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			AllPeers =
 				case Config#config.sync_from_local_peers_only of
 					true ->

--- a/apps/arweave/src/ar_peers.erl
+++ b/apps/arweave/src/ar_peers.erl
@@ -217,7 +217,7 @@ resolve_peers([RawPeer | Peers]) ->
 	end.
 
 get_trusted_peers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.peers of
 		[] ->
 			ArweavePeers = [
@@ -233,7 +233,7 @@ get_trusted_peers() ->
 	end.
 -else.
 get_trusted_peers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.peers.
 -endif.
 
@@ -376,7 +376,7 @@ resolve_and_cache_peer(RawPeer, Type) ->
 %%%===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.verify of
 		false ->
 			%% Trap exit to avoid corrupting any open files on quit.
@@ -715,7 +715,7 @@ ping_peers(Peers) ->
 %% Do not filter out loopback IP addresses with custom port in the debug mode
 %% to allow multiple local VMs to peer with each other.
 is_loopback_ip({127, _, _, _, Port}) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Port == Config#config.port;
 is_loopback_ip({_, _, _, _, _}) ->
 	false.

--- a/apps/arweave/src/ar_poller.erl
+++ b/apps/arweave/src/ar_poller.erl
@@ -61,7 +61,7 @@ init(Workers) ->
 		false ->
 			ok
 	end,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{ok, #state{ 
 		workers = Workers,
 		worker_count = length(Workers),
@@ -97,7 +97,7 @@ handle_cast(collect_peers, State) ->
 
 handle_cast({peer_out_of_sync_timeout, Peer}, State) ->
 	#state{ in_sync_trusted_peers = Set } = State,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(Peer, Config#config.peers) of
 		false ->
 			{noreply, State};
@@ -107,7 +107,7 @@ handle_cast({peer_out_of_sync_timeout, Peer}, State) ->
 
 handle_cast({peer_out_of_sync, Peer}, State) ->
 	#state{ in_sync_trusted_peers = Set } = State,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(Peer, Config#config.peers) of
 		false ->
 			{noreply, State};

--- a/apps/arweave/src/ar_poller_sup.erl
+++ b/apps/arweave/src/ar_poller_sup.erl
@@ -21,7 +21,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Children = lists:map(
 		fun(Num) ->
 			Name = list_to_atom("ar_poller_worker_" ++ integer_to_list(Num)),

--- a/apps/arweave/src/ar_poller_worker.erl
+++ b/apps/arweave/src/ar_poller_worker.erl
@@ -28,7 +28,7 @@ start_link(Name) ->
 %%%===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	[ok] = ar_events:subscribe([node_state]),
 	State = #state{ polling_frequency_ms = Config#config.polling * 1000 },
 	case ar_node:is_joined() of
@@ -201,7 +201,7 @@ slow_block_application_warning(N) ->
 			"paused.~n~n", [N]).
 
 warning(Peer, Event) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(Peer, Config#config.peers) of
 		false ->
 			ok;

--- a/apps/arweave/src/ar_pool.erl
+++ b/apps/arweave/src/ar_pool.erl
@@ -66,7 +66,7 @@ start_link() ->
 
 %% @doc Return true if we are a pool client.
 is_client() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.is_pool_client == true.
 
 %% @doc Return a list of up to two most recently cached VDF session key, seed pairs.
@@ -97,13 +97,13 @@ post_partial_solution(Solution) ->
 
 %% @doc Return the pool server as a "peer" recognized by ar_http_iface_client.
 pool_peer() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{pool, Config#config.pool_server_address}.
 
 %% @doc Process the set of coordinated mining jobs received from the pool.
 process_cm_jobs(Jobs, Peer) ->
 	#pool_cm_jobs{ h1_to_h2_jobs = H1ToH2Jobs, h1_read_jobs = H1ReadJobs } = Jobs,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Partitions = ar_mining_io:get_partitions(infinity),
 	case Config#config.mine of
 		true ->

--- a/apps/arweave/src/ar_pool_cm_job_poller.erl
+++ b/apps/arweave/src/ar_pool_cm_job_poller.erl
@@ -73,7 +73,7 @@ terminate(Reason, _State) ->
 %%%===================================================================
 
 push_cm_jobs_to_cm_peers(Jobs) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Peers = Config#config.cm_peers,
 	Payload = ar_serialize:jsonify(ar_serialize:pool_cm_jobs_to_json_struct(Jobs)),
 	push_cm_jobs_to_cm_peers(Payload, Peers).

--- a/apps/arweave/src/ar_pool_job_poller.erl
+++ b/apps/arweave/src/ar_pool_job_poller.erl
@@ -39,7 +39,7 @@ handle_call(Request, _From, State) ->
 
 handle_cast(fetch_jobs, State) ->
 	PrevOutput = (ar_pool:get_latest_job())#job.output,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Peer =
 		case {Config#config.coordinated_mining, Config#config.cm_exit_peer} of
 			{true, not_set} ->

--- a/apps/arweave/src/ar_rate_limiter.erl
+++ b/apps/arweave/src/ar_rate_limiter.erl
@@ -26,7 +26,7 @@ start_link() ->
 %% @doc Hang until it is safe to make another request to the given Peer with the given Path.
 %% The limits are configured in include/ar_blacklist_middleware.hrl.
 throttle(Peer, Path) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(Peer, Config#config.local_peers) of
 		true ->
 			ok;

--- a/apps/arweave/src/ar_repack.erl
+++ b/apps/arweave/src/ar_repack.erl
@@ -62,7 +62,7 @@ name(StoreID) ->
 	list_to_atom("ar_repack_" ++ ar_storage_module:label(StoreID)).
 
 register_workers() ->
-    {ok, Config} = application:get_env(arweave, config),
+    {ok, Config} = arweave_config:get_env(),
     
     RepackInPlaceWorkers = lists:flatmap(
         fun({StorageModule, Packing}) ->
@@ -100,7 +100,7 @@ init({StoreID, ToPacking}) ->
 	PaddedModuleEnd = ar_block:get_chunk_padded_offset(ModuleEnd),
     Cursor = read_cursor(StoreID, ToPacking, ModuleStart),
 
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	BatchSize = Config#config.repack_batch_size,
 	CacheSize = Config#config.repack_cache_size_mb,
 	NumEntropyOffsets = calculate_num_entropy_offsets(CacheSize, BatchSize),

--- a/apps/arweave/src/ar_repack_io.erl
+++ b/apps/arweave/src/ar_repack_io.erl
@@ -34,7 +34,7 @@ name(StoreID) ->
 	list_to_atom("ar_repack_io_" ++ ar_storage_module:label(StoreID)).
 
 init(StoreID) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ReadBatchSize = Config#config.repack_batch_size,
 	State = #state{ 
 		store_id = StoreID,

--- a/apps/arweave/src/ar_shutdown_manager.erl
+++ b/apps/arweave/src/ar_shutdown_manager.erl
@@ -209,7 +209,7 @@ list_connections(gun) ->
 		{_, P, _, _} <- supervisor:which_children(gun_sup)
 	]);
 list_connections(cowboy) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Filters = [{'=:=', peer_port, Config#config.port}],
 	SocketsInfo = connections(#{ filters => Filters }),
 	[ S || #{ socket := S } <- SocketsInfo ].
@@ -240,7 +240,7 @@ killers_connections_init(Sockets) ->
 
 killers_connections_loop([]) -> ok;
 killers_connections_loop(Killers) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	TcpTimeout = 1000*Config#config.shutdown_tcp_connection_timeout,
 	receive
 		{'EXIT', Pid, _} ->
@@ -289,7 +289,7 @@ killer_init(Socket) ->
 	?LOG_DEBUG([{socket, Socket}, {pid, self()}, {action, started}]),
 	erlang:process_flag(trap_exit, true),
 	erlang:link(Socket),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Mode = Config#config.shutdown_tcp_mode,
 	State = socket_info(Socket),
 	NewState = killer_loop(State#{

--- a/apps/arweave/src/ar_storage.erl
+++ b/apps/arweave/src/ar_storage.erl
@@ -423,7 +423,7 @@ read_account2(Addr, RootHash) ->
 	%% from the number in the latest block.
 	Size = ar_wallets:get_size(),
 	MaxFileCount = Size div ?WALLET_LIST_CHUNK_SIZE + 1,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	read_account(Addr, RootHash, 0, MaxFileCount, Config#config.data_dir, false).
 
 read_account(_Addr, _RootHash, Left, Right, _DataDir, _RightFileFound) when Left == Right ->
@@ -487,7 +487,7 @@ read_account2(Addr, RootHash, Pos, Left, _Right, DataDir, L, _RightFileFound) ->
 	end.
 
 lookup_block_filename(H) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Name = filename:join([Config#config.data_dir, ?BLOCK_DIR,
 			binary_to_list(ar_util:encode(H))]),
 	NameJSON = iolist_to_binary([Name, ".json"]),
@@ -946,7 +946,7 @@ read_wallet_list_chunk(RootHash) ->
 	read_wallet_list_chunk(RootHash, 0, ar_patricia_tree:new()).
 
 read_wallet_list_chunk(RootHash, Position, Tree) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Filename =
 		binary_to_list(iolist_to_binary([
 			Config#config.data_dir,
@@ -1044,7 +1044,7 @@ read_block_from_file(Filename, Encoding) ->
 
 init([]) ->
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ensure_directories(Config#config.data_dir),
 	%% Copy genesis transactions (snapshotted in the repo) into data_dir/txs
 	ar_weave:add_mainnet_v1_genesis_txs(),
@@ -1096,7 +1096,7 @@ block_index_tip() ->
 	end.
 
 write_block(B) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case lists:member(disk_logging, Config#config.enable) of
 		true ->
 			?LOG_INFO([{event, writing_block_to_disk},
@@ -1145,7 +1145,7 @@ parse_block_binary(Bin) ->
 	end.
 
 filepath(PathComponents) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	to_string(filename:join([Config#config.data_dir | PathComponents])).
 
 to_string(Bin) when is_binary(Bin) ->
@@ -1164,7 +1164,7 @@ ensure_directories(DataDir) ->
 	filelib:ensure_dir(filename:join([DataDir, ?TX_DIR, "migrated_v1"]) ++ "/").
 
 get_same_disk_storage_modules_total_size() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	{ok, Info} = file:read_file_info(DataDir),
 	Device = Info#file_info.major_device,
@@ -1226,7 +1226,7 @@ write_file_atomic(Filename, Data) ->
 	end.
 
 write_term(Name, Term) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	write_term(DataDir, Name, Term, override).
 
@@ -1252,7 +1252,7 @@ write_term(Dir, Name, Term, Override) ->
 	end.
 
 read_term(Name) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	read_term(DataDir, Name).
 
@@ -1270,7 +1270,7 @@ read_term(Dir, Name) ->
 	end.
 
 delete_term(Name) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	file:delete(filename:join(DataDir, atom_to_list(Name))).
 

--- a/apps/arweave/src/ar_storage_module.erl
+++ b/apps/arweave/src/ar_storage_module.erl
@@ -127,7 +127,7 @@ packing_label(Packing) ->
 get_by_id(?DEFAULT_MODULE) ->
 	?DEFAULT_MODULE;
 get_by_id(ID) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	RepackInPlaceModules = [element(1, El)
 			|| El <- Config#config.repack_in_place_storage_modules],
 	get_by_id(ID, Config#config.storage_modules ++ RepackInPlaceModules).
@@ -143,7 +143,7 @@ get_by_id(ID, [Module | Modules]) ->
 	end.
 
 get_all_module_ranges() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	RepackInPlaceModulesStoreIDs = [
 			{{BucketSize, Bucket, TargetPacking}, ar_storage_module:id(Module)}
 		|| {{BucketSize, Bucket, _Packing} = Module, TargetPacking} <- Config#config.repack_in_place_storage_modules],
@@ -192,7 +192,7 @@ get_packing(ID) ->
 %% @doc Return a configured storage module covering the given Offset, preferably
 %% with the given Packing. Return not_found if none is found.
 get(Offset, Packing) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	get(Offset, Packing, Config#config.storage_modules, not_found).
 
 %% @doc Return a configured storage module with the given Packing covering the given Offset.
@@ -203,7 +203,7 @@ get_strict(Offset, Packing) ->
 
 %% @doc Return the list of all configured storage modules covering the given Offset.
 get_all(Offset) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	get_all(Offset, Config#config.storage_modules, []).
 
 %% @doc Return the list of identifiers of all configured storage modules
@@ -215,17 +215,17 @@ get_all_packed(Offset, Packing) ->
 %% @doc Return the list of configured storage modules whose ranges intersect
 %% the given interval.
 get_all(Start, End) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	get_all(Start, End, Config#config.storage_modules, []).
 
 %% @doc Return true if the given Offset belongs to at least one storage module.
 has_any(Offset) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	has_any(Offset, Config#config.storage_modules).
 
 %% @doc Return true if the given range is covered by the configured storage modules.
 has_range(Start, End) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case ets:lookup(?MODULE, unique_sorted_intervals) of
 		[] ->
 			Intervals = get_unique_sorted_intervals(Config#config.storage_modules),
@@ -253,7 +253,7 @@ has_range(Start, End) ->
 %% 3. returns [{7, 10, sm1}, {10, 20, sm_2}, {20, 25, sm_3}]
 %% 4. returns [{7, 10, sm1}, {10, 20, sm_4}, {20, 25, sm_3}]
 get_cover(Start, End, MaybeModule) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	SortedStorageModules = sort_storage_modules_by_left_bound(
 			Config#config.storage_modules, MaybeModule),
 	case get_cover2(Start, End, SortedStorageModules) of
@@ -266,7 +266,7 @@ get_cover(Start, End, MaybeModule) ->
 	end.
 
 is_repack_in_place(ID) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	lists:any(
 		fun({Module, _TargetPacking}) ->
 			ar_storage_module:id(Module) == ID
@@ -438,9 +438,9 @@ get_cover2(Start, End, [{BucketSize, Bucket, _Packing} = StorageModule | Storage
 %%%===================================================================
 
 label_test() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
-		application:set_env(arweave, config, Config#config{storage_modules = [
+		arweave_config:set_env(Config#config{storage_modules = [
 			{ar_block:partition_size(), 0, {spora_2_6, <<"a">>}},
 			{ar_block:partition_size(), 2, {spora_2_6, <<"a">>}},
 			{ar_block:partition_size(), 0, {spora_2_6, <<"b">>}},
@@ -474,7 +474,7 @@ label_test() ->
 		?assertEqual("storage_module_524288_3_composite_5",
 			label(id({524288, 3, {composite, <<"b">>, 2}})))
 	after
-		application:set_env(arweave, config, Config)
+		arweave_config:set_env(Config)
 	end.
 
 has_any_test() ->

--- a/apps/arweave/src/ar_sup.erl
+++ b/apps/arweave/src/ar_sup.erl
@@ -104,7 +104,7 @@ init([]) ->
 		?CHILD(ar_pool_cm_job_poller, worker),
 		?CHILD(ar_chain_stats, worker)
 	],
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DebugChildren = case Config#config.debug of
 		true -> [?CHILD(ar_process_sampler, worker)];
 		false -> []

--- a/apps/arweave/src/ar_sync_record_sup.erl
+++ b/apps/arweave/src/ar_sync_record_sup.erl
@@ -22,7 +22,7 @@ start_link() ->
 
 init([]) ->
 	ets:new(sync_records, [set, public, named_table, {read_concurrency, true}]),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ConfiguredWorkers = lists:map(
 		fun(StorageModule) ->
 			StoreID = ar_storage_module:id(StorageModule),

--- a/apps/arweave/src/ar_tx_blacklist.erl
+++ b/apps/arweave/src/ar_tx_blacklist.erl
@@ -332,7 +332,7 @@ terminate(Reason, _State) ->
 %%%===================================================================
 
 initialize_state() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	DataDir = Config#config.data_dir,
 	Dir = filename:join(DataDir, "ar_tx_blacklist"),
 	ok = filelib:ensure_dir(Dir ++ "/"),
@@ -353,7 +353,7 @@ initialize_state() ->
 	).
 
 refresh_blacklist() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	WhitelistFiles = Config#config.transaction_whitelist_files,
 	case load_from_files(WhitelistFiles) of
 		error ->
@@ -369,7 +369,7 @@ refresh_blacklist() ->
 	end.
 
 refresh_blacklist(Whitelist) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	BlacklistFiles = Config#config.transaction_blacklist_files,
 	case load_from_files(BlacklistFiles) of
 		error ->

--- a/apps/arweave/src/ar_tx_emitter.erl
+++ b/apps/arweave/src/ar_tx_emitter.erl
@@ -148,7 +148,7 @@ terminate(Reason, _State) ->
 %%%===================================================================
 
 max_propagation_peers() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Config#config.max_propagation_peers.
 
 emit(_Set, _Peers, _MaxPeers, N, State) when N =< 0 ->

--- a/apps/arweave/src/ar_tx_emitter_sup.erl
+++ b/apps/arweave/src/ar_tx_emitter_sup.erl
@@ -21,7 +21,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	MaxEmitters = Config#config.max_emitters,
 	Workers = lists:map(fun tx_workers/1, lists:seq(1, MaxEmitters)),
 	WorkerNames = [ Name || #{ id := Name } <- Workers],

--- a/apps/arweave/src/ar_tx_poller.erl
+++ b/apps/arweave/src/ar_tx_poller.erl
@@ -79,7 +79,7 @@ handle_info({event, node_state, {initialized, _}}, State) ->
 	%% Send a check_for_received_txs cast periodically to check for externally submitted
 	%% transactions. If there have not been any for longer than 30 seconds, request the
 	%% mempool from a peer and download the transactions.
-    {ok, Config} = application:get_env(arweave, config),
+    {ok, Config} = arweave_config:get_env(),
     case lists:member(tx_poller, Config#config.disable) of
         true ->
             ok;

--- a/apps/arweave/src/ar_vdf.erl
+++ b/apps/arweave/src/ar_vdf.erl
@@ -17,7 +17,7 @@ step_number_to_salt_number(StepNumber) ->
 compute(StartStepNumber, PrevOutput, IterationCount) ->
 	Salt = step_number_to_salt_number(StartStepNumber - 1),
 	SaltBinary = << Salt:256 >>,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.vdf of
 		openssl ->
 			ar_vdf_nif:vdf_sha2_nif(SaltBinary, PrevOutput, ?VDF_CHECKPOINT_COUNT_IN_STEP - 1, 0,

--- a/apps/arweave/src/ar_verify_chunks.erl
+++ b/apps/arweave/src/ar_verify_chunks.erl
@@ -43,7 +43,7 @@ name(StoreID) ->
 %%%===================================================================
 
 init(StoreID) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	?LOG_INFO([{event, verify_chunk_storage_started},
 		{store_id, StoreID}, {mode, Config#config.verify},
 		{chunk_samples, Config#config.verify_samples}]),

--- a/apps/arweave/src/ar_verify_chunks_sup.erl
+++ b/apps/arweave/src/ar_verify_chunks_sup.erl
@@ -21,7 +21,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Config#config.verify of
 		false ->
 			ignore;

--- a/apps/arweave/src/ar_wallet.erl
+++ b/apps/arweave/src/ar_wallet.erl
@@ -120,12 +120,12 @@ new_keyfile(KeyType, WalletName) ->
 	end.
 
 wallet_filepath(Wallet) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Filename = lists:flatten(["arweave_keyfile_", binary_to_list(Wallet), ".json"]),
 	filename:join([Config#config.data_dir, ?WALLET_DIR, Filename]).
 
 wallet_filepath2(Wallet) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Filename = lists:flatten([binary_to_list(Wallet), ".json"]),
 	filename:join([Config#config.data_dir, ?WALLET_DIR, Filename]).
 
@@ -307,7 +307,7 @@ base64_address_with_optional_checksum_to_decoded_address_safe(AddrBase64)->
 %% @doc Read a wallet of one of the given types from disk. Files modified later are prefered.
 %% If no file is found, create one of the type standing first in the list.
 get_or_create_wallet(Types) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	WalletDir = filename:join(Config#config.data_dir, ?WALLET_DIR),
 	Entries =
 		lists:reverse(lists:sort(filelib:fold_files(

--- a/apps/arweave/src/ar_watchdog.erl
+++ b/apps/arweave/src/ar_watchdog.erl
@@ -66,7 +66,7 @@ start_link() ->
 %%--------------------------------------------------------------------
 init([]) ->
 	process_flag(trap_exit, true),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	MinerLogging = not lists:member(miner_logging, Config#config.disable),
 	State = #state{ mined_blocks = maps:new(), miner_logging = MinerLogging },
 	{ok, State}.

--- a/apps/arweave/src/ar_weave.erl
+++ b/apps/arweave/src/ar_weave.erl
@@ -162,7 +162,7 @@ add_mainnet_v1_genesis_txs() ->
 	case filelib:is_dir("genesis_data/genesis_txs") of
 		true ->
 			{ok, Files} = file:list_dir("genesis_data/genesis_txs"),
-			{ok, Config} = application:get_env(arweave, config),
+			{ok, Config} = arweave_config:get_env(),
 			lists:foldl(
 				fun(F, Acc) ->
 					SourcePath = "genesis_data/genesis_txs/" ++ F,

--- a/apps/arweave/src/ar_webhook_sup.erl
+++ b/apps/arweave/src/ar_webhook_sup.erl
@@ -28,7 +28,7 @@ start_link() ->
 %% ===================================================================
 
 init([]) ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Children = lists:map(
 		fun
 			(Hook) when is_record(Hook, config_webhook) ->

--- a/apps/arweave/src/arweave_config.erl
+++ b/apps/arweave/src/arweave_config.erl
@@ -1,0 +1,35 @@
+%%%===================================================================
+%%% @doc Arweave Configuration Interface.
+%%%
+%%% `arweave_config' module is an interface to the Arweave
+%%% configuration data store where all configuration parameters are
+%%% stored and specified.
+%%%
+%%% @end
+%%%===================================================================
+-module(arweave_config).
+-export([
+	get_env/0,
+	set_env/1
+]).
+
+%%--------------------------------------------------------------------
+%% @doc A wrapper for `application:get_env/2'.
+%% @deprecated this function is a temporary interface and will be
+%%             replaced by `arweave_config:get/1' function.
+%% @see application:get_env/2
+%% @end
+%%--------------------------------------------------------------------
+get_env() ->
+	application:get_env(arweave, config).
+
+%%--------------------------------------------------------------------
+%% @doc A wrapper for `application:set_env/3'.
+%% @deprecated this function is a temporary interface and will be
+%%             replaced by `arweave_config:set/2' function.
+%% @see application:set_env/3
+%% @end
+%%--------------------------------------------------------------------
+set_env(Value) ->
+	application:set_env(arweave, config, Value).
+

--- a/apps/arweave/src/user_default.erl
+++ b/apps/arweave/src/user_default.erl
@@ -13,5 +13,5 @@
 
 
 config() ->
-  {ok, Config} = application:get_env(arweave, config),
+  {ok, Config} = arweave_config:get_env(),
   Config.

--- a/apps/arweave/test/ar_coordinated_mining_tests.erl
+++ b/apps/arweave/test/ar_coordinated_mining_tests.erl
@@ -152,10 +152,11 @@ test_no_secret() ->
 test_bad_secret() ->
 	[Node, _ExitNode, _ValidatorNode] = ar_test_node:start_coordinated(1),
 	Peer = ar_test_node:peer_ip(Node),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
-		ok = application:set_env(arweave, config,
-				Config#config{ cm_api_secret = <<"this_is_not_the_actual_secret">> }),
+		ok = arweave_config:set_env(Config#config{
+			cm_api_secret = <<"this_is_not_the_actual_secret">>
+		}),
 		?assertMatch(
 			{error, {ok, {{<<"421">>, _}, _, 
 				<<"CM API disabled or invalid CM API secret in request.">>, _, _}}},
@@ -173,7 +174,7 @@ test_bad_secret() ->
 				<<"CM API disabled or invalid CM API secret in request.">>, _, _}}},
 			ar_http_iface_client:cm_publish_send(Peer, dummy_solution()))
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end.
 
 test_partition_table() ->

--- a/apps/arweave/test/ar_data_sync_mines_off_only_last_chunks_test.erl
+++ b/apps/arweave/test/ar_data_sync_mines_off_only_last_chunks_test.erl
@@ -59,7 +59,7 @@ test_mines_off_only_last_chunks() ->
 					%% bound based on the nonce limiter entropy reset, but ar_data_sync waits
 					%% for ?SEARCH_SPACE_UPPER_BOUND_DEPTH confirmations before packing the
 					%% chunks.
-					{ok, Config} = application:get_env(arweave, config),
+					{ok, Config} = arweave_config:get_env(),
 					lists:foreach(
 						fun(O) ->
 							[ar_chunk_storage:delete(O, ar_storage_module:id(Module))

--- a/apps/arweave/test/ar_data_sync_mines_off_only_second_last_chunks_test.erl
+++ b/apps/arweave/test/ar_data_sync_mines_off_only_second_last_chunks_test.erl
@@ -46,7 +46,7 @@ test_mines_off_only_second_last_chunks() ->
 					%% bound based on the nonce limiter entropy reset, but ar_data_sync waits
 					%% for ?SEARCH_SPACE_UPPER_BOUND_DEPTH confirmations before packing the
 					%% chunks.
-					{ok, Config} = application:get_env(arweave, config),
+					{ok, Config} = arweave_config:get_env(),
 					lists:foreach(
 						fun(O) ->
 							[ar_chunk_storage:delete(O, ar_storage_module:id(Module))

--- a/apps/arweave/test/ar_http_iface_tests.erl
+++ b/apps/arweave/test/ar_http_iface_tests.erl
@@ -279,7 +279,7 @@ test_single_regossip(_) ->
 	).
 
 test_node_blacklisting_get_spammer() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{RequestFun, ErrorResponse} = get_fun_msg_pair(get_info),
 	node_blacklisting_test_frame(
 		RequestFun,
@@ -289,7 +289,7 @@ test_node_blacklisting_get_spammer() ->
 	).
 
 test_node_blacklisting_post_spammer() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{RequestFun, ErrorResponse} = get_fun_msg_pair(send_tx_binary),
 	NErrors = 11,
 	NRequests = Config#config.requests_per_minute_limit div 2 + NErrors,
@@ -799,10 +799,11 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 			peer => ar_test_node:peer_ip(main),
 			path => "/wallet"
 		}),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
-		application:set_env(arweave, config,
-				Config#config{ internal_api_secret = <<"correct_secret">> }),
+		arweave_config:set_env(Config#config{
+			internal_api_secret = <<"correct_secret">>
+		}),
 		{ok, {{<<"421">>, _}, _, _, _, _}} =
 			ar_http:req(#{
 				method => post,
@@ -817,7 +818,7 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 				path => "/wallet",
 				headers => [{<<"X-Internal-Api-Secret">>, <<"correct_secret">>}]
 			}),
-		application:set_env(arweave, config, Config#config{ internal_api_secret = not_set }),
+		arweave_config:set_env(Config#config{ internal_api_secret = not_set }),
 		{CreateWalletRes} = ar_serialize:dejsonify(CreateWalletBody),
 		[WalletAccessCode] = proplists:get_all_values(<<"wallet_access_code">>, CreateWalletRes),
 		[Address] = proplists:get_all_values(<<"wallet_address">>, CreateWalletRes),
@@ -856,8 +857,9 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 				path => "/unsigned_tx",
 				body => ar_serialize:jsonify({UnsignedTXProps})
 			}),
-		application:set_env(arweave, config,
-				Config#config{ internal_api_secret = <<"correct_secret">> }),
+		arweave_config:set_env(Config#config{
+			internal_api_secret = <<"correct_secret">>
+		}),
 		{ok, {{<<"421">>, _}, _, _, _, _}} =
 			ar_http:req(#{
 				method => post,
@@ -874,7 +876,7 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 				headers => [{<<"X-Internal-Api-Secret">>, <<"correct_secret">>}],
 				body => ar_serialize:jsonify({UnsignedTXProps})
 			}),
-		application:set_env(arweave, config, Config#config{ internal_api_secret = not_set }),
+		arweave_config:set_env(Config#config{ internal_api_secret = not_set }),
 		{Res} = ar_serialize:dejsonify(Body),
 		TXID = proplists:get_value(<<"id">>, Res),
 		timer:sleep(200),
@@ -895,7 +897,7 @@ test_post_unsigned_tx({_B0, Wallet1, _Wallet2, _StaticWallet}) ->
 			maps:from_list(GetTXRes)
 		)
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end.
 
 %% @doc Ensure the HTTP client stops fetching data from an endpoint when its data size

--- a/apps/arweave/test/ar_mining_io_tests.erl
+++ b/apps/arweave/test/ar_mining_io_tests.erl
@@ -14,7 +14,7 @@ chunks_read(_Worker, WhichChunk, Candidate, RangeStart, ChunkOffsets) ->
 setup_all() ->
 	[B0] = ar_weave:init([], 1, ?WEAVE_SIZE),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StorageModules = lists:flatten(
 		[[{ar_block:partition_size(), N, {spora_2_6, RewardAddr}}] || N <- lists:seq(0, 8)]),
 	ar_test_node:start(B0, RewardAddr, Config, StorageModules),
@@ -133,7 +133,7 @@ test_partitions() ->
 		ar_mining_io:get_partitions(trunc(5 * ar_block:partition_size()))).
 
 default_candidate() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	MiningAddr = Config#config.mining_addr,
 	#mining_candidate{
 		mining_address = MiningAddr

--- a/apps/arweave/test/ar_mining_server_tests.erl
+++ b/apps/arweave/test/ar_mining_server_tests.erl
@@ -21,7 +21,7 @@
 setup_all() ->
 	[B0] = ar_weave:init([], ar_test_node:get_difficulty_for_invalid_hash(), ?WEAVE_SIZE),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	%% We'll use partition 0 for any unsynced ranges.
 	StorageModules = [
 		{ar_block:partition_size(), 1, {spora_2_6, RewardAddr}},
@@ -31,13 +31,13 @@ setup_all() ->
 	Config.
 
 cleanup_all(Config) ->
-	ok = application:set_env(arweave, config, Config).
+	ok = arweave_config:set_env(Config).
 
 %% @doc Setup the environment so we can control VDF step generation.
 setup_pool_client() ->
 	[B0] = ar_weave:init([], ar_test_node:get_difficulty_for_invalid_hash(), ?WEAVE_SIZE),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	%% We'll use partition 0 for any unsynced ranges.
 	StorageModules = [
 		{ar_block:partition_size(), 1, {spora_2_6, RewardAddr}},
@@ -54,7 +54,7 @@ setup_pool_client() ->
 	Config.
 
 cleanup_pool_client(Config) ->
-	ok = application:set_env(arweave, config, Config).
+	ok = arweave_config:set_env(Config).
 
 setup_one() ->
 	ets:new(mock_counter, [set, public, named_table]),

--- a/apps/arweave/test/ar_node_tests.erl
+++ b/apps/arweave/test/ar_node_tests.erl
@@ -186,7 +186,7 @@ test_persisted_mempool() ->
 	try
 		%% Rejoin the network.
 		%% Expect the pending transactions to be picked up and distributed.
-		ok = application:set_env(arweave, config, Config#config{
+		ok = arweave_config:set_env(Config#config{
 			start_from_latest_state = false,
 			peers = [ar_test_node:peer_ip(peer1)]
 		}),
@@ -199,5 +199,5 @@ test_persisted_mempool() ->
 		B = read_block_when_stored(H),
 		?assertEqual([SignedTX#tx.id], B#block.txs)
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end.

--- a/apps/arweave/test/ar_p3_config_tests.erl
+++ b/apps/arweave/test/ar_p3_config_tests.erl
@@ -712,7 +712,7 @@ rates_endpoint_test_() ->
 test_no_rates_endpoint() ->
 	RewardAddress = ar_wallet:to_address(ar_wallet:new_keyfile()),
 	[B0] = ar_weave:init(),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ar_test_node:start(B0, RewardAddress, Config),
 
 	{<<"200">>, Body} = get_rates(),
@@ -725,7 +725,7 @@ test_no_rates_endpoint() ->
 test_empty_rates_endpoint() ->
 	RewardAddress = ar_wallet:to_address(ar_wallet:new_keyfile()),
 	[B0] = ar_weave:init(),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = empty_p3_config() },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -737,13 +737,13 @@ test_empty_rates_endpoint() ->
 			DecodedBody
 		)
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 test_empty_payments_and_services_rates_endpoint() ->
 	RewardAddress = ar_wallet:to_address(ar_wallet:new_keyfile()),
 	[B0] = ar_weave:init(),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		P3Config = #p3_config{ payments = #{}, services = #{}},
 		Config = BaseConfig#config{ p3 = P3Config },
@@ -756,7 +756,7 @@ test_empty_payments_and_services_rates_endpoint() ->
 			DecodedBody
 		)
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 test_rates_endpoint() ->
@@ -765,7 +765,7 @@ test_rates_endpoint() ->
 	DepositAddress = ar_wallet:to_address(Pub1),
 	EncodedDepositAddress = ar_util:encode(DepositAddress),
 	[B0] = ar_weave:init(),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = sample_p3_config(DepositAddress, -100, 3) },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -815,7 +815,7 @@ test_rates_endpoint() ->
 			DecodedBody
 		)
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 %% ------------------------------------------------------------------

--- a/apps/arweave/test/ar_p3_tests.erl
+++ b/apps/arweave/test/ar_p3_tests.erl
@@ -475,7 +475,7 @@ e2e_deposit_before_charge() ->
 		{Sender2Address, ?AR(10000), <<>>},
 		{DepositAddress, ?AR(10000), <<>>}
 	]),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = sample_p3_config(DepositAddress, -100, 3) },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -685,7 +685,7 @@ e2e_deposit_before_charge() ->
 			{<<"200">>, <<"0">>}, get_balance(Sender2Address),
 			"No balance change expected")
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 e2e_charge_before_deposit() ->
@@ -701,7 +701,7 @@ e2e_charge_before_deposit() ->
 	[B0] = ar_weave:init([
 		{Address1, ?AR(10000), <<>>}
 	]),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = sample_p3_config(DepositAddress, -2000, 2) },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -775,7 +775,7 @@ e2e_charge_before_deposit() ->
 
 		?assertEqual({<<"200">>, <<"-800">>}, get_balance(Address1))
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 %% @doc Test that nodes correctly scan old blocks that came in while they were offline.
@@ -789,7 +789,7 @@ e2e_restart_p3_service() ->
 		{Sender1Address, ?AR(10000), <<>>},
 		{DepositAddress, ?AR(10000), <<>>}
 	]),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = sample_p3_config(DepositAddress, -100, 1) },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -849,7 +849,7 @@ e2e_restart_p3_service() ->
 		?assertEqual(5, ar_p3_db:get_scan_height(),
 			"Restarting node should not have reset scan height db: scan height 5")
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 %% @doc Test that a bunch of concurrent requests don't overspend the P3 account and that they
@@ -866,7 +866,7 @@ e2e_concurrent_requests() ->
 		{Address1, ?AR(10000), <<>>},
 		{DepositAddress, ?AR(10000), <<>>}
 	]),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	try
 		Config = BaseConfig#config{ p3 = sample_p3_config(DepositAddress, 0, 1, 100) },
 		ar_test_node:start(B0, RewardAddress, Config),
@@ -935,7 +935,7 @@ e2e_concurrent_requests() ->
 		{ok, AccountValid} = ar_p3_db:get_account(Address1),
 		?assertEqual(Count+1, AccountValid#p3_account.count)
 	after
-		ok = application:set_env(arweave, config, BaseConfig)
+		ok = arweave_config:set_env(BaseConfig)
 	end.
 
 %% ------------------------------------------------------------------

--- a/apps/arweave/test/ar_post_block_tests.erl
+++ b/apps/arweave/test/ar_post_block_tests.erl
@@ -30,7 +30,7 @@ reset_node() ->
 	[{H, _, _} | _] = ar_test_node:assert_wait_until_height(peer1, Height + 1),
 	B = ar_test_node:remote_call(peer1, ar_block_cache, get, [block_cache, H]),
 	PrevB = ar_test_node:remote_call(peer1, ar_block_cache, get, [block_cache, PrevH]),
-	{ok, Config} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	Key = ar_test_node:remote_call(peer1, ar_wallet, load_key, [Config#config.mining_addr]),
 	{Key, B, PrevB}.
 
@@ -337,7 +337,7 @@ test_rejects_invalid_blocks() ->
 	post_block(B2, invalid_signature),
 	%% Nonce limiter output too far in the future.
 	Info1 = B1#block.nonce_limiter_info,
-	{ok, Config} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	Key = ar_test_node:remote_call(peer1, ar_wallet, load_key, [Config#config.mining_addr]),
 	B3 = sign_block(B1#block{
 			%% Change the solution hash so that the validator does not go down
@@ -552,7 +552,7 @@ test_reject_block_invalid_double_signing_proof(KeyType) ->
 	post_block(B3, invalid_double_signing_proof_same_address),
 	ar_test_node:mine(peer1),
 	BI2 = ar_test_node:assert_wait_until_height(peer1, 2),
-	{ok, MainConfig} = application:get_env(arweave, config),
+	{ok, MainConfig} = arweave_config:get_env(),
 	Key2 = element(1, ar_wallet:load_key(MainConfig#config.mining_addr)),
 	Preimage3 = << (B0#block.hash)/binary, (crypto:strong_rand_bytes(32))/binary >>,
 	Preimage4 = << (B0#block.hash)/binary, (crypto:strong_rand_bytes(32))/binary >>,
@@ -752,7 +752,7 @@ test_resigned_solution() ->
 	ar_test_node:disconnect_from(peer1),
 	ar_test_node:mine(peer1),
 	B = ar_node:get_current_block(),
-	{ok, Config} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	Key = ar_test_node:remote_call(peer1, ar_wallet, load_key, [Config#config.mining_addr]),
 	ok = ar_events:subscribe(block),
 	B2 = sign_block(B#block{ tags = [<<"tag1">>] }, B0, Key),

--- a/apps/arweave/test/ar_pricing_tests.erl
+++ b/apps/arweave/test/ar_pricing_tests.erl
@@ -309,7 +309,7 @@ test_auto_redenomination_and_endowment_debt() ->
 	?assert(?REWARD_HISTORY_BLOCKS == 3),
 	?assert(?DOUBLE_SIGNING_REWARD_SAMPLE_SIZE == 2),
 	?assertEqual(262144 * 3, B0#block.weave_size),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{_, MinerPub} = ar_wallet:load_key(Config#config.mining_addr),
 	?assertEqual(0, get_balance(MinerPub)),
 	?assertEqual(0, get_reserved_balance(Config#config.mining_addr)),

--- a/apps/arweave/test/ar_sync_record_tests.erl
+++ b/apps/arweave/test/ar_sync_record_tests.erl
@@ -18,7 +18,7 @@ test_sync_record() ->
 	WeaveSize = 4 * ?DATA_CHUNK_SIZE,
 	[B0] = ar_weave:init([], 1, WeaveSize),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
 		Partition = {ar_block:partition_size(), 0, {composite, RewardAddr, 1}},
 		PartitionID = ar_storage_module:id(Partition),
@@ -137,7 +137,7 @@ test_sync_record() ->
 
 		ar_test_node:stop()
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end.
 
 
@@ -147,7 +147,7 @@ test_sync_record_with_replica_2_9() when ?BLOCK_2_9_SYNCING ->
 	WeaveSize = 4 * ?DATA_CHUNK_SIZE,
 	[B0] = ar_weave:init([], 1, WeaveSize),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
 		Partition = {ar_block:partition_size(), 0, {replica_2_9, RewardAddr}},
 		PartitionID = ar_storage_module:id(Partition),
@@ -176,6 +176,6 @@ test_sync_record_with_replica_2_9() when ?BLOCK_2_9_SYNCING ->
 
 		ar_test_node:stop()
 	after
-		ok = application:set_env(arweave, config, Config)
+		ok = arweave_config:set_env(Config)
 	end;
 test_sync_record_with_replica_2_9() -> ok.

--- a/apps/arweave/test/ar_test_data_sync.erl
+++ b/apps/arweave/test/ar_test_data_sync.erl
@@ -39,11 +39,11 @@ setup_nodes2(#{ peer_addr := PeerAddr } = Options) ->
 			Value ->
 				{Value, Options}
 		end,
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	Options3 = Options2#{ config => Config#config{ 
 		enable = Config#config.enable ++ [pack_served_chunks] } },
 	ar_test_node:start(Options3),
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	ar_test_node:start_peer(peer1, B0, PeerAddr, PeerConfig#config{ 
 		enable = Config#config.enable ++ [pack_served_chunks] }),
 	ar_test_node:connect_to_peer(peer1),
@@ -250,7 +250,7 @@ get_tx_offset(Node, TXID) ->
 	}).
 
 get_tx_data(TXID) ->
-  {ok, Config} = application:get_env(arweave, config),
+  {ok, Config} = arweave_config:get_env(),
 	ar_http:req(#{
 		method => get,
 		peer => {127, 0, 0, 1, Config#config.port},

--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -176,7 +176,7 @@ peer_name(Node) ->
 	).
 
 peer_port(Node) ->
-	{ok, Config} = ar_test_node:remote_call(Node, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(Node, arweave_config, get_env, []),
 	Config#config.port.
 
 stop_peers([]) ->
@@ -213,13 +213,13 @@ wait_until_joined() ->
 	 ).
 
 get_config(Node) ->
-	remote_call(Node, application, get_env, [arweave, config]).
+	remote_call(Node, arweave_config, get_env, []).
 
 set_config(Node, Config) ->
-	remote_call(Node, application, set_env, [arweave, config, Config]).
+	remote_call(Node, arweave_config, set_env, [Config]).
 
 update_config(Config) ->
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	Config2 = BaseConfig#config{
 		start_from_latest_state = Config#config.start_from_latest_state,
 		auto_join = Config#config.auto_join,
@@ -243,7 +243,7 @@ update_config(Config) ->
 		repack_in_place_storage_modules = Config#config.repack_in_place_storage_modules,
 		allow_rebase = Config#config.allow_rebase
 	},
-	ok = application:set_env(arweave, config, Config2),
+	ok = arweave_config:set_env(Config2),
 	?LOG_INFO("Updated Config:"),
 	ar_config:log_config(Config2),
 	Config2.
@@ -257,7 +257,7 @@ start_node(B0, Config) ->
 start_node(B0, Config, WaitUntilSync) ->
 	?LOG_INFO("Starting node"),
 	clean_up_and_stop(),
-	{ok, BaseConfig} = application:get_env(arweave, config),
+	{ok, BaseConfig} = arweave_config:get_env(),
 	write_genesis_files(BaseConfig#config.data_dir, B0),
 	update_config(Config),
 	ar:start_dependencies(),
@@ -349,7 +349,7 @@ mine(Node) ->
 %% @doc Fetch and decode a binary-encoded block by hash H from the HTTP API of the
 %% given node. Return {ok, B} | {error, Reason}.
 http_get_block(H, Node) ->
-	{ok, Config} = remote_call(Node, application, get_env, [arweave, config]),
+	{ok, Config} = remote_call(Node, arweave_config, get_env, []),
 	Port = Config#config.port,
 	Peer = {127, 0, 0, 1, Port},
 	case ar_http:req(#{ peer => Peer, method => get,
@@ -574,7 +574,7 @@ start(Options) when is_map(Options) ->
 	Config =
 		case maps:get(config, Options, not_set) of
 			not_set ->
-				element(2, application:get_env(arweave, config));
+				element(2, arweave_config:get_env());
 			Value2 ->
 				Value2
 		end,
@@ -608,7 +608,7 @@ start(B0, RewardAddr, Config) ->
 start(B0, RewardAddr, Config, StorageModules) ->
 	clean_up_and_stop(),
 	write_genesis_files(Config#config.data_dir, B0),
-	ok = application:set_env(arweave, config, Config#config{
+	ok = arweave_config:set_env(Config#config{
 		start_from_latest_state = true,
 		auto_join = true,
 		peers = [],
@@ -803,7 +803,7 @@ sign_tx(Node, Wallet, Args, SignFun) ->
 	).
 
 stop() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	application:stop(arweave),
 	ar:stop_dependencies(),
 	Config.
@@ -822,7 +822,7 @@ join_on(#{ node := Node, join_on := JoinOnNode }, Rejoin) ->
 
 join(JoinOnNode, Rejoin) ->
 	Peer = peer_ip(JoinOnNode),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	case Rejoin of
 		true ->
 			stop();
@@ -832,7 +832,7 @@ join(JoinOnNode, Rejoin) ->
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
 	StorageModules = [{ar_block:partition_size(), N,
 			get_default_storage_module_packing(RewardAddr, N)} || N <- lists:seq(0, 4)],
-	ok = application:set_env(arweave, config, Config#config{
+	ok = arweave_config:set_env(Config#config{
 		start_from_latest_state = false,
 		mining_addr = RewardAddr,
 		storage_modules = StorageModules,
@@ -933,7 +933,7 @@ wait_until_syncs_genesis_data(Node) ->
 	ok = remote_call(Node, ar_test_node, wait_until_syncs_genesis_data, [], 100_000).
 
 wait_until_syncs_genesis_data() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	ar_util:do_until(
 		fun() ->
 			case ar_node:get_current_block() of

--- a/apps/arweave/test/ar_tx_blacklist_tests.erl
+++ b/apps/arweave/test/ar_tx_blacklist_tests.erl
@@ -51,7 +51,7 @@ test_uses_blacklists() ->
 	WhitelistFile = random_filename(),
 	ok = file:write_file(WhitelistFile, <<>>),
 	RewardAddr = ar_wallet:to_address(ar_wallet:new_keyfile()),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	StorageModule = {30 * 1024 * 1024, 0, {composite, RewardAddr, 1}},
 	try
 		ar_test_node:start(#{ b0 => B0, addr => RewardAddr,
@@ -278,7 +278,7 @@ create_files(BadTXIDs, [{Start1, End1}, {Start2, End2}, {Start3, End3}]) ->
 	[Filename || {Filename, _} <- Files].
 
 random_filename() ->
-	{ok, Config} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, Config} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	filename:join(Config#config.data_dir,
 		"ar-tx-blacklist-tests-transaction-blacklist-"
 		++
@@ -461,4 +461,4 @@ decode_chunk(EncodedProof) ->
 
 teardown(Config) ->
 	ok = ar_test_node:remote_call(peer1, cowboy, stop_listener, [ar_tx_blacklist_test_listener]),
-	application:set_env(arweave, config, Config).
+	arweave_config:set_env(Config).

--- a/apps/arweave/test/ar_tx_tests.erl
+++ b/apps/arweave/test/ar_tx_tests.erl
@@ -231,8 +231,8 @@ polls_for_transactions_and_gossips_and_mines(B0, TXFuns) ->
 	%% Expect them to be accepted, fetched by the peer we did not push them to
 	%% and included into the block.
 	%% Expect the block to be accepted by the peer.
-	{ok, MainConfig} = application:get_env(arweave, config),
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, MainConfig} = arweave_config:get_env(),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	try
 		MainConfig2 = MainConfig#config{ max_propagation_peers = 0 },
 		_ = ar_test_node:start(#{ b0 => B0, config => MainConfig2 }),
@@ -279,7 +279,7 @@ polls_for_transactions_and_gossips_and_mines(B0, TXFuns) ->
 			TXs
 		)
 	after
-		application:set_env(arweave, config, MainConfig),
+		arweave_config:set_env(MainConfig),
 		ar_test_node:set_config(peer1, PeerConfig)
 	end.
 
@@ -293,8 +293,8 @@ keeps_txs_after_new_block(B0, FirstTXSetFuns, SecondTXSetFuns) ->
 	%% Expect the block to be accepted.
 	%% Expect transactions from the difference between the two sets to be kept in the mempool.
 	%% Mine a block on the first node, expect the difference to be included into the block.
-	{ok, MainConfig} = application:get_env(arweave, config),
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, MainConfig} = arweave_config:get_env(),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 
 	try
 		MainConfig2 = MainConfig#config{ disable = [tx_poller | MainConfig#config.disable] },
@@ -343,7 +343,7 @@ keeps_txs_after_new_block(B0, FirstTXSetFuns, SecondTXSetFuns) ->
 			lists:sort((read_block_when_stored(hd(BI2)))#block.txs)
 		)
 	after
-		application:set_env(arweave, config, MainConfig),
+		arweave_config:set_env(MainConfig),
 		ar_test_node:set_config(peer1, PeerConfig)
 	end.
 
@@ -860,7 +860,7 @@ recovers_from_forks(ForkHeight) ->
 	_ = ar_test_node:start(B0),
 	_ = ar_test_node:start_peer(peer1, B0),
 	ar_test_node:connect_to_peer(peer1),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	MainPort = Config#config.port,
 	PreForkTXs = lists:foldl(
 		fun(Height, TXs) ->

--- a/apps/arweave/test/ar_vdf_external_update_tests.erl
+++ b/apps/arweave/test/ar_vdf_external_update_tests.erl
@@ -18,7 +18,7 @@
 %% -------------------------------------------------------------------------------------------------
 
 setup_external_update() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	[B0] = ar_weave:init(),
 	%% Start the testnode with a configured VDF server so that it doesn't compute its own VDF -
 	%% this is necessary so that we can test the behavior of apply_external_update without any
@@ -45,7 +45,7 @@ setup_external_update() ->
 
 cleanup_external_update({Pid, Config}) ->
 	exit(Pid, kill),
-	ok = application:set_env(arweave, config, Config),
+	ok = arweave_config:set_env(Config),
 	ets:delete(add_task),
 	ets:delete(computed_output).
 

--- a/apps/arweave/test/ar_vdf_server_tests.erl
+++ b/apps/arweave/test/ar_vdf_server_tests.erl
@@ -15,13 +15,13 @@
 
 setup() ->
 	ets:new(computed_output, [named_table, set, public]),
-	{ok, Config} = application:get_env(arweave, config),
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, Config} = arweave_config:get_env(),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
     {Config, PeerConfig}.
 
 cleanup({Config, PeerConfig}) ->
-	application:set_env(arweave, config, Config),
-	ar_test_node:remote_call(peer1, application, set_env, [arweave, config, PeerConfig]),
+	arweave_config:set_env(Config),
+	ar_test_node:remote_call(peer1, arweave_config, set_env, [PeerConfig]),
 	ets:delete(computed_output).
 
 %% -------------------------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ test_vdf_server_push_fast_block() ->
 	ar_test_node:remote_call(peer1, ar_http, block_peer_connections, []),
 	timer:sleep(3000),
 
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ 
@@ -145,7 +145,7 @@ test_vdf_server_push_slow_block() ->
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ 
@@ -200,7 +200,7 @@ test_vdf_server_push_slow_block() ->
 %%
 test_vdf_client_fast_block() ->
 	ar_test_node:stop(),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
@@ -218,7 +218,7 @@ test_vdf_client_fast_block() ->
 	ar_test_node:stop(peer1),
 
 	%% Restart peer1 as a VDF client
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ 
@@ -253,7 +253,7 @@ test_vdf_client_fast_block() ->
 	BI = assert_wait_until_height(peer1, 1).
 
 test_vdf_client_fast_block_pull_interface() ->
-  	{ok, Config} = application:get_env(arweave, config),
+  	{ok, Config} = arweave_config:get_env(),
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
@@ -271,7 +271,7 @@ test_vdf_client_fast_block_pull_interface() ->
 	ar_test_node:stop(peer1),
 
 	%% Restart peer1 as a VDF client
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ 
@@ -309,7 +309,7 @@ test_vdf_client_fast_block_pull_interface() ->
 	BI = assert_wait_until_height(peer1, 1).
 
 test_vdf_client_slow_block() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
@@ -326,7 +326,7 @@ test_vdf_client_slow_block() ->
 	ar_test_node:stop(peer1),
 
 	%% Restart peer1 as a VDF client
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ 
@@ -353,7 +353,7 @@ test_vdf_client_slow_block() ->
 	BI = assert_wait_until_height(peer1, 1).
 
 test_vdf_client_slow_block_pull_interface() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	{_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
 
@@ -370,7 +370,7 @@ test_vdf_client_slow_block_pull_interface() ->
 	ar_test_node:stop(peer1),
 
 	%% Restart peer1 as a VDF client
-	{ok, PeerConfig} = ar_test_node:remote_call(peer1, application, get_env, [arweave, config]),
+	{ok, PeerConfig} = ar_test_node:remote_call(peer1, arweave_config, get_env, []),
 	_ = ar_test_node:start_peer(peer1,
 		B0, PeerAddress,
 		PeerConfig#config{ 
@@ -381,7 +381,7 @@ test_vdf_client_slow_block_pull_interface() ->
 		}
 	),
 	%% Start the main as a VDF server
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	_ = ar_test_node:start(
 		B0, ar_wallet:to_address(ar_wallet:new_keyfile()),
 		Config#config{ 

--- a/apps/arweave/test/ar_webhook_tests.erl
+++ b/apps/arweave/test/ar_webhook_tests.erl
@@ -51,7 +51,7 @@ webhooks_test_() ->
 test_webhooks() ->
 	{_, Pub} = Wallet = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(10000), <<>>}]),
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	try
 		Port = ar_test_node:get_unused_port(),
 		PortBinary = integer_to_binary(Port),
@@ -209,7 +209,7 @@ test_webhooks() ->
 		assert_transaction_data_synced(V2TXID),
 		cowboy:stop_listener(ar_webhook_test_listener)
 	after
-		application:set_env(arweave, config, Config#config{ webhooks = [] })
+		arweave_config:set_env(Config#config{ webhooks = [] })
 	end.
 
 create_v2_tx(Wallet) ->
@@ -257,7 +257,7 @@ upload_chunks([Proof | Proofs]) ->
 	upload_chunks(Proofs).
 
 random_tx_blacklist_filename() ->
-	{ok, Config} = application:get_env(arweave, config),
+	{ok, Config} = arweave_config:get_env(),
 	filename:join(Config#config.data_dir,
 		"ar-webhook-tests-transaction-blacklist-"
 		++


### PR DESCRIPTION
This commit introduces `arweave_config` module, an interface to application module and the first temporary bricks for Arweave dynamic configuration.

After this commit, all modules MUST call `arweave_config:set_env/2` and/or `arweave_config:get_env/1` to configure a parameter on arweave.

see: https://github.com/ArweaveTeam/arweave-dev/issues/964