### PR TITLE
Fix Cowboy/Ranch Warning Message

### DIFF
--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -91,24 +91,25 @@ start_http_iface_listener(Config) ->
 	Dispatch = cowboy_router:compile([{'_', ?HTTP_IFACE_ROUTES}]),
 	TlsCertfilePath = Config#config.tls_cert_file,
 	TlsKeyfilePath = Config#config.tls_key_file,
-	TransportOpts = [
+	TransportOpts = #{
 		% ranch_tcp parameters
-		{backlog, Config#config.'http_api.tcp.backlog'},
-		{delay_send, Config#config.'http_api.tcp.delay_send'},
-		{keepalive, Config#config.'http_api.tcp.keepalive'},
-		{linger, {
+		backlog => Config#config.'http_api.tcp.backlog',
+		delay_send => Config#config.'http_api.tcp.delay_send',
+		keepalive => Config#config.'http_api.tcp.keepalive',
+		linger => {
 				Config#config.'http_api.tcp.linger',
 				Config#config.'http_api.tcp.linger_timeout'
-			}
 		},
-		{max_connections, Config#config.'http_api.tcp.max_connections'},
-		{nodelay, Config#config.'http_api.tcp.nodelay'},
-		{num_acceptors, Config#config.'http_api.tcp.num_acceptors'},
-		{port, Config#config.port},
-		{send_timeout_close, Config#config.'http_api.tcp.send_timeout_close'},
-		{send_timeout, Config#config.'http_api.tcp.send_timeout'},
-		{shutdown, Config#config.'http_api.tcp.listener_shutdown'}
-	],
+		max_connections => Config#config.'http_api.tcp.max_connections',
+		nodelay => Config#config.'http_api.tcp.nodelay',
+		num_acceptors => Config#config.'http_api.tcp.num_acceptors',
+		send_timeout_close => Config#config.'http_api.tcp.send_timeout_close',
+		send_timeout => Config#config.'http_api.tcp.send_timeout',
+		shutdown => Config#config.'http_api.tcp.listener_shutdown',
+		socket_opts => [
+			{port, Config#config.port}
+		]
+	},
 	ProtocolOpts = #{
 		active_n => Config#config.'http_api.http.active_n',
 		inactivity_timeout => Config#config.'http_api.http.inactivity_timeout',


### PR DESCRIPTION
When starting cowboy/ranch, a warning message was displayed:

    Setting Ranch options together with socket options is deprecated.
    Please use the new map syntax that allows specifying socket options
    separately from other options.

see: https://github.com/ArweaveTeam/arweave-dev/issues/1019