### PR TITLE
Fix missing arweave config startup

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -1321,6 +1321,7 @@ warn_if_single_scheduler() ->
 	end.
 
 shell() ->
+	arweave_config:start(),
 	Config = #config{ debug = true },
 	start_for_tests(test,Config),
 	ar_test_node:boot_peers(test).


### PR DESCRIPTION
Arweave config is an independent application and was missing from ar:shell/0 entry-point.