### PR TITLE
fix(arweave_config_legacy): timeout during high load

### DIFF
--- a/apps/arweave_config/test/arweave_config_legacy_SUITE.erl
+++ b/apps/arweave_config/test/arweave_config_legacy_SUITE.erl
@@ -66,6 +66,11 @@ all() ->
 %% @end
 %%--------------------------------------------------------------------
 arweave_config_legacy(_Config) ->
+	ct:pal(test, 1, "simple unsupported handler test"),
+	_ = gen_server:call(arweave_config_legacy, unsupported),
+	_ = gen_server:cast(arweave_config_legacy, unsupported),
+	_ = erlang:send(arweave_config_legacy, unsupported),
+
 	ct:pal(test, 1, "config keys should be the same"),
 	Keys = arweave_config_legacy:keys(),
 	ConfigKeys = record_info(fields, config),


### PR DESCRIPTION
This commit fixes a timeout on arweave_config_legacy when to many processes are trying to communicate with it. Instead of using messaging, a protected ETS table has been created, where the processes can directly fetch the configuration from it.