### PR TITLE
Integrate HTTP API Interface for Arweave Config

### DIFF
--- a/apps/arweave_config/src/arweave_config_http_server.erl
+++ b/apps/arweave_config/src/arweave_config_http_server.erl
@@ -1,0 +1,406 @@
+%%%===================================================================
+%%% GNU General Public License, version 2 (GPL-2.0)
+%%% The GNU General Public License (GPL-2.0)
+%%% Version 2, June 1991
+%%%
+%%% ------------------------------------------------------------------
+%%%
+%%% @copyright 2025 (c) Arweave
+%%% @author Arweave Team
+%%% @author Mathieu Kerjouan
+%%% @doc Configuration HTTP Server Interface.
+%%%
+%%% This module is using cowboy to handle configuration requests. The
+%%% goal is to configure dynamically some values using a web
+%%% interface. The default TCP port used is `4891'.
+%%%
+%%% The interface is using a RESTful like module, where a path is
+%%% representing an object.
+%%%
+%%% A configuration path is converted to a parameter:
+%%%
+%%% ```
+%%% v1/config/debug
+%%%
+%%% % becomes
+%%%
+%%% [debug]
+%%% '''
+%%%
+%%% This API is also versionned, the `v0' version is mostly a draft to
+%%% see how the different methods are behaving.
+%%%
+%%% JSON data returned try to follow jsend format.
+%%%
+%%% see: https://github.com/omniti-labs/jsend
+%%%
+%%% == Examples ==
+%%%
+%%% By default, the values being used and returned are raw:
+%%%
+%%% ```
+%%% # get the value of global.debug parameter
+%%% $ curl localhost:4891/v1/config/debug
+%%% {"status":"success","data":true}
+%%%
+%%% # set the value of global.debug parameter
+%%% $ curl localhost:4891/v1/config/global/debug -d false
+%%% {"status":"success","data":false}
+%%% '''
+%%%
+%%% === Unix Socket Support ===
+%%%
+%%% Arweave Configuration HTTP API can listen to an unix socket
+%%% instead of an IP address. If a valid path is given instead of an
+%%% IP address, cowboy will listen on this file. When the server is
+%%% stopped, this file should be removed.
+%%%
+%%% One can then use an HTTP client (e.g. curl) to send HTTP requests,
+%%% here an example
+%%%
+%%% ```
+%%% curl \
+%%%   --unix-socket ${WORKDIR}/arweave.sock \
+%%%   http://localhost/v1/config/...
+%%% '''
+%%%
+%%% Enabling the usage of an unix socket restrict the surface attack,
+%%% and limit the configuration access to only the user with
+%%% read/write access to it. The "authentication" is then based on
+%%% UNIX credentials.
+%%%
+%%% Note: it can also be a good way to offer an interface for a GUI.
+%%%
+%%% @end
+%%%===================================================================
+-module(arweave_config_http_server).
+-export([start_link/0, stop/0]).
+-export([start_as_child/0, stop_as_child/0]).
+-export([init/2]).
+-include_lib("kernel/include/logger.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% @doc start cowboy as `arweave_config_sup' child.
+%% @end
+%%--------------------------------------------------------------------
+start_as_child() ->
+	Spec = #{
+			id => ?MODULE,
+			start => {?MODULE, start_link, []},
+			type => worker,
+			restart => temporary
+	},
+	supervisor:start_child(arweave_config_sup, Spec).
+
+%%--------------------------------------------------------------------
+%% @doc stop cowboy from `arweave_config_sup'.
+%% @end
+%%--------------------------------------------------------------------
+stop_as_child() ->
+	stop(),
+	supervisor:terminate_child(arweave_config_sup, ?MODULE),
+	supervisor:delete_child(arweave_config_sup, ?MODULE).
+
+%%--------------------------------------------------------------------
+%% @doc start arweave config http api interface.
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+	{ok, DefaultHost} = arweave_config:get([config,http,api,listen,address]),
+	{ok, DefaultPort} = arweave_config:get([config,http,api,listen,port]),
+	TransportOpts =
+		case inet:parse_address(binary_to_list(DefaultHost)) of
+			{ok, Address} ->
+				[
+					{port, DefaultPort},
+					{ip, Address}
+				];
+			{error, _} ->
+				% if it's not an ip address, this is
+				% an unix socket.
+				[
+					{ip, {local, DefaultHost}}
+				]
+		end,
+	ProtocolOpts = #{
+		env => #{ dispatch => dispatch() }
+	},
+	cowboy:start_clear(?MODULE, TransportOpts, ProtocolOpts).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+stop() ->
+	ListenAddress = ranch:get_addr(?MODULE),
+	cowboy:stop_listener(?MODULE),
+	case ListenAddress of
+		{local, Address} ->
+			?LOG_DEBUG("remove ~p", [Address]),
+			file:delete(Address),
+			ok;
+		_ ->
+			ok
+	end.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+dispatch() ->
+	cowboy_router:compile([
+		{'_', router()}
+	]).
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+headers() ->
+	#{ <<"content-type">> => <<"application/json">> }.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+router() ->
+	[
+		{"/v0", ?MODULE, #{}},
+		{"/v0/config", ?MODULE, #{}},
+		{"/v0/config/[...]", ?MODULE, #{}},
+		{"/v0/environment", ?MODULE, #{}}
+	].
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+% @todo returns API specifications
+% init(Req = #{ path := <<"/v0">> }, State) ->
+% 	Reply = cowboy_req:reply(200, #{}, <<>>, Req),
+% 	{ok, Reply, State};
+% @todo returns arweave and beam arguments
+% init(Req = #{ path := <<"/v0/arguments">> }, State) -> ok;
+init(Req = #{ path := <<"/v0/environment">>, method := <<"GET">> }, State) ->
+	Environment = arweave_config_environment:get(),
+	AsMap = maps:from_list(Environment),
+	Headers = headers(),
+	Body = encode(
+		jsend(
+			success,
+			AsMap
+		)
+	),
+	Reply = cowboy_req:reply(200, Headers, Body, Req),
+	{ok, Reply, State};
+init(Req = #{ path := <<"/v0/config">> }, State) ->
+	% @todo: add the configuration from spec (with default value)
+	% should return the full configuration using different format.
+	Config = arweave_config_store:to_map(),
+	Headers = headers(),
+	Body = encode(
+		jsend(
+			success,
+			Config
+		)
+	),
+	Reply = cowboy_req:reply(200, Headers, Body, Req),
+	{ok, Reply, State};
+init(Req = #{ path := <<"/v0/config/">> }, State) ->
+	init(Req#{ path => <<"/v0/config">> }, State);
+init(Req = #{ path := <<"/v0/config/", Key/binary>> }, State)
+	when Key =/= <<>> ->
+		apply_config(Key, Req, State);
+init(Req, State) ->
+	?LOG_INFO("~p", [{Req, State}]),
+	Headers = headers(),
+	Body = encode(
+		jsend(
+			error,
+			<<"not found">>
+		)
+	),
+	Reply = cowboy_req:reply(404, Headers, Body, Req),
+	{ok, Reply, State}.
+
+%%--------------------------------------------------------------------
+%%
+%%--------------------------------------------------------------------
+apply_config(Key, Req, State) ->
+	case config(Key, Req, State) of
+		{ok, #{
+			status := Status,
+			body := Body,
+			req := NewReq
+		}} ->
+			Reply = cowboy_req:reply(
+				Status,
+				headers(),
+				encode(Body),
+				NewReq
+			),
+			{ok, Reply, State};
+		_Else ->
+			Reply = cowboy_req:reply(
+				400,
+				headers(),
+				encode(
+					jsend(
+						error,
+						<<"configuration error">>
+					)
+				),
+				Req
+			),
+			{ok, Reply, State}
+	end.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% config end-point
+%%--------------------------------------------------------------------
+config(Key, Req, State) ->
+	io:format("~p~n", [{Key, Req, State}]),
+	Key2 = re:replace(Key, <<"/">>, <<".">>, [global]),
+	Key3 = case Key2 of
+		_ when is_list(Key2) -> list_to_binary(Key2);
+		_ when is_binary(Key2) -> Key2
+	end,
+	case arweave_config_parser:key(Key3) of
+		{ok, Parameter} ->
+			config1(Parameter, Req, State);
+		_ ->
+			NewState = #{
+				status => 400,
+				headers => headers(),
+				body => jsend(
+					error,
+					<<"bad data">>
+				),
+				req => Req
+			},
+			{ok, NewState}
+	end.
+
+config1(Parameter, Req = #{ method := <<"GET">> }, State) ->
+	case arweave_config:get(Parameter) of
+		{ok, Value} ->
+			NewState = State#{
+				status => 200,
+				headers => headers(),
+				body => jsend(
+					success,
+					Value
+				),
+				req => Req
+			},
+			{ok, NewState};
+		_ ->
+			NewState = State#{
+				status => 404,
+				headers => headers(),
+				body => jsend(
+					error,
+					<<"not_found">>
+				),
+				req => Req
+			},
+			{ok, NewState}
+	end;
+config1(Parameter, Req = #{ method := <<"POST">> }, State) ->
+	case cowboy_req:has_body(Req) of
+		true ->
+			config_post(Parameter, Req, State);
+		false ->
+			NewState = State#{
+				status => 400,
+				headers => headers(),
+				body => jsend(
+					error,
+					<<"missing body">>
+				),
+				req => Req
+			},
+			{ok, NewState}
+	end.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+config_post(Parameter, Req, State) ->
+	case cowboy_req:read_body(Req) of
+		{ok, Data, Req0} ->
+			config_post1(Data, Parameter, Req0, State);
+		_ ->
+			NewState = State#{
+				status => 400,
+				headers => headers(),
+				body => jsend(
+					error,
+					<<"bad data">>
+				),
+				req => Req
+			},
+			{ok, NewState}
+	end.
+
+config_post1(Data, Parameter, Req, State) ->
+	case arweave_config_spec:set(Parameter, Data) of
+		{ok, NewValue, OldValue} ->
+			NewState = State#{
+				status => 200,
+				headers => headers(),
+				body => jsend(
+					success,
+					#{
+						new => NewValue,
+						old => OldValue
+					}
+				),
+				req => Req
+			},
+			{ok, NewState};
+		_ ->
+			NewState = State#{
+				status => 400,
+				headers => headers(),
+				body => jsend(
+					error,
+					<<"bad data">>
+				),
+				req => Req
+			},
+			{ok, NewState}
+	end.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+-spec jsend(Status, Data) -> Return when
+	Status :: success | fail | error,
+	Data :: binary() | map() | list() | integer(),
+	Return :: #{
+		status => success | fail | error,
+		data => Data,
+		message => Data
+	}.
+
+jsend(success, Data) ->
+	#{
+		status => success,
+		data => Data
+	};
+jsend(fail, Data) ->
+	#{
+		status => fail,
+		data => Data
+	};
+jsend(error, Message) ->
+	#{
+		status => error,
+		message => Message
+	}.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+encode(Data) ->
+	jiffy:encode(Data).
+

--- a/apps/arweave_config/src/arweave_config_parameters.erl
+++ b/apps/arweave_config/src/arweave_config_parameters.erl
@@ -72,13 +72,81 @@ init() ->
 					logger:set_application_level(arweave, debug),
 					legacy_set(K, V, S)
 			end
+		},
+
+		%-----------------------------------------------------
+		% arweave_config http api parameters
+		%-----------------------------------------------------
+		#{
+			parameter_key => [config,http,api,enabled],
+			environment => <<"AR_CONFIG_HTTP_API_ENABLED">>,
+			short_description => <<"enable arweave configuration http api interface">>,
+			% @todo enable it by default after testing
+			default => false,
+			type => boolean,
+			required => false,
+			runtime => false
+		},
+		#{
+			parameter_key => [config,http,api,listen,port],
+			environment => <<"AR_CONFIG_HTTP_API_LISTEN_PORT">>,
+			short_description => "set arweave configuration http api interface port",
+			default => 4891,
+			type => tcp_port,
+			required => false,
+			runtime => false
+		},
+		#{
+			parameter_key => [config,http,api,listen,address],
+			environment => <<"AR_CONFIG_HTTP_API_LISTEN_ADDRESS">>,
+			short_description => "set arweave configuration http api listen address",
+			type => [ipv4, file],
+			required => false,
+			% can be an ip address or an unix socket path,
+			% the configuration should be transparent
+			% though and we should avoid using
+			%   {local, socket_path}
+			% the rule is probably to say if the value
+			% start with / then this is an unix socket,
+			% else this is an ip address or an hostname.
+			default => <<"127.0.0.1">>,
+			runtime => false
 		}
+		% @todo implement read, write and token parameters
+		% #{
+		% 	parameter => [config,http,api,read],
+		% 	environment => <<"AR_CONFIG_HTTP_API_READ">>,
+		% 	short_description => "allow read (get method) on arweave configuration http api",
+		% 	type => boolean,
+		% 	required => false,
+		% 	default => true
+		% },
+		% #{
+		% 	parameter => [config,http,api,write],
+		% 	environment => <<"AR_CONFIG_HTTP_API_WRITE">>,
+		% 	short_description => "allow write (post method) on arweave configuration http api",
+		% 	type => boolean,
+		% 	required => false,
+		% 	default => true
+		% },
+		% #{
+		% 	parameter => [config,http,api,token],
+		% 	environment => <<"AR_CONFIG_HTTP_API_TOKEN">>,
+		% 	short_description => "set an access token for arweave configuration http api interface",
+		% 	type => string,
+		% 	required => false,
+		% 	default => <<>>
+		% }
 	].
 
 legacy_get(_K, #{ spec := #{ legacy := L }}) ->
 	V = arweave_config_legacy:get(L),
-	{ok, V}.
+	{ok, V};
+legacy_get(_K, _) ->
+	{error, not_found}.
 
 legacy_set(_K, V, #{ spec := #{ legacy := L }}) ->
 	arweave_config_legacy:set(L, V),
+	{store, V};
+legacy_set(_K, V, _) ->
 	{store, V}.

--- a/apps/arweave_config/src/arweave_config_specs/arweave_config_spec_type.erl
+++ b/apps/arweave_config/src/arweave_config_specs/arweave_config_spec_type.erl
@@ -51,6 +51,7 @@
 -export([init/2]).
 -include("arweave_config_spec.hrl").
 -include_lib("kernel/include/logger.hrl").
+-include_lib("eunit/include/eunit.hrl").
 
 init(#{ type := Type }, State) ->
 	{ok, State#{ type => Type }};

--- a/apps/arweave_config/test/arweave_config_http_server_SUITE.erl
+++ b/apps/arweave_config/test/arweave_config_http_server_SUITE.erl
@@ -1,0 +1,247 @@
+%%%===================================================================
+%%% GNU General Public License, version 2 (GPL-2.0)
+%%% The GNU General Public License (GPL-2.0)
+%%% Version 2, June 1991
+%%%
+%%% ------------------------------------------------------------------
+%%%
+%%% @author Arweave Team
+%%% @author Mathieu Kerjouan
+%%% @copyright 2025 (c) Arweave
+%%% @doc
+%%% @end
+%%%===================================================================
+-module(arweave_config_http_server_SUITE).
+-export([suite/0, description/0]).
+-export([init_per_suite/1, end_per_suite/1]).
+-export([init_per_testcase/2, end_per_testcase/2]).
+-export([all/0]).
+-export([
+	default/1,
+	unix_socket/1
+]).
+-include("arweave_config.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+suite() -> [{userdata, [description()]}].
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+description() -> {description, "arweave_config http api interface"}.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+init_per_suite(Config) ->
+	application:ensure_all_started(gun),
+	Config.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+end_per_suite(_Config) ->
+	application:stop(gun),
+	ok.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+init_per_testcase(_TestCase, Config) ->
+	ct:pal(info, 1, "start arweave_config"),
+	ok = arweave_config:start(),
+	Config.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+end_per_testcase(_TestCase, _Config) ->
+	ct:pal(info, 1, "stop arweave_config"),
+	ok = arweave_config:stop().
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+all() ->
+	[
+		default,
+		unix_socket
+	].
+
+%%--------------------------------------------------------------------
+%% @doc test `arweave_config' main interface.
+%% @end
+%%--------------------------------------------------------------------
+default(_Config) ->
+	% the server can be started as child (under
+	% arweave_config_sup). The goal is to enable it on demand only
+	% if a specific parameter or environment variable is present.
+	ct:pal(test, 1, "start arweave config http server"),
+	arweave_config_http_server:start_as_child(),
+
+	% the whole configuration can be seen using /v0/config
+	% end-point
+	ct:pal(test, 1, "fetch the whole configuration"),
+	{ok, 200, D1} = get_path("/v0/config"),
+	{true, {success, _}} = is_jsend(D1),
+
+	% any parameters can be fetched using /v0/config/${parameter},
+	% they are separated by '/'
+	ct:pal(test, 1, "fetch debug parameter"),
+	{ok, 200, D2} = get_path("/v0/config/debug"),
+	{true, {success, false}} = is_jsend(D2),
+
+	% parameters can be set using a POST method and following the
+	% same pattern. At this time, the data sent is untyped (no
+	% json support)
+	ct:pal(test, 1, "set debug parameter"),
+	{ok, 200, D3} = post_path("/v0/config/debug", <<"true">>),
+	{true,
+		{success, #{
+				<<"new">> := true,
+				<<"old">> := false
+			}
+		}
+	} = is_jsend(D3),
+
+	% when a parameter was set, the new value should be present.
+	ct:pal(test, 1, "fetch debug parameter"),
+	{ok, 200, D4} = get_path("/v0/config/debug"),
+	{true, {success, true}} = is_jsend(D4),
+
+	% if a bad value is given by the client, an error must be
+	% returned, if possible with a message containing the reason.
+	ct:pal(test, 1, "set bad value on parameter"),
+	{ok, 400, D5} = post_path("/v0/config/debug", <<"random">>),
+	{true, {error, _}} = is_jsend(D5),
+
+	% if a parameter is not present, an error should be returned
+	% with the reason
+	ct:pal(test, 1, "check unknown parameter"),
+	{ok, 404, D6} = get_path("/v0/config/parameter/not/found"),
+	{true, {error, _}} = is_jsend(D6),
+
+	% arweave environment should be available to the client, at
+	% this time, all environment variables are displayed.
+	ct:pal(test, 1, "fetch arweave config environment"),
+	{ok, 200, D7} = get_path("/v0/environment"),
+	{true, {success, _}} = is_jsend(D7),
+
+	ct:pal(test, 1, "stop config http server"),
+	arweave_config_http_server:stop_as_child(),
+
+	{comment, "arweave_config_http_server tested "}.
+
+unix_socket(Config) ->
+	SocketPath = filename:join("/tmp", "./arweave.sock"),
+	ct:pal(test, 1, "set socket to ~p", [SocketPath]),
+	arweave_config:set([config,http,api,listen,address], SocketPath),
+
+	ct:pal(test, 1, "start arweave config http server"),
+	arweave_config_http_server:start_link(),
+	timer:sleep(500),
+	{ok, _} = file:read_file_info(SocketPath),
+
+	ct:pal(test, 1, "stop arweave config http server"),
+	arweave_config_http_server:stop(),
+	timer:sleep(500),
+	{error, enoent} = file:read_file_info(SocketPath),
+
+	{command, "unix socket feature tested"}.
+
+%%--------------------------------------------------------------------
+%% simple http client for get request.
+%%--------------------------------------------------------------------
+get_path(Path) ->
+	get_path(Path, #{}).
+
+get_path(Path, Opts) ->
+	Host = maps:get(host, Opts, "127.0.0.1"),
+	Port = maps:get(port, Opts, 4891),
+	% @todo host and port should be defined as macros
+	{ok, Pid} = gun:open(Host, Port),
+	StreamRef = gun:get(Pid, Path),
+	body(Pid, StreamRef).
+
+%%--------------------------------------------------------------------
+%% simple http client for post request.
+%%--------------------------------------------------------------------
+post_path(Path, Data) ->
+	post_path(Path, Data, #{}).
+
+post_path(Path, Data, Opts) ->
+	Host = maps:get(host, Opts, "127.0.0.1"),
+	Port = maps:get(port, Opts, 4891),
+	% @todo host and port should be defined as macros
+	{ok, Pid} = gun:open(Host, Port),
+	StreamRef = gun:post(Pid, Path, #{}, Data),
+	body(Pid, StreamRef).
+
+%%--------------------------------------------------------------------
+%% from https://ninenines.eu/docs/en/gun/2.1/guide/http/
+%%--------------------------------------------------------------------
+body(ConnPid, MRef) ->
+	receive
+		{gun_response, ConnPid, StreamRef, fin, Status, Headers} ->
+			{ok, Status, no_data};
+		{gun_response, ConnPid, StreamRef, nofin, Status, Headers} ->
+			receive_data(
+				ConnPid,
+				MRef,
+				Status,
+				StreamRef,
+				<<>>
+			);
+		{'DOWN', MRef, process, ConnPid, Reason} ->
+			{error, Reason}
+	after 1000 ->
+		timeout
+	end.
+
+%%--------------------------------------------------------------------
+%% from https://ninenines.eu/docs/en/gun/2.1/guide/http/
+%%--------------------------------------------------------------------
+receive_data(ConnPid, MRef, Status, StreamRef, Buffer) ->
+	receive
+		{gun_data, ConnPid, StreamRef, nofin, Data} ->
+			receive_data(
+				ConnPid,
+				MRef,
+				Status,
+				StreamRef,
+				<<Buffer/binary, Data/binary>>
+			 );
+		{gun_data, ConnPid, StreamRef, fin, Data} ->
+			{ok, Status, <<Buffer/binary, Data/binary>>};
+		{'DOWN', MRef, process, ConnPid, Reason} ->
+			{error, Reason}
+	after 1000 ->
+		timeout
+	end.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+is_jsend(Data) ->
+	try
+		jiffy:decode(Data, [return_maps])
+	of
+		#{
+			<<"status">> := <<"success">>,
+			<<"data">> := D
+		} -> {true, {success, D}};
+		#{
+			<<"status">> := <<"fail">>,
+			<<"data">> := D
+		} -> {true, {fail, D}};
+		#{
+			<<"status">> := <<"error">>,
+			<<"message">> := M
+		} -> {true, {error, M}};
+		_ -> false
+	catch
+		_:_ -> false
+	end.

