### PR TITLE
Enforce OTP Version in Rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,5 @@
+{minimum_otp_vsn, "26.0"}.
+
 {deps, [
 	{b64fast, {git, "https://github.com/ArweaveTeam/b64fast.git", {ref, "58f0502e49bf73b29d95c6d02460d1fb8d2a5273"}}},
 	{jiffy, {git, "https://github.com/ArweaveTeam/jiffy.git", {ref, "073da726e07bafb5d140020a9e8765c703da3ef7"}}},


### PR DESCRIPTION
Arweave is now officially supporting Erlang/OTP R26, to avoid confusion and/or mistake during testing, this version should be enforced. If the wrong version is present, it should crash and alert us.

see: https://github.com/ArweaveTeam/arweave-dev/issues/946