### PR TITLE
fix: fix logic to determing the packing format being mined

### DIFF
--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -3,7 +3,8 @@
 -behaviour(gen_server).
 
 -export([start_link/0, start_link/1, set_largest_seen_upper_bound/1,
-			get_packing/0, get_partitions/0, get_partitions/1, read_recall_range/4,
+			get_packing/0, get_partitions/0, get_partitions/1, 
+			get_minable_storage_modules/0, read_recall_range/4,
 			is_recall_range_readable/2, garbage_collect/0,
 			get_replica_format_from_packing_difficulty/1]).
 
@@ -52,10 +53,10 @@ is_recall_range_readable(Candidate, RecallRangeStart) ->
 			{is_recall_range_readable, Candidate, RecallRangeStart}, 60000).
 
 get_packing() ->
-	{ok, Config} = arweave_config:get_env(),
+	Partitions = get_minable_storage_modules(),
 	%% ar_config:validate_storage_modules/1 ensures that we only mine against a single
-	%% packing format. So we can grab it any partition.
-	case Config#config.storage_modules of
+	%% packing format. So we can grab any partition.
+	case Partitions of
 		[] -> undefined;
         [{_, _, Packing} | _Rest] -> Packing
     end.
@@ -63,8 +64,8 @@ get_packing() ->
 get_partitions(PartitionUpperBound) when PartitionUpperBound =< 0 ->
 	[];
 get_partitions(PartitionUpperBound) ->
-	{ok, Config} = arweave_config:get_env(),
 	Max = ar_node:get_max_partition_number(PartitionUpperBound),
+	MinableStorageModules = get_minable_storage_modules(),
 	AllPartitions = lists:foldl(
 		fun	(Module, Acc) ->
 				Addr = ar_storage_module:module_address(Module),
@@ -81,15 +82,25 @@ get_partitions(PartitionUpperBound) ->
 				)
 		end,
 		sets:new(),
-		Config#config.storage_modules
+		MinableStorageModules
 	),
 	FilteredPartitions = sets:filter(
-        fun ({PartitionNumber, Addr, _PackingDifficulty}) ->
-            PartitionNumber =< Max andalso Addr == Config#config.mining_addr
+        fun ({PartitionNumber, _Addr, _PackingDifficulty}) ->
+            PartitionNumber =< Max
         end,
         AllPartitions
     ),
     lists:sort(sets:to_list(FilteredPartitions)).
+
+get_minable_storage_modules() ->
+	{ok, Config} = arweave_config:get_env(),
+	lists:filter(
+		fun	(Module) ->
+				ar_storage_module:module_address(Module) == Config#config.mining_addr
+		end,
+		Config#config.storage_modules
+	).
+
 
 garbage_collect() ->
 	gen_server:cast(?MODULE, garbage_collect).

--- a/apps/arweave/src/ar_mining_io.erl
+++ b/apps/arweave/src/ar_mining_io.erl
@@ -53,10 +53,9 @@ is_recall_range_readable(Candidate, RecallRangeStart) ->
 			{is_recall_range_readable, Candidate, RecallRangeStart}, 60000).
 
 get_packing() ->
-	Partitions = get_minable_storage_modules(),
 	%% ar_config:validate_storage_modules/1 ensures that we only mine against a single
 	%% packing format. So we can grab any partition.
-	case Partitions of
+	case get_minable_storage_modules() of
 		[] -> undefined;
         [{_, _, Packing} | _Rest] -> Packing
     end.
@@ -65,7 +64,6 @@ get_partitions(PartitionUpperBound) when PartitionUpperBound =< 0 ->
 	[];
 get_partitions(PartitionUpperBound) ->
 	Max = ar_node:get_max_partition_number(PartitionUpperBound),
-	MinableStorageModules = get_minable_storage_modules(),
 	AllPartitions = lists:foldl(
 		fun	(Module, Acc) ->
 				Addr = ar_storage_module:module_address(Module),
@@ -82,7 +80,7 @@ get_partitions(PartitionUpperBound) ->
 				)
 		end,
 		sets:new(),
-		MinableStorageModules
+		get_minable_storage_modules()
 	),
 	FilteredPartitions = sets:filter(
         fun ({PartitionNumber, _Addr, _PackingDifficulty}) ->

--- a/apps/arweave/test/ar_mining_io_tests.erl
+++ b/apps/arweave/test/ar_mining_io_tests.erl
@@ -131,6 +131,40 @@ test_partitions() ->
 			{3, MiningAddress, 0},
 			{4, MiningAddress, 0}],
 		ar_mining_io:get_partitions(trunc(5 * ar_block:partition_size()))).
+get_minable_storge_modules_test() ->
+	{ok, Config} = arweave_config:get_env(),
+	Addr = Config#config.mining_addr,
+	try
+		Input = [
+			{100, 0, {spora_2_6, Addr}},
+			{200, 0, unpacked},
+			{300, 0, {replica_2_9, Addr}}
+		],
+		Expected = [
+			{100, 0, {spora_2_6, Addr}},
+			{300, 0, {replica_2_9, Addr}}
+		],
+		arweave_config:set_env(Config#config{storage_modules = Input}),
+		?assertEqual(Expected, ar_mining_io:get_minable_storage_modules())
+	after
+		arweave_config:set_env(Config)
+	end.
+
+get_packing_test() ->
+	{ok, Config} = arweave_config:get_env(),
+	Addr = Config#config.mining_addr,
+	try
+		Input = [
+			{100, 0, unpacked},
+			{200, 0, {spora_2_6, Addr}},
+			{300, 0, {replica_2_9, Addr}}
+		],
+		Expected = {spora_2_6, Addr},
+		arweave_config:set_env(Config#config{storage_modules = Input}),
+		?assertEqual(Expected, ar_mining_io:get_packing())
+	after
+		arweave_config:set_env(Config)
+	end.
 
 default_candidate() ->
 	{ok, Config} = arweave_config:get_env(),

--- a/apps/arweave/test/ar_mining_io_tests.erl
+++ b/apps/arweave/test/ar_mining_io_tests.erl
@@ -131,6 +131,7 @@ test_partitions() ->
 			{3, MiningAddress, 0},
 			{4, MiningAddress, 0}],
 		ar_mining_io:get_partitions(trunc(5 * ar_block:partition_size()))).
+
 get_minable_storge_modules_test() ->
 	{ok, Config} = arweave_config:get_env(),
 	Addr = Config#config.mining_addr,


### PR DESCRIPTION
Previously we just went off the first entry in the storage_modules list. This is right in most cases, but for any miner that has configured storage_modules with multiple packing formats it could give thew wrong results