--- a/apps/arweave_config/test/arweave_config_spec_SUITE.erl
+++ b/apps/arweave_config/test/arweave_config_spec_SUITE.erl
@@ -25,7 +25,8 @@
 	default_set/1,
 	default_set_state/1,
 	default_multi/1,
-	default_runtime/1
+	default_runtime/1,
+	default_multi_types/1
 ]).
 -include("arweave_config.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -98,7 +99,8 @@ all() ->
 		default_set,
 		default_set_state,
 		default_multi,
-		default_runtime
+		default_runtime,
+		default_multi_types
 	].
 
 %%--------------------------------------------------------------------
@@ -169,7 +171,9 @@ default_set_state(_Config) ->
 	{ok, empty, undefined} =
 		arweave_config_spec:set([default_set_state], ok),
 	{ok, full, empty} =
-		arweave_config_spec:set([default_set_state], ok).
+		arweave_config_spec:set([default_set_state], ok),
+
+	{comment, "set state tested"}.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -177,13 +181,21 @@ default_set_state(_Config) ->
 %%--------------------------------------------------------------------
 default_multi(_Config) ->
 	% default value to 1
+	ct:pal(test, 1, "set value to 1"),
 	{ok, 1} = arweave_config_spec:get([one]),
 	{ok, one, 1} = arweave_config_spec:set([one], one),
 
 	% on default value, but always return 3
