### PR TITLE
Integrate HTTP Server Logging

### DIFF
--- a/apps/arweave/src/ar.erl
+++ b/apps/arweave/src/ar.erl
@@ -1160,18 +1160,24 @@ start(Config) ->
 
 start(normal, _Args) ->
 	{ok, Config} = arweave_config:get_env(),
+
 	%% Set erlang socket backend
 	persistent_term:put({kernel, inet_backend}, Config#config.'socket.backend'),
+
 	%% Configure logger
 	ar_logger:init(Config),
+
 	%% Start the Prometheus metrics subsystem.
 	prometheus_registry:register_collector(prometheus_process_collector),
 	prometheus_registry:register_collector(ar_metrics_collector),
+
 	%% Register custom metrics.
 	ar_metrics:register(),
+
 	%% Start other apps which we depend on.
 	set_mining_address(Config),
 	ar_chunk_storage:run_defragmentation(),
+
 	%% Start Arweave.
 	ar_sup:start_link().
 

--- a/apps/arweave/src/ar_logger.erl
+++ b/apps/arweave/src/ar_logger.erl
@@ -1,95 +1,333 @@
 %%%===================================================================
-%%% @doc module in charge of the logging features.
+%%% GNU General Public License, version 2 (GPL-2.0)
+%%% The GNU General Public License (GPL-2.0)
+%%% Version 2, June 1991
+%%%
+%%% ------------------------------------------------------------------
+%%%
+%%% @copyright 2025 (c) Arweave
+%%% @author Arweave Team
+%%% @doc Arweave Logging Interface.
+%%%
+%%% This module is in charge of starting, stopping, enabling,
+%%% disabling logging Arweave handlers.
+%%%
+%%% == Logger Primary Configuration ==
+%%%
+%%% Primary logger configuration is defined in `config/sys.config',
+%%% with the help of `logger_level' key.
+%%%
+%%% see: https://www.erlang.org/doc/apps/kernel/logger_chapter
+%%%
+%%% == Logger Default Configuration ==
+%%%
+%%% The default configuration is used to log to the console, and it
+%%% should be not modified by default. To avoid modify this, this
+%%% value is defined outside of this module, in `config/sys.config'
+%%% via the help of `logger' key.  Here the configuration:
+%%%
+%%% ```
+%%% [{handler, default, logger_std_h, #{
+%%%     level => warning,
+%%%     formatter => {
+%%%       logger_formatter, #{
+%%%         legacy_header => false,
+%%%         single_line => true,
+%%%         chars_limit => 16256,
+%%%         max_size => 8128,
+%%%         depth => 256,
+%%%         template => [time," [",level,"] ",mfa,":",line," ",msg,"\n"]
+%%%       }
+%%%     }
+%%%   }
+%%% }].
+%%% '''
+%%%
+%%% see: https://www.erlang.org/doc/apps/kernel/logger_chapter
 %%% @end
+%%% @see logger
+%%% @see logger_handler
+%%% @TODO integrate with arweave_config.
+%%% @TODO create domain for different part of the code, but all
+%%%       calls to logger inside arweave should be in the domain
+%%%       [arweave].
+%%% @TODO ensure primary logger configuration is set with the right
+%%%       values (level => all).
 %%%===================================================================
 -module(ar_logger).
--export([init/1]).
+-compile(warnings_as_errors).
+-export([
+	init/1,
+	is_started/1,
+	handlers/0,
+	start_handlers/0,
+	start_handler/1,
+	started_handlers/0,
+	stop_handlers/0,
+	stop_handler/1,
+	gen_log/3
+]).
 -include_lib("arweave/include/ar.hrl").
 -include_lib("arweave_config/include/arweave_config.hrl").
 
 %%--------------------------------------------------------------------
-%% @doc Uses #config{} record by default.
+%% @doc legacy compatible interface. to be removed.
 %% @end
 %%--------------------------------------------------------------------
-init(Config) ->
-    init_console(Config),
-    init_default(Config),
-    init_debug(Config).
+init(Config = #config{}) ->
+	start_handler(default),
+	start_handler(arweave_info),
+	init_debug(Config).
 
-%%--------------------------------------------------------------------
-%% @hidden
-%% @doc Configure logging for console output.
-%% @end
-%%--------------------------------------------------------------------
-init_console(Config) ->
-    Template = [time," [",level,"] ",mfa,":",line," ",msg,"\n"],
-    LoggerFormatterConsole = #{ legacy_header => false
-			      , single_line => true
-			      , chars_limit => 16256
-			      , max_size => 8128
-			      , depth => 256
-			      , template => Template
-			      },
-    logger:set_handler_config(default, formatter, {logger_formatter, LoggerFormatterConsole}),
-    logger:set_handler_config(default, level, error).
-
-%%--------------------------------------------------------------------
-%% @hidden
-%% @doc Configure logging to the logfile.
-%% @end
-%%--------------------------------------------------------------------
-init_default(Config) ->
-    Level = info,
-    FileName = log_filename(#{ level => Level }),
-    FilePath = filename:flatten(filename:join(Config#config.log_dir, FileName)),
-    LoggerConfigDisk = #{ file => FilePath
-			, type => file
-			, max_no_files => 10
-			, max_no_bytes => 51418800 % 10 x 5MB
-			, modes => [raw, append]
-			},
-    LoggerConfig = #{ config => LoggerConfigDisk, level => Level },
-    Template = [time," [",level,"] ",mfa,":",line," ",msg,"\n"],
-    LoggerFormatterDisk = #{ chars_limit => 16256
-			   , max_size => 8128
-			   , depth => 256
-			   , legacy_header => false
-			   , single_line => true
-			   , template => Template
-			   },
-    logger:add_handler(disk_log, logger_std_h, LoggerConfig),
-    logger:set_handler_config(disk_log, formatter, {logger_formatter, LoggerFormatterDisk}).
-
-%%--------------------------------------------------------------------
-%% @hidden
-%% @doc set debug logging feature
-%% @end
-%%--------------------------------------------------------------------
-init_debug(#config{ debug = true } = Config) ->
-    Level = debug,
-    FileName = log_filename(#{ level => Level }),
-    FilePath = lists:flatten(filename:join([Config#config.log_dir, FileName])),
-    DebugLoggerConfigDisk = #{ file => FilePath
-			     , type => file
-			     , max_no_files => 20
-			     , max_no_bytes => 51418800 % 10 x 5MB
-			     , modes => [raw, append]
-			     },
-    LoggerConfig = #{ config => DebugLoggerConfigDisk, level => Level },
-    logger:add_handler(disk_debug_log, logger_std_h, LoggerConfig),
-    logger:set_application_level(arweave, Level);
+init_debug(#config{ debug = true }) ->
+	start_handler(arweave_debug);
 init_debug(_) ->
-    Level = info,
-    logger:set_application_level(arweave, Level).
+	ok.
+
+%%--------------------------------------------------------------------
+%% @hidden
+%%--------------------------------------------------------------------
+template() ->
+	[time," [",level,"] ",mfa,":",line," ",msg,"\n"].
+
+%%--------------------------------------------------------------------
+%% @doc wrapper around `logger:get_handler_config/1'.
+%% @see logger:get_handle_config/1
+%% @end
+%%--------------------------------------------------------------------
+is_started(Handler) ->
+	case logger:get_handler_config(Handler) of
+		{ok, _} -> true;
+		_ -> false
+	end.
+
+%%--------------------------------------------------------------------
+%% @doc defined loggers.
+%% @end
+%%--------------------------------------------------------------------
+handlers() -> #{
+	% log every info message.
+	% This handler can be configured on demand, all message
+	% greater or equal than info are being logged.
+	arweave_info => #{
+		level => debug,
+		config => #{
+			type => file,
+			file => logfile_path(#{
+				prefix => "arweave",
+				level => info
+			}),
+			max_no_files => 10,
+			max_no_bytes => 51_418_800,
+			modes => [raw, append],
+			sync_mode_qlen => 10,
+			drop_mode_qlen => 200,
+			flush_qlen => 1000,
+			burst_limit_enable => true,
+			burst_limit_max_count => 500,
+			burst_limit_window_time => 1000,
+			overload_kill_enable => true,
+			overload_kill_qlen => 20_000,
+			overload_kill_mem_size => 3_000_000,
+			overload_kill_restart_after => 5000
+		},
+		formatter => {
+			logger_formatter, #{
+				chars_limit => 16256,
+				depth => 256,
+				legacy_header => false,
+				max_size => 8128,
+				single_line => true,
+				template => template(),
+				time_offset => "Z"
+			}
+		},
+		filter_default => log,
+		filters => [
+			{n_wildcard, {fun logger_filters:level/2, {stop, lt, info}}},
+			{n_http, {fun logger_filters:domain/2, {stop, sub, [arweave,http]}}}
+		]
+	},
+
+	% log every debug message.
+	% Only debug messages are being logged.
+	arweave_debug => #{
+		level => debug,
+		config => #{
+			type => file,
+			file => logfile_path(#{
+				prefix => "arweave",
+				level => debug
+			}),
+			max_no_files => 10,
+			max_no_bytes => 51_418_800,
+			modes => [raw, append],
+			sync_mode_qlen => 10,
+			drop_mode_qlen => 200,
+			flush_qlen => 1000,
+			burst_limit_enable => true,
+			burst_limit_max_count => 500,
+			burst_limit_window_time => 1000,
+			overload_kill_enable => true,
+			overload_kill_qlen => 20_000,
+			overload_kill_mem_size => 3_000_000,
+			overload_kill_restart_after => 5000
+		},
+		formatter => {
+			logger_formatter, #{
+				chars_limit => 16256,
+				depth => 256,
+				legacy_header => false,
+				max_size => 8128,
+				single_line => true,
+				template => template(),
+				time_offset => "Z"
+			}
+		},
+		filter_default => log,
+		filters => [
+			{n_wildcard, {fun logger_filters:level/2, {stop, gt, debug}}},
+			{n_http, {fun logger_filters:domain/2, {stop, sub, [arweave,http]}}}
+		]
+	},
+
+	% this handler will log only log message containing the domain
+	% [arweave,http,api] in info level.
+	arweave_http_api => #{
+		level => info,
+		config => #{
+			type => file,
+			file => logfile_path(#{
+				prefix => "arweave-http-api",
+				level => debug
+			}),
+			max_no_files => 10,
+			max_no_bytes => 51_418_800,
+			modes => [raw, append],
+			sync_mode_qlen => 10,
+			drop_mode_qlen => 200,
+			flush_qlen => 1000,
+			burst_limit_enable => true,
+			burst_limit_max_count => 500,
+			burst_limit_window_time => 1000,
+			overload_kill_enable => true,
+			overload_kill_qlen => 20_000,
+			overload_kill_mem_size => 3_000_000,
+			overload_kill_restart_after => 5000
+		},
+		formatter => {
+			logger_formatter, #{
+				legacy_header => false,
+				single_line => true,
+				chars_limit => 16256,
+				max_size => 8128,
+				depth => 256,
+				template => [
+					time, " ",
+					"ip=", peer_ip, " ",
+					"port=", peer_port, " ",
+					"version=", version, " ",
+					"method=", method, " ",
+					"code=", code, " ",
+					"path=", path, " ",
+					"body_length=", body_length, " ",
+					"duration=", duration, " ",
+					"msg=", msg, "\n"
+				],
+				time_offset => "Z"
+			}
+		},
+		filter_default => stop,
+		filters => [
+			{info, {fun logger_filters:level/2, {stop, lt, info}}},
+			{http, {fun logger_filters:domain/2, {log, sub, [arweave,http,api]}}}
+		]
+	}
+}.
+
+%%--------------------------------------------------------------------
+%% @doc start all defined loggers.
+%% @end
+%%--------------------------------------------------------------------
+start_handlers() ->
+	Handlers = maps:keys(handlers()),
+	[ start_handler(Handler) || Handler <- Handlers ].
+
+%%--------------------------------------------------------------------
+%% @doc start one defined logger.
+%% @end
+%%--------------------------------------------------------------------
+start_handler(Handler) ->
+	case maps:get(Handler, handlers(), undefined) of
+		undefined ->
+			{error, not_found};
+		Config ->
+			start_handler(Handler, Config)
+	end.
+
+start_handler(Handler, Config) ->
+	case is_started(Handler) of
+		true ->
+			ok;
+		false ->
+			logger:add_handler(Handler, logger_std_h, Config)
+	end.
+
+%%--------------------------------------------------------------------
+%% @doc stop all loggers set.
+%% @end
+%%--------------------------------------------------------------------
+stop_handlers() ->
+	Handlers = maps:keys(handlers()),
+	[ stop_handler(Handler) || Handler <- Handlers ].
+
+%%--------------------------------------------------------------------
+%% @doc stop logger.
+%% @end
+%%--------------------------------------------------------------------
+stop_handler(Handler) -> logger:remove_handler(Handler).
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% @doc list started handlers.
+%% @end
+%%--------------------------------------------------------------------
+started_handlers() ->
+	HandlersIds = maps:keys(handlers()),
+	#{ handlers := HandlersStarted } = logger:get_config(),
+	[ Id ||
+		#{ id := Id } <- HandlersStarted,
+		Id2 <- HandlersIds,
+		Id =:= Id2
+	].
+
+%%--------------------------------------------------------------------
+%% @hidden
+%% @doc function only used to write to logs during test.
+%% @end
+%%--------------------------------------------------------------------
+gen_log(Format, FormatMsg, Meta) ->
+	?LOG_EMERGENCY(Format, FormatMsg, Meta),
+	?LOG_ALERT(Format, FormatMsg, Meta),
+	?LOG_CRITICAL(Format, FormatMsg, Meta),
+	?LOG_ERROR(Format, FormatMsg, Meta),
+	?LOG_WARNING(Format, FormatMsg, Meta),
+	?LOG_NOTICE(Format, FormatMsg, Meta),
+	?LOG_INFO(Format, FormatMsg, Meta),
+	?LOG_DEBUG(Format, FormatMsg, Meta).
 
 %%--------------------------------------------------------------------
 %% @hidden
 %% @doc returns a log filename.
 %% @end
 %%--------------------------------------------------------------------
