### PR TITLE
Preserve application-level errors in ar_http (after 902b9bc)

### DIFF
--- a/apps/arweave/src/ar_http.erl
+++ b/apps/arweave/src/ar_http.erl
@@ -82,8 +82,10 @@ req(Args, ReestablishedConnection) ->
 					case {ReestablishedConnection, should_retry_closed_connection(Error)} of
 						{false, true} ->
 							req(Args, true);
-						{_, _} ->
-							{error, client_error}
+						{_, true} ->
+							{error, client_error};
+						{_, false} ->
+							{error, Error}
 					end;
 				Reply ->
 					Reply


### PR DESCRIPTION
The retry-closed-connection change (902b9bc) broadened the error catch to all {error, _} tuples, unintentionally converting errors like too_much_data and timeout into client_error.