+	ct:pal(test, 1, "get value"),
 	{ok, 3} = arweave_config_spec:get([three]),
-	{ok, 3, undefined} = arweave_config_spec:set([three], any).
+	{ok, 3, undefined} = arweave_config_spec:set([three], any),
 
+	{comment, "multi spec tested"}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
 default_runtime(_Config) ->
 	ct:pal(test, 1, "initial state not in runtime"),
 	false = arweave_config:is_runtime(),
@@ -204,6 +216,25 @@ default_runtime(_Config) ->
 
 	% not_runtime parameter can't be set during runtime
 	{error, _} = arweave_config_spec:set([not_runtime], 2).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+default_multi_types(_Config) ->
+	ct:pal(test, 1, "set a boolean"),
+	{ok, true, undefined} =
+		arweave_config_spec:set([default], <<"true">>),
+
+	ct:pal(test, 1, "set an integer"),
+	{ok, 1, true} =
+		arweave_config_spec:set([default], 1),
+
+	ct:pal(test, 1, "set an ipv4"),
+	{ok, <<"127.0.0.1">>, 1} =
+		arweave_config_spec:set([default], <<"127.0.0.1">>),
+
+	{comment, "multi types tested"}.
 
 %%--------------------------------------------------------------------
 %% @doc defines custom parameters for tests.
