### PR TITLE
Generate a random node name during test

### DIFF
--- a/apps/arweave/test/ar_test_node.erl
+++ b/apps/arweave/test/ar_test_node.erl
@@ -279,9 +279,7 @@ random_id(Length, EncodedBase)
 	when is_integer(Length), Length>=1,
 	     is_integer(EncodedBase), EncodedBase>=2, EncodedBase=<37 ->
 	<<Binary:(Length*8)>> = crypto:strong_rand_bytes(Length),
-	integer_to_list(Binary, EncodedBase);
-random_id(_, _) ->
-	random_id(4, 36).
+	integer_to_list(Binary, EncodedBase).
 
 %%--------------------------------------------------------------------
 %% @doc To avoid collision with other node started on the system, a


### PR DESCRIPTION
see: https://github.com/ArweaveTeam/arweave-dev/issues/1024

When using arweave test suite, sometimes the node crashes and leaks an epmd session. To avoid issue like that, every node should have their own unique random name.