### PR TITLE
Fix partial tls support

### DIFF
--- a/apps/arweave/src/ar_http_iface_server.erl
+++ b/apps/arweave/src/ar_http_iface_server.erl
@@ -128,10 +128,13 @@ start_http_iface_listener(Config) ->
 		not_set ->
 			cowboy:start_clear(ar_http_iface_listener, TransportOpts, ProtocolOpts);
 		_ ->
-			cowboy:start_tls(ar_http_iface_listener, TransportOpts ++ [
-				{certfile, TlsCertfilePath},
-				{keyfile, TlsKeyfilePath}
-			], ProtocolOpts)
+			cowboy:start_tls(ar_http_iface_listener,
+				TransportOpts#{socket_opts => [
+					{port, Config#config.port},
+					{certfile, TlsCertfilePath},
+					{keyfile, TlsKeyfilePath}
+				]},
+				ProtocolOpts)
 	end.
 
 name_route([]) ->


### PR DESCRIPTION
b07b1d8 broke TLS support introduced in a5a0c4f by changing TransportOpts to a map but not updating its use.
This was identified and fixed by perplexity computer .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the TLS listener startup path; misconfiguration would prevent HTTPS from starting, but the change is small and localized to option wiring.
> 
> **Overview**
> Restores working TLS support for the HTTP interface by updating the `cowboy:start_tls/3` call to correctly apply `certfile`/`keyfile` (and port) via the `TransportOpts` map’s `socket_opts`.
> 
> This replaces the previous list-style transport option extension with a map update, aligning with the newer `TransportOpts` representation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909fdbc62417af5730e2df848d335a386e524189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->