@@ -293,5 +324,12 @@ specs(default_runtime) ->
 		#{
 			parameter_key => [not_runtime],
 			runtime => false
+		}
+	];
+specs(default_multi_types) ->
+	[
+		#{
+			parameter_key => [default],
+			type => [boolean, integer, ipv4]
 		}
 	].

--- a/apps/arweave_config/test/arweave_config_type_SUITE.erl
+++ b/apps/arweave_config/test/arweave_config_type_SUITE.erl
@@ -27,7 +27,8 @@
 	path/1,
 	base64/1,
 	base64url/1,
-	tcp_port/1
+	tcp_port/1,
+	file/1
 ]).
 -include_lib("common_test/include/ct.hrl").
 
@@ -79,7 +80,8 @@ all() ->
 		path,
 		base64,
 		base64url,
-		tcp_port
+		tcp_port,
+		file
 	].
 
 none(_Config) ->
@@ -96,11 +98,11 @@ atom(_Config) ->
 boolean(_Config) ->
 	[
 		{ok, true} = arweave_config_type:boolean(X)
-		|| X <- [<<"true">>, "true", true, 1]
+		|| X <- [<<"true">>, "true", true]
 	],
 	[
 		{ok, false} = arweave_config_type:boolean(X)
-		|| X <- [<<"false">>, "false", false, 0]
+		|| X <- [<<"false">>, "false", false]
 	],
 	{error, not_boolean} =
 		arweave_config_type:boolean(not_boolean).
