### PR TITLE
Disabling fail-fast on workflow

### DIFF
--- a/.github/workflows/x-test-full.yml
+++ b/.github/workflows/x-test-full.yml
@@ -36,6 +36,7 @@ jobs:
       - ${{ inputs.os_release }}
 
     strategy:
+      fail-fast: false
       max-parallel: 12
       matrix:
         core_test_mod: [

--- a/.github/workflows/x-test-on-demand.yml
+++ b/.github/workflows/x-test-on-demand.yml
@@ -38,6 +38,9 @@ jobs:
       - ${{ inputs.os_name }}
       - ${{ inputs.os_release }}
 
+    strategy:
+      fail-fast: false
+
     steps:
       - name: cleanup
         if: always()

--- a/.github/workflows/x-test-vdf.yml
+++ b/.github/workflows/x-test-vdf.yml
@@ -36,6 +36,7 @@ jobs:
       - ${{ inputs.os_release }}
 
     strategy:
+      fail-fast: false
       max-parallel: 12
       matrix:
         core_test_mod: [


### PR DESCRIPTION
To improve speed, fail-fast should be disabled. In case of timeout, the workflow will be restarted manually.