### PR TITLE
impr: expose max_duplicate_data_roots as a config option

### DIFF
--- a/apps/arweave/src/ar_cli_parser.erl
+++ b/apps/arweave/src/ar_cli_parser.erl
@@ -254,6 +254,12 @@ show_help() ->
 			{"max_disk_pool_data_root_buffer_mb",
 				"The max size (in MiB) per data root of the pending chunks in the disk"
 				" pool. The default is 50."},
+			{"max_duplicate_data_roots",
+				io_lib:format(
+					"The maximum number of duplicate data roots to inspect when "
+					"checking whether a posted chunk is already synced. Default is ~B.",
+					[?DEFAULT_MAX_DUPLICATE_DATA_ROOTS]
+				)},
 			{"disk_cache_size_mb",
 				lists:flatten(io_lib:format(
 					"The maximum size (in MiB) of the disk space allocated for"
@@ -769,6 +775,8 @@ parse(["max_disk_pool_buffer_mb", Num | Rest], C) ->
 	parse(Rest, C#config{ max_disk_pool_buffer_mb = list_to_integer(Num) });
 parse(["max_disk_pool_data_root_buffer_mb", Num | Rest], C) ->
 	parse(Rest, C#config{ max_disk_pool_data_root_buffer_mb = list_to_integer(Num) });
+parse(["max_duplicate_data_roots", Num | Rest], C) ->
+	parse(Rest, C#config{ max_duplicate_data_roots = list_to_integer(Num) });
 parse(["disk_cache_size_mb", Num | Rest], C) ->
 	parse(Rest, C#config{ disk_cache_size = list_to_integer(Num) });
 parse(["packing_workers", Num | Rest], C) ->

--- a/apps/arweave/src/ar_config.erl
+++ b/apps/arweave/src/ar_config.erl
@@ -641,6 +641,10 @@ parse_options([{<<"max_disk_pool_data_root_buffer_mb">>, D} | Rest], Config)
 		when is_integer(D) ->
 	parse_options(Rest, Config#config{ max_disk_pool_data_root_buffer_mb = D });
 
+parse_options([{<<"max_duplicate_data_roots">>, D} | Rest], Config)
+		when is_integer(D) ->
+	parse_options(Rest, Config#config{ max_duplicate_data_roots = D });
+
 parse_options([{<<"disk_cache_size_mb">>, D} | Rest], Config) when is_integer(D) ->
 	parse_options(Rest, Config#config{ disk_cache_size = D });
 

--- a/apps/arweave/src/ar_data_sync.erl
+++ b/apps/arweave/src/ar_data_sync.erl
@@ -216,12 +216,13 @@ add_chunk_to_disk_pool(DataRoot, DataPath, Chunk, Offset, TXSize) ->
 							not_found ->
 								{ok, {DataPathHash, DiskPoolChunkKey, PassedState2}};
 							{ok, {TXStartOffset, _}} ->
+								{ok, Config} = arweave_config:get_env(),
 								case chunk_offsets_synced(DataRootIndex, DataRootKey,
 										%% The same data may be uploaded several times.
 										%% Here we only accept the chunk if any of the
-										%% last 5 instances of this data is not filled in
-										%% yet.
-										EndOffset2, TXStartOffset, 5) of
+										%% last configured number of instances of this
+										%% data is not filled in yet.
+										EndOffset2, TXStartOffset, Config#config.max_duplicate_data_roots) of
 									true ->
 										synced;
 									false ->

--- a/apps/arweave/test/ar_config_tests.erl
+++ b/apps/arweave/test/ar_config_tests.erl
@@ -105,6 +105,7 @@ test_parse_config() ->
 		disk_pool_data_root_expiration_time = 10000,
 		max_disk_pool_buffer_mb = 100000,
 		max_disk_pool_data_root_buffer_mb = 100000000,
+		max_duplicate_data_roots = 7,
 		disk_cache_size = 1024,
 		semaphores = #{
 			get_chunk := 1,

--- a/apps/arweave/test/ar_config_tests_config_fixture.json
+++ b/apps/arweave/test/ar_config_tests_config_fixture.json
@@ -81,6 +81,7 @@
   "disk_pool_data_root_expiration_time": 10000,
   "max_disk_pool_buffer_mb": 100000,
   "max_disk_pool_data_root_buffer_mb": 100000000,
+  "max_duplicate_data_roots": 7,
   "disk_cache_size_mb": 1024,
   "semaphores": {
     "get_chunk": 1,

--- a/apps/arweave/test/ar_data_roots_sync_tests.erl
+++ b/apps/arweave/test/ar_data_roots_sync_tests.erl
@@ -288,20 +288,21 @@ test_chunk_skipped_with_duplicate_data_root() ->
 	ok = wait_for_chunk_to_persist(main, AbsEnd1).
 
 test_chunk_skipped_with_depth_exhaustion() ->
+	MaxDuplicateDataRoots = 3,
 	Wallet = {_, Pub} = ar_wallet:new(),
 	[B0] = ar_weave:init([{ar_wallet:to_address(Pub), ?AR(2_000_000_000_000_000), <<>>}]),
 	start_peers_then_disconnect(peer1, main, B0),
-	%% Mine 6 blocks with identical data roots this will make sure the oldest chunk is will not
-	%% be persisted (we only persist the first 5 chunks with the same data root). 
+	%% Mine one more block than the configured duplicate-depth limit. This ensures the oldest
+	%% chunk falls outside the configured duplicate data-root window.
 	Blocks = lists:map(
 		fun(_) -> mine_block_with_small_fixed_data_tx(peer1, Wallet) end,
-		lists:seq(1, 6)
+		lists:seq(1, MaxDuplicateDataRoots + 1)
 	),
 	{LastB, _} = lists:last(Blocks),
-	%% Now we mine 10 empty blocks. This pushes the 6 chunks mined earlier out of the disk pool,
-	%% which will either promote them to storage (first 5) or purge it from memory (last 1).
+	%% Mine enough empty blocks to push the chunks out of the disk pool. The later duplicates
+	%% should still be persistable, but the oldest should now be outside the configured window.
 	mine_empty_blocks_on_peer_after(peer1, LastB, 10),
-	join_main_on_peer1(LastB#block.height + 10, false),
+	join_main_on_peer1(LastB#block.height + 10, false, MaxDuplicateDataRoots),
 	ar_test_node:disconnect_from(peer1),
 	[{B1, [{TX1, Chunks1}]} | HigherBlocks] = Blocks,
 	lists:foreach(
@@ -312,8 +313,9 @@ test_chunk_skipped_with_depth_exhaustion() ->
 		end,
 		HigherBlocks
 	),
-	%% POST chunks for blocks 2-6 and wait for promotion. The oldest block B1 is not among
-	%% the last 5 duplicate offsets, so it should not become queryable via duplicate fanout.
+	%% POST chunks for the later duplicate blocks and wait for promotion. The oldest block B1
+	%% is outside the configured duplicate-offset window, so it should not become queryable via
+	%% duplicate fanout.
 	HigherAbsEnds = lists:map(
 		fun({B, [{TX, Chunks}]}) ->
 			[{AbsEnd, Proof}] = ar_test_data_sync:build_proofs(B, TX, Chunks),
@@ -329,8 +331,8 @@ test_chunk_skipped_with_depth_exhaustion() ->
 		HigherAbsEnds
 	),
 	timer:sleep(10_000),
-	%% POST chunk for block 1 (lowest offset). chunk_offsets_synced/5 only checks the last
-	%% 5 synced duplicate offsets, so B1 is treated as already synced and skipped.
+	%% POST chunk for block 1 (lowest offset). chunk_offsets_synced/5 only checks the configured
+	%% number of synced duplicate offsets, so B1 is treated as already synced and skipped.
 	[{AbsEnd1, Proof1}] = ar_test_data_sync:build_proofs(B1, TX1, Chunks1),
 	post_chunk(main, Proof1),
 	timer:sleep(10_000),
@@ -376,8 +378,11 @@ mine_empty_blocks_on_peer_after(Peer, Block, Count) ->
 %% data_roots syncing. Does not disconnect — caller may call
 %% ar_test_node:remote_call(main, ar_test_node, disconnect_from, [peer1]) when needed.
 join_main_on_peer1(ExpectedHeight, EnableBackgroundSync) ->
+	join_main_on_peer1(ExpectedHeight, EnableBackgroundSync, undefined).
+
+join_main_on_peer1(ExpectedHeight, EnableBackgroundSync, MaxDuplicateDataRoots) ->
 	{ok, BaseConfig} = arweave_config:get_env(),
-	MainConfig = BaseConfig#config{
+	Config = BaseConfig#config{
 		mine = false,
 		sync_jobs = 0,
 		header_sync_jobs =
@@ -387,6 +392,12 @@ join_main_on_peer1(ExpectedHeight, EnableBackgroundSync) ->
 			end,
 		enable_data_roots_syncing = EnableBackgroundSync
 	},
+	MainConfig = case MaxDuplicateDataRoots of
+		undefined ->
+			Config;
+		Value ->
+			Config#config{ max_duplicate_data_roots = Value }
+	end,
 	ar_test_node:join_on(#{ node => main, join_on => peer1, config => MainConfig }, true),
 	ar_test_node:connect_to_peer(peer1),
 	ar_test_node:wait_until_joined(main),

--- a/apps/arweave_config/include/arweave_config.hrl
+++ b/apps/arweave_config/include/arweave_config.hrl
@@ -46,6 +46,9 @@
 -define(DEFAULT_MAX_DISK_POOL_DATA_ROOT_BUFFER_MB, 10000).
 -endif.
 
+%% The default number of duplicate data roots checked for a posted chunk.
+-define(DEFAULT_MAX_DUPLICATE_DATA_ROOTS, 5).
+
 %% The default total size limit for unconfirmed and seeded chunks.
 -ifdef(AR_TEST).
 -define(DEFAULT_MAX_DISK_POOL_BUFFER_MB, 100).
@@ -336,6 +339,7 @@
 	disk_pool_data_root_expiration_time = ?DEFAULT_DISK_POOL_DATA_ROOT_EXPIRATION_TIME_S,
 	max_disk_pool_buffer_mb = ?DEFAULT_MAX_DISK_POOL_BUFFER_MB,
 	max_disk_pool_data_root_buffer_mb = ?DEFAULT_MAX_DISK_POOL_DATA_ROOT_BUFFER_MB,
+	max_duplicate_data_roots = ?DEFAULT_MAX_DUPLICATE_DATA_ROOTS,
 	semaphores = #{
 		get_chunk => ?MAX_PARALLEL_GET_CHUNK_REQUESTS,
 		get_and_pack_chunk => ?MAX_PARALLEL_GET_AND_PACK_CHUNK_REQUESTS,


### PR DESCRIPTION
controls the maximum number of data_roots that a node will store a chunk against. Default is 5