@@ -150,3 +152,26 @@ tcp_port(_Config) ->
 	{ok, 1234} = arweave_config_type:tcp_port(<<"1234">>),
 	{error, 78912} = arweave_config_type:tcp_port(<<"78912">>).
 
+file(_Config) ->
+	ct:pal(test, 1, "test absolute path and path as binary"),
+	{ok, <<"/tmp/arweave.sock">>} =
+		arweave_config_type:file(<<"/tmp/arweave.sock">>),
+
+	ct:pal(test, 1, "test relative path and path as list"),
+	{ok, P1} =
+		arweave_config_type:file("./arweave.sock"),
+	true = is_binary(P1),
+
+	ct:pal(test, 1, "test a wrong path"),
+	{error, _} =
+		arweave_config_type:file("/random/t/a/b/c.sock"),
+
+	ct:pal(test, 1, "test a file without write access"),
+	{error, _} =
+		arweave_config_type:file("/root/data/arweave.sock"),
+
+	ct:pal(test, 1, "test a wrong erlang type"),
+	{error, _} =
+		arweave_config_type:file(1234),
+
+	ok.


### PR DESCRIPTION
This commit integrate cowboy as part of arweave config to give access to
an HTTP API interface and dynamically configure parameters while arweave
is running.

The process in chage of this interface is not started automatically for
the moment, but can be started using two methods: (1) in "standalone"
mode using arweave_config_http_server:start_link() or (2) as child using
arweave_config_http_server:start_as_child(). The second method will start the
process under arweave_config_sup supervisor.

The API is using v0 prefix (this is not a stable interface for the
moment). Here the list of supported end-points:

  - /v0/config: export the whole configuration with parameter set

  - /v0/config/${parameter}: display a parameter value

  - /v0/environment: display the environment used by arweave

This implementation is using JSEND JSON format, instead of recreating
the wheel, JSEND format is easy and flexible enough for the private API
end-points.

see: https://github.com/ArweaveTeam/arweave-dev/issues/978