-log_filename(Opts) ->
-    Prefix = maps:get(prefix, Opts, "arweave"),
-    Level = maps:get(level, Opts, info),
-    NodeName = erlang:node(),
-    RawFileName = lists:join("-", ["arweave", NodeName, Level]),
-    filename:flatten(RawFileName) ++ ".log".
+logfile_path(Opts) ->
+	% TODO: if arweave_config is not set, even with a default
+	% value set, this part of the code crashes.
+	LogDir = arweave_config:get([logging,path], "./logs"),
+	Prefix = maps:get(prefix, Opts),
+	Level = maps:get(level, Opts),
+	NodeName = erlang:node(),
+	RawFilename = lists:join("-", [Prefix, NodeName, Level]),
+	Filename = filename:flatten(RawFilename) ++ ".log",
+	filename:flatten(filename:join(LogDir, Filename)).

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,7 +1,22 @@
 [
 	{arweave, []},
 	{kernel, [
-		{inet_dist_use_interface, {127, 0, 0, 1}}
+		{inet_dist_use_interface, {127, 0, 0, 1}},
+		{logger_level, all},
+		{logger, [{handler, default, logger_std_h, #{
+				level => warning,
+				formatter => {
+					logger_formatter, #{
+						legacy_header => false,
+						single_line => true,
+						chars_limit => 16256,
+						max_size => 8128,
+						depth => 256,
+						template => [time," [",level,"] ",mfa,":",line," ",msg,"\n"]
+					}
+				}
+			}
+		}]}
 	]},
 	{sasl, [
 		{sasl_error_logger, false}


### PR DESCRIPTION
This commit adds support for http server logging. This logging
method is not enabled by default. ar_logger module has been rewritten
to be more compatible with the new arweave dynamic configuration
module.

A full refacto has been done on ar_logger module to be compatible with
arweave_config. The idea is to generate logger configuration directly
from ar_logger module, with a long list of parameters coming from
arweave_config. To start/stop an handler:

    ar_logger:start(arweave_info).
    ar_logger:start(arweave_debug).
    ar_logger:start(arweave_http_api).

    ar_logger:stop(arweave_http_api).
    ar_logger:stop(arweave_debug).
    ar_logger:stop(arweave_info).

arweave_http_api has a custom template logging, using mostly metadata
from cowboy response and producing a logfmt like output. Here an example:

    2025-12-02T14:19:25.637013Z ip=1.2.3.4 port=48540 version=HTTP/1.1
        method=GET code=200 path=/info body_length=0 duration=1 msg=

Where "ip" and "port" are from the remote peer, "version" is the http
protocol version used, "method" is the HTTP method used, "code" is the
returned code to the peer, "path" is the path requested by the remote
peer, "body_length" is the size of the body if defined and "duration"
is the time to produce the answer in millisecond.

ar_logger:handlers/0 defines all the available handlers supported by
arweave with all their options. Filters have been created to decrease
the number of lines in debug (only storing debug level without other
levels).

see: https://github.com/ArweaveTeam/arweave-dev/